### PR TITLE
fix(upgrade): Fix rare TempDir path issue

### DIFF
--- a/src/cmd/upgrade.go
+++ b/src/cmd/upgrade.go
@@ -33,13 +33,13 @@ func Upgrade(currentVersion string) {
 	switch runtime.GOOS {
 	case "windows":
 		assetURL += "-windows-x64.zip"
-		location = os.Getenv("TEMP") + "spicetify-" + tagName + ".zip"
+		location = os.TempDir() + "/spicetify-" + tagName + ".zip"
 	case "linux":
 		assetURL += "-linux-amd64.tar.gz"
-		location = "/tmp/spicetify-" + tagName + ".tar.gz"
+		location = os.TempDir() + "/spicetify-" + tagName + ".tar.gz"
 	case "darwin":
 		assetURL += "-darwin-amd64.tar.gz"
-		location = os.Getenv("TMPDIR") + "spicetify-" + tagName + ".tar.gz"
+		location = os.TempDir() + "/spicetify-" + tagName + ".tar.gz"
 	}
 
 	utils.PrintBold("Downloading:")


### PR DESCRIPTION
Resolves #1133

Explanation:
Temp Path doesn't always return `/` at the end. Adding `/` on Windows, macOS and Linux resolves it even when there will be two slashes since both Windows & Unix treat two slashes as one.

This issue is very rare and this patch should fix it.
Instead of using env variables, it has been switched to `os.TempDir()`.
![image](https://user-images.githubusercontent.com/9348108/136675354-64dc8d5c-87b2-4258-a9a1-b481f3643770.png)
