### PR TITLE
Add Custom App extension loader manifest

### DIFF
--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -94,6 +94,19 @@ func htmlMod(htmlPath string, flags Flag) {
 		}
 	}
 
+	for _, v := range flags.CustomApp {
+		manifest, _, err := utils.GetAppManifest(v)
+		if err == nil {
+			for _, extensionFile := range manifest.ExtensionFiles {
+				if strings.HasSuffix(extensionFile, ".mjs") {
+					extensionsHTML += `<script defer type="module" src="extensions/` + v + `/` + extensionFile + `"></script>` + "\n"
+				} else {
+					extensionsHTML += `<script defer src="extensions/` + v + `/` + extensionFile + `"></script>` + "\n"
+				}
+			}
+		}
+	}
+
 	utils.ModifyFile(htmlPath, func(content string) string {
 		utils.Replace(
 			&content,

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -13,12 +13,12 @@ import (
 )
 
 var (
-	spicetifyFolder         = getSpicetifyFolder()
+	spicetifyFolder         = utils.GetSpicetifyFolder()
 	rawFolder, themedFolder = getExtractFolder()
-	backupFolder            = getUserFolder("Backup")
-	userThemesFolder        = getUserFolder("Themes")
-	userExtensionsFolder    = getUserFolder("Extensions")
-	userAppsFolder          = getUserFolder("CustomApps")
+	backupFolder            = utils.GetUserFolder("Backup")
+	userThemesFolder        = utils.GetUserFolder("Themes")
+	userExtensionsFolder    = utils.GetUserFolder("Extensions")
+	userAppsFolder          = utils.GetUserFolder("CustomApps")
 	quiet                   bool
 	isAppX                  = false
 	spotifyPath             string
@@ -191,48 +191,8 @@ func GetSpotifyPath() string {
 	return spotifyPath
 }
 
-func getSpicetifyFolder() string {
-	result, isAvailable := os.LookupEnv("SPICETIFY_CONFIG")
-	defer func() { utils.CheckExistAndCreate(result) }()
-
-	if isAvailable && len(result) > 0 {
-		return result
-	}
-
-	if runtime.GOOS == "windows" {
-		result = filepath.Join(os.Getenv("USERPROFILE"), ".spicetify")
-
-	} else if runtime.GOOS == "linux" {
-		parent, isAvailable := os.LookupEnv("XDG_CONFIG_HOME")
-
-		if !isAvailable || len(parent) == 0 {
-			parent = filepath.Join(os.Getenv("HOME"), ".config")
-			utils.CheckExistAndCreate(parent)
-		}
-
-		result = filepath.Join(parent, "spicetify")
-
-	} else if runtime.GOOS == "darwin" {
-		parent := filepath.Join(os.Getenv("HOME"), ".config")
-		utils.CheckExistAndCreate(parent)
-
-		result = filepath.Join(parent, "spicetify")
-	}
-
-	return result
-}
-
-// getUserFolder checks if folder `name` is available in spicetifyFolder,
-// else creates then returns the path.
-func getUserFolder(name string) string {
-	dir := filepath.Join(spicetifyFolder, name)
-	utils.CheckExistAndCreate(dir)
-
-	return dir
-}
-
 func getExtractFolder() (string, string) {
-	dir := getUserFolder("Extracted")
+	dir := utils.GetUserFolder("Extracted")
 
 	raw := filepath.Join(dir, "Raw")
 	utils.CheckExistAndCreate(raw)

--- a/src/cmd/path.go
+++ b/src/cmd/path.go
@@ -48,7 +48,7 @@ func ThemeAllAssetsPath() (string, error) {
 
 // ExtensionPath return path of extension file
 func ExtensionPath(name string) (string, error) {
-	return getExtensionPath(name)
+	return utils.GetExtensionPath(name)
 }
 
 // ExtensionAllPath returns paths of all extension files
@@ -56,7 +56,7 @@ func ExtensionAllPath() (string, error) {
 	exts := featureSection.Key("extensions").Strings("|")
 	results := []string{}
 	for _, v := range exts {
-		path, err := getExtensionPath(v)
+		path, err := utils.GetExtensionPath(v)
 		if err != nil {
 			path = utils.Red("Extension " + v + " not found")
 		}
@@ -68,7 +68,7 @@ func ExtensionAllPath() (string, error) {
 
 // AppPath return path of app directory
 func AppPath(name string) (string, error) {
-	return getCustomAppPath(name)
+	return utils.GetCustomAppPath(name)
 }
 
 // AppAllPath returns paths of all apps
@@ -76,7 +76,7 @@ func AppAllPath() (string, error) {
 	exts := featureSection.Key("custom_apps").Strings("|")
 	results := []string{}
 	for _, v := range exts {
-		path, err := getCustomAppPath(v)
+		path, err := utils.GetCustomAppPath(v)
 		if err != nil {
 			path = utils.Red("App " + v + " not found")
 		}

--- a/src/cmd/watch.go
+++ b/src/cmd/watch.go
@@ -90,7 +90,7 @@ func WatchExtensions(extName []string, liveUpdate bool) {
 	var extPathList []string
 
 	for _, v := range extNameList {
-		extPath, err := getExtensionPath(v)
+		extPath, err := utils.GetExtensionPath(v)
 		if err != nil {
 			utils.PrintError(`Extension "` + v + `" not found.`)
 			continue
@@ -134,7 +134,7 @@ func WatchCustomApp(appName []string, liveUpdate bool) {
 
 	threadCount := 0
 	for _, v := range appNameList {
-		appPath, err := getCustomAppPath(v)
+		appPath, err := utils.GetCustomAppPath(v)
 		if err != nil {
 			utils.PrintError(`Custom app "` + v + `" not found.`)
 			continue
@@ -155,13 +155,18 @@ func WatchCustomApp(appName []string, liveUpdate bool) {
 		manifestPath := filepath.Join(appPath, "manifest.json")
 		manifestFileContent, err := os.ReadFile(manifestPath)
 		if err == nil {
-			var manifestJson appManifest
+			var manifestJson utils.AppManifest
 			if err = json.Unmarshal(manifestFileContent, &manifestJson); err == nil {
 				for _, subfile := range(manifestJson.Files) {
 					subfilePath := filepath.Join(appPath, subfile)
 					appFileList = append(appFileList, subfilePath)
 				}
+				for _, subfile := range(manifestJson.ExtensionFiles) {
+					subfilePath := filepath.Join(appPath, subfile)
+					appFileList = append(appFileList, subfilePath)
+				}
 			}
+			
 		}
 
 		threadCount += 1

--- a/src/utils/path-utils.go
+++ b/src/utils/path-utils.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+func GetSpicetifyFolder() string {
+	result, isAvailable := os.LookupEnv("SPICETIFY_CONFIG")
+	defer func() { CheckExistAndCreate(result) }()
+
+	if isAvailable && len(result) > 0 {
+		return result
+	}
+
+	if runtime.GOOS == "windows" {
+		result = filepath.Join(os.Getenv("USERPROFILE"), ".spicetify")
+
+	} else if runtime.GOOS == "linux" {
+		parent, isAvailable := os.LookupEnv("XDG_CONFIG_HOME")
+
+		if !isAvailable || len(parent) == 0 {
+			parent = filepath.Join(os.Getenv("HOME"), ".config")
+			CheckExistAndCreate(parent)
+		}
+
+		result = filepath.Join(parent, "spicetify")
+
+	} else if runtime.GOOS == "darwin" {
+		parent := filepath.Join(os.Getenv("HOME"), ".config")
+		CheckExistAndCreate(parent)
+
+		result = filepath.Join(parent, "spicetify")
+	}
+
+	return result
+}
+
+// getUserFolder checks if folder `name` is available in spicetifyFolder,
+// else creates then returns the path.
+func GetUserFolder(name string) string {
+	dir := filepath.Join(GetSpicetifyFolder(), name)
+	CheckExistAndCreate(dir)
+
+	return dir
+}
+
+var userAppsFolder = GetUserFolder("CustomApps")
+var userExtensionsFolder = GetUserFolder("Extensions")
+
+func GetCustomAppPath(name string) (string, error) {
+	customAppFolderPath := filepath.Join(userAppsFolder, name)
+
+	if _, err := os.Stat(customAppFolderPath); err == nil {
+		return customAppFolderPath, nil
+	}
+
+	customAppFolderPath = filepath.Join(GetExecutableDir(), "CustomApps", name)
+
+	if _, err := os.Stat(customAppFolderPath); err == nil {
+		return customAppFolderPath, nil
+	}
+
+	return "", errors.New("Custom app not found")
+}
+
+func GetExtensionPath(name string) (string, error) {
+	extFilePath := filepath.Join(userExtensionsFolder, name)
+
+	if _, err := os.Stat(extFilePath); err == nil {
+		return extFilePath, nil
+	}
+
+	extFilePath = filepath.Join(GetExecutableDir(), "Extensions", name)
+
+	if _, err := os.Stat(extFilePath); err == nil {
+		return extFilePath, nil
+	}
+
+	return "", errors.New("Extension not found")
+}

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"archive/zip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -287,4 +288,26 @@ func SeekToCloseParen(content string, regexpTerm string, leftChar, rightChar byt
 		return content[start:end]
 	}
 	return ""
+}
+
+type AppManifest struct {
+	Files []string `json:"subfiles"`
+	ExtensionFiles []string `json:"subfiles_extension"`
+}
+
+func GetAppManifest(app string) (AppManifest, string, error) {
+	customAppPath, err := GetCustomAppPath(app)
+	if err != nil {
+		PrintError(`Custom app "` + app + `" not found.`)
+		return AppManifest{}, customAppPath, err;
+	}
+	manifestFileContent, err := os.ReadFile(filepath.Join(customAppPath, "manifest.json"))
+	if err != nil {
+		manifestFileContent = []byte{'{', '}'}
+	}
+	var manifestJson AppManifest
+	if err = json.Unmarshal(manifestFileContent, &manifestJson); err == nil {
+		return manifestJson, customAppPath, err;
+	}
+	return manifestJson, customAppPath, err;
 }


### PR DESCRIPTION
This adds the ability for Custom Apps to inject extensions from inside of the app folder, without having to actually make and require installation of a separate extension. This can be used to allow the app to execute code before it is actually opened from the UI, as currently apps only execute code at all when opened.

Here's an example app: [test-ext.zip](https://github.com/khanhas/spicetify-cli/files/7326771/test-ext.zip)

The feature can be used by first creating a js file in your Custom App's folder, then add the name of that js file to the app's `manifest.json`, as an array, just like `subfiles`, but instead named `subfiles_extension`.

Ex:

```json
{
    "name": "Extension App",
    "icon": "...",
    "active-icon": "...",
    "subfiles": [],
    "subfiles_extension": ["extension.js"]
}
```

The above manifest will result in `extension.js` being added as an extension, just like a typical one.