### PR TITLE
Add action to automatically update AUR and homebrew on tag creation

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,16 @@
+name: Update Homebrew/AUR from tag
+
+on:
+    push:
+        tags:
+            - "v*"
+
+jobs:
+    update:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Request
+              uses: fjogeleit/http-request-action@master
+              with:
+                  url: https://vps.itsmeow.dev/spicetify-update
+                  method: GET


### PR DESCRIPTION
Whenever a tag/release is created, it makes a request to my server which then pushes an update to AUR and homebrew automatically.

Unfortunately, I have to host the application on my server because we don't have access to repository secrets. Otherwise, I would just write a general github action with Docker or something and pass the SSH key in the secrets.

Source of the server application is here: https://github.com/itsmeow/spicetify-cli-update/