### PR TITLE
shuffle+: Fix failed request and exception on empty folders.

### DIFF
--- a/Extensions/shuffle+.js
+++ b/Extensions/shuffle+.js
@@ -321,8 +321,9 @@
                 },
             });
         }
+
         await Spicetify.CosmosAsync.put("sp://player/v2/main/queue", {
-            queue_revision: Spicetify.Queue?.revision,
+            queue_revision: Spicetify.Queue?.queueRevision,
             next_tracks: list.map((uri) => ({
                 uri,
                 provider: context ? "context" : "queue",
@@ -330,7 +331,7 @@
                     is_queued: isQueue,
                 },
             })),
-            prev_tracks: Spicetify.Queue?.prev_tracks,
+            prev_tracks: Spicetify.Queue?.prevTracks,
         });
         success(count);
         Spicetify.Player.next();

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -437,9 +437,9 @@ declare namespace Spicetify {
      * history of played tracks and current track metadata.
      */
     const Queue: {
-        next_tracks: any[];
-        prev_tracks: any[];
-        revision: string;
+        nextTracks: any[];
+        prevTracks: any[];
+        queueRevision: string;
         track: any;
     };
     /**


### PR DESCRIPTION
This PR contains two commits.

The first fixes #1152, where the request fails due to a missing field (with Queue returning undefined).
The second fixes an exception when the user has a empty folder, which breaks the recursive search.