### PR TITLE
pushExtensions param fix

### DIFF
--- a/src/cmd/watch.go
+++ b/src/cmd/watch.go
@@ -109,7 +109,7 @@ func WatchExtensions(extName []string, liveUpdate bool) {
 			os.Exit(1)
 		}
 
-		pushExtensions(filePath)
+		pushExtensions("",filePath)
 
 		utils.PrintSuccess(utils.PrependTime(`Extension "` + filePath + `" is updated.`))
 	}, autoReloadFunc)


### PR DESCRIPTION
I've altered the params passed to pushExtensions when it's called inside WatchExtensions to mirror the way it's called when `spicetify apply` is executed.

I'm new to Go, but since `watch -e` does not properly update extensions since the last release, and given that `spicetify apply` does update them as expected, this change seemed logical to me.

**This needs testing by someone who knows what they're doing** (ie. not me).