### PR TITLE
RFC: Fix install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,17 +15,17 @@ case $(uname -sm) in
 esac
 
 if [ $# -eq 0 ]; then
-	latest_release_uri="https://api.github.com/repos/khanhas/spicetify-cli/releases/latest"
+	latest_release_uri="https://api.github.com/repos/spicetify/spicetify-cli/releases/latest"
 	echo "DOWNLOADING    $latest_release_uri"
 	spicetify_asset_path=$(
 		command curl -sSf "$latest_release_uri" |
-			command grep -o "/khanhas/spicetify-cli/releases/download/.*/spicetify-.*-${target}\\.tar\\.gz" |
+			command grep -o "/spicetify/spicetify-cli/releases/download/.*/spicetify-.*-${target}\\.tar\\.gz" |
 			command head -n 1
 	)
 	if [ ! "$spicetify_asset_path" ]; then exit 1; fi
 	download_uri="https://github.com${spicetify_asset_path}"
 else
-	download_uri="https://github.com/khanhas/spicetify-cli/releases/download/v${1}/spicetify-${1}-${target}.tar.gz"
+	download_uri="https://github.com/spicetify/spicetify-cli/releases/download/v${1}/spicetify-${1}-${target}.tar.gz"
 fi
 
 spicetify_install="$HOME/.spicetify"


### PR DESCRIPTION
At 58ee5338dc9ada0b2625113f67e62598bd6bc281, the `install.sh` script fails, exiting with error code `1`.

This is due to this curl:

```bash
command curl -sSf "$latest_release_uri"
```

Now returning:
```json
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/159981830/releases/latest",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}
```

Even if adding `-L` to follow the redirect, the grep will fail since `khanhas` does not match.

This PR fixes that. Copyright notice was left as is.

Just in case it's relevant, and it's a problem on my side, I tested this on my side under:
- OS: Fedora 35
- Curl: 7.79.1
- Bash: 5.1.8(1)-release