### PR TITLE
fix: `main` selector for newReleases.js

### DIFF
--- a/CustomApps/new-releases/index.js
+++ b/CustomApps/new-releases/index.js
@@ -69,6 +69,7 @@ class Grid extends react.Component {
         };
     }
 
+    viewportSelector = "#main .os-viewport";
     updatePostsVisual() {
         gridList = [];
         for (const date of dateList) {
@@ -171,7 +172,7 @@ class Grid extends react.Component {
         this.configButton = new Spicetify.Menu.Item("New Releases config", false, openConfig);
         this.configButton.register();
 
-        const viewPort = document.querySelector("main .os-viewport");
+        const viewPort = document.querySelector(this.viewportSelector);
 
         if (gridList.length) {
             // Already loaded
@@ -185,7 +186,7 @@ class Grid extends react.Component {
     }
 
     componentWillUnmount() {
-        const viewPort = document.querySelector("main .os-viewport");
+        const viewPort = document.querySelector(this.viewportSelector);
         lastScroll = viewPort.scrollTop;
         this.configButton.deregister();
     }


### PR DESCRIPTION
(Fix for #1501)

Replaced the selector used to grab the viewport when a user attempts to go to an album listed by the new-releases custom app (Spotify changed/removed some stuff in the last update).

Added the new selector as a property of the Grid class since I thought that would be more appropriate than hardcoding it in both places (and makes it a tiny bit easier the next time Spotify breaks it again and we have to change the selector).