### PR TITLE
Fix hooks for Spotify 1.1.80

### DIFF
--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -186,7 +186,7 @@ func getColorCSS(scheme map[string]string) string {
 
 func insertCustomApp(jsPath string, flags Flag) {
 	utils.ModifyFile(jsPath, func(content string) string {
-		const REACT_REGEX = `lazy\(\(\(\)=>(\w+)\.(\w+)\(\d+\)\.then\(\w+\.bind\(\w+,\d+\)\)\)\)`
+		const REACT_REGEX = `lazy\(\((?:\(\)=>|function\(\)\{return )(\w+)\.(\w+)\(\d+\)\.then\(\w+\.bind\(\w+,\d+\)\)\}?\)\)`
 		const REACT_ELEMENT_REGEX = `\w+\(\)\.createElement\(([\w\.]+),\{path:"\/collection"(?:,[:\.\w,]+)?\}`
 		reactSymbs := utils.FindSymbol(
 			"Custom app React symbols",

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -282,20 +282,20 @@ func exposeAPIs_main(input string) string {
 	// React Hook
 	utils.ReplaceOnce(
 		&input,
-		`\w+=\(\w+,(\w+)\.lazy\)\(?\(\(\)=>\w+\.\w+\((?:\d+)?\)\.then\(\w+\.bind\(\w+,\w+\)\)\)\)?;`,
-		`${0}Spicetify.React=${1};`)
+		`(\w+=\(\w+,(\w+)\.lazy\)\(?\((?:\(\)=>|function\(\)\{return )\w+\.\w+\((?:\d+)?\)\.then\(\w+\.bind\(\w+,\w+\)\)\}?\)\)?),`,
+		`${1};Spicetify.React=${2};var `)
 
 	utils.Replace(
 		&input,
 		`"data-testid":`,
 		`"":`)
 
-	reAllAPIPromises := regexp.MustCompile(`return ?{version:\w+,(?:\w+:[\w!$,().]+,)+(?:get\w+:(?:async)?\(\)=>[()\w=>{} ]+,)?((?:get\w+:\(\)=>(?:[\w$]+|[(){}]+),?)+)}`)
+	reAllAPIPromises := regexp.MustCompile(`return ?(?:function\(\))?\{(?:[ \w\.,\(\)\{\}]+)?((?:get\w+:(?:\(\)=>|function\(\)\{return ?)(?:[\w$]+|[(){}]+)\}?,?)+)[\}\)]+;`)
 	allAPIPromises := reAllAPIPromises.FindAllStringSubmatch(input, -1)
 	for _, found := range allAPIPromises {
 		splitted := strings.Split(found[1], ",")
 		if len(splitted) > 15 { // Actual number is about 34
-			matchMap := regexp.MustCompile(`get(\w+):\(\)=>([\w$]+|[(){}]+),?`)
+			matchMap := regexp.MustCompile(`get(\w+):(?:\(\)=>|function\(\)\{return ?)([\w$]+|\{\})\}?,?`)
 			code := "Spicetify.Platform={};"
 			for _, apiFunc := range splitted {
 				matches := matchMap.FindStringSubmatch(apiFunc)
@@ -329,8 +329,8 @@ Spicetify.React.useEffect(() => {
 	// React Component: Context Menu and Right Click Menu
 	utils.Replace(
 		&input,
-		`=(\w+)=>(\w+\(\)\.createElement\(([\w\.]+),\w*\((\w+,[\w\.]+)?\)\(\{\},\w+,\{action:"open",trigger:"right-click"\}\)\))`,
-		`=Spicetify.ReactComponent.RightClickMenu=${1}=>${2};Spicetify.ReactComponent.ContextMenu=${3}`)
+		`=(?:function\()?(\w+)(?:=>|\)\{return )(\w+\(\)\.createElement\(([\w\.]+),\w*\((\w+,[\w\.]+)?\)\(\{\},\w+,\{action:"open",trigger:"right-click"\}\)\))\}?`,
+		`=Spicetify.ReactComponent.RightClickMenu=${1}=>${2};Spicetify.ReactComponent.ContextMenu=${3};`)
 
 	// React Component: Context Menu - Menu
 	utils.Replace(


### PR DESCRIPTION
This is a preliminary pull request that will maintain basic support for Spotify 1.1.80 while further hooks are fixed.

## Fixed hooks

- Custom App React symbols
- `Spicetify.React`
- `Spicetify.Platform`
- `Spicetify.ReactComponent.RightClickMenu`
- `Spicetify.ReactComponent.ContextMenu`

## Known Broken Hooks

- `Spicetify.Menu`
- `Spicetify.ReactComponent.Menu`
- `Spicetify.ReactComponent.MenuItem`
- `Spicetify.ReactComponent.AlbumMenu`
- `Spicetify.ReactComponent.PodcastShowMenu`
- `Spicetify.ReactComponent.ArtistMenu`
- `Spicetify.ReactComponent.PlaylistMenu`
- Home config

## Additional Information

It seems `enable-devtool` is no longer functional. I have created a workaround for Windows exectuables. If you install Cheat Engine, attach to Spotify.exe, hit "Add Address Manually", enter `016525fd`, set value to `255`. This will enable devtool when activated. It will likely stop working on the next Spotify update. Further investigation will be necessary to create a long-term solution. The way this works is by directly modifying the memory of the Spotify executable browser and enabling the developer mode flag in Chromium Embedded Framework. I determined this address by disassembling and analyzing Spotify.exe using Ghidra, and determined this was the data location used to store the true/false value for developer mode.