### PR TITLE
add path for void linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright 2022 khanhas. GPL license.
 # Edited from project Denoland install script (https://github.com/denoland/deno_install)
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright 2022 khanhas. GPL license.
 # Edited from project Denoland install script (https://github.com/denoland/deno_install)
 

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -293,6 +293,7 @@ func linuxApp() string {
 	potentialList := []string{
 		"/opt/spotify/",
 		"/usr/share/spotify/",
+		"/usr/libexec/spotify/",
 		"/var/lib/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
 	}
 


### PR DESCRIPTION
adding check in path for `/usr/libexec/spotify`: [reason](https://github.com/void-linux/void-packages/blob/a10403d2ac194303421ddfbdbd33c770cd4afacb/srcpkgs/spotify/template#L44)

isn't https://github.com/spicetify/spicetify-cli/blob/e7ea852355d55eb153d3d8e7279e714a883d1c55/install.sh#L36 a bashism? 
[install.sh](https://github.com/spicetify/spicetify-cli/blob/master/install.sh) is specified to use `sh` but in some systems `sh` is symlinked to `dash`.