### PR TITLE
fix: `fullAppDisplay` album info & background

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Get Tag
-        run: echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        run: echo "TAG=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
 
       - name: Is Unix Platform
         run: echo "IS_UNIX=${{ matrix.os != 'windows' && matrix.arch != '386' }}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,9 @@ jobs:
 
       - name: Build
         if: env.IS_UNIX == 'true' || env.IS_WIN == 'true'
-        run: go build -ldflags "-X main.version=${{ env.TAG }}" -o "./spicetify${{ matrix.os == 'windows' && '.exe' || '' }}"
+        run: |
+          go build -ldflags "-X main.version=${{ env.TAG }}" -o "./spicetify${{ matrix.os == 'windows' && '.exe' || '' }}"
+          chmod +x "./spicetify${{ matrix.os == 'windows' && '.exe' || '' }}"
         env:
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -162,9 +162,6 @@ class LyricsContainer extends react.Component {
     async fetchColors(uri) {
         let prominent = 0;
         try {
-            // const colors = await CosmosAsync.get(`hm://colorextractor/v1/extract-presets?uri=${uri}&format=json`);
-            // prominent = colors.entries[0].color_swatches[4].color;
-            // hermes deprecated 1.1.81 onwards
             const colors = await CosmosAsync.get(
                 `https://spclient.wg.spotify.com/color-lyrics/v2/track/${uri.split(":")[2]}/?format=json&vocalRemoval=false&market=from_token`
             );

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -162,8 +162,13 @@ class LyricsContainer extends react.Component {
     async fetchColors(uri) {
         let prominent = 0;
         try {
-            const colors = await CosmosAsync.get(`hm://colorextractor/v1/extract-presets?uri=${uri}&format=json`);
-            prominent = colors.entries[0].color_swatches[4].color;
+            // const colors = await CosmosAsync.get(`hm://colorextractor/v1/extract-presets?uri=${uri}&format=json`);
+            // prominent = colors.entries[0].color_swatches[4].color;
+            // hermes deprecated 1.1.81 onwards
+            const colors = await CosmosAsync.get(
+                `https://spclient.wg.spotify.com/color-lyrics/v2/track/${uri.split(":")[2]}/?format=json&vocalRemoval=false&market=from_token`
+            );
+            prominent = colors.colors.background;
         } catch {
             prominent = 0;
         }

--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -341,9 +341,13 @@ body.video-full-screen.video-full-screen--hide-ui {
 
         async getAlbumDate(uri) {
             const id = uri.replace("spotify:album:", "");
-            const albumInfo = await Spicetify.CosmosAsync.get(`hm://album/v1/album-app/album/${id}/desktop`);
+            // const albumInfo = await Spicetify.CosmosAsync.get(`hm://album/v1/album-app/album/${id}/desktop`);
+            // const albumDate = new Date(albumInfo.year, (albumInfo.month || 1) - 1, albumInfo.day || 0);
+            // hermes protocol deprecated 1.1.81 onwards
 
-            const albumDate = new Date(albumInfo.year, (albumInfo.month || 1) - 1, albumInfo.day || 0);
+            const albumInfo = await Spicetify.CosmosAsync.get(`https://api.spotify.com/v1/albums/${id}`);
+
+            const albumDate = new Date(albumInfo.release_date);
             const recentDate = new Date();
             recentDate.setMonth(recentDate.getMonth() - 6);
             return albumDate.toLocaleString("default", albumDate > recentDate ? { year: "numeric", month: "short" } : { year: "numeric" });

--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -341,9 +341,6 @@ body.video-full-screen.video-full-screen--hide-ui {
 
         async getAlbumDate(uri) {
             const id = uri.replace("spotify:album:", "");
-            // const albumInfo = await Spicetify.CosmosAsync.get(`hm://album/v1/album-app/album/${id}/desktop`);
-            // const albumDate = new Date(albumInfo.year, (albumInfo.month || 1) - 1, albumInfo.day || 0);
-            // hermes protocol deprecated 1.1.81 onwards
 
             const albumInfo = await Spicetify.CosmosAsync.get(`https://api.spotify.com/v1/albums/${id}`);
 


### PR DESCRIPTION
As the hermes protocol is broken `1.1.81` onwards, this can "fix" the issue. Now the lyrics-plus background will always match spotify lyrics background.

Maybe, in the future, there is a way to restore the old colorextractor.