### PR TITLE
fix(fullAppDisplay): background for full screen display on a vertical monitor

### DIFF
--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -420,25 +420,38 @@ body.video-full-screen.video-full-screen--hide-ui {
             const { innerWidth: width, innerHeight: height } = window;
             this.back.width = width;
             this.back.height = height;
-            const dim = width > height ? width : height;
 
             const ctx = this.back.getContext("2d");
             ctx.imageSmoothingEnabled = false;
             ctx.filter = `blur(30px) brightness(0.6)`;
             const blur = 30;
 
+            const x = -blur * 2;
+
+            let y,dim;
+
+            if (width > height) {
+                dim = width;
+                y = x - (width - height) / 2;
+            } else {
+                dim = height;
+                y = x;
+            }
+
+            const size = dim + 4 * blur;
+
             if (!CONFIG.enableFade) {
                 ctx.globalAlpha = 1;
-                ctx.drawImage(nextImg, -blur * 2, -blur * 2 - (width - height) / 2, dim + 4 * blur, dim + 4 * blur);
+                ctx.drawImage(nextImg, x, y, size, size);
                 return;
             }
 
             let factor = 0.0;
             const animate = () => {
                 ctx.globalAlpha = 1;
-                ctx.drawImage(prevImg, -blur * 2, -blur * 2 - (width - height) / 2, dim + 4 * blur, dim + 4 * blur);
+                ctx.drawImage(prevImg, x, y, size, size);
                 ctx.globalAlpha = Math.sin((Math.PI / 2) * factor);
-                ctx.drawImage(nextImg, -blur * 2, -blur * 2 - (width - height) / 2, dim + 4 * blur, dim + 4 * blur);
+                ctx.drawImage(nextImg, x, y, size, size);
 
                 if (factor < 1.0) {
                     factor += 0.016;

--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -428,7 +428,7 @@ body.video-full-screen.video-full-screen--hide-ui {
 
             const x = -blur * 2;
 
-            let y,dim;
+            let y, dim;
 
             if (width > height) {
                 dim = width;


### PR DESCRIPTION
**Issue:**
If the canvas size of the fullAppDisplay.js is higher then wide the background offset calculation goes wrong and the background is displayed with a gap towards the top.

**Fix**:
This PR changes the calculation to use a different offset in the case of `height > width` which corrects the issue and leads to an expected result.

**Comparison:**
<p float="middle">
<img width="360" alt="spicetify_fullAppDisplay_vertical" src="https://user-images.githubusercontent.com/18489892/160683615-10feb490-2411-4d74-8c39-8e74bad07d4d.png">&nbsp;<img width="360" alt="spicetify_fullAppDisplay_vertical_fixed" src="https://user-images.githubusercontent.com/18489892/160683623-4201cf30-af0e-4cab-bd84-d4fa70d7cdfd.png">
</p>

