### PR TITLE
Fix `New Releases` custom app for Spotify 1.1.81+

### DIFF
--- a/CustomApps/new-releases/Settings.js
+++ b/CustomApps/new-releases/Settings.js
@@ -189,6 +189,13 @@ function openConfig() {
                     when: () => true,
                 },
                 {
+                    desc: "Track limit",
+                    key: "limit",
+                    defaultValue: CONFIG.limit,
+                    type: ConfigInput,
+                    when: () => true,
+                },
+                {
                     desc: "Date locale",
                     key: "locale",
                     defaultValue: CONFIG.locale,


### PR DESCRIPTION
- Based on already merged fix for `Shuffle+` (#1559)
- Fixes #1539 #1530

### Notes:
- May or may not return `error 500` when fetching large libraries of followed artists
- May or may not fetch releases from all followed artists (due to above)
- Limits amount of queried albums to 5 (to limit errors)
- Shows notifications with:
   - Error code (`500`, `429` etc.)
   - Amount of followed artists to fetch releases from
   - Amount of followed artists failed to fetch releases from due to `error 500` (that's what that new function is for...)
   
Let me know if any changes are needed 😄 