### PR TITLE
Few more fix for branch "fix-specific-version-fetch"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,18 +19,18 @@ command -v grep >/dev/null || { echo "grep isn't installed\!" >&2; exit 1; }
 
 # download uri
 shortcut=https://github.com/spicetify/spicetify-cli/releases
-tag=$(curl -LsH 'Accept: application/json' $shortcut/latest)
-tag=${tag%\,\"update_url*}
-tag=${tag##*tag_name\":\"}
-tag=${tag%\"}
-
 if [ $# -gt 0 ]; then
-	download_uri=$shortcut/download/v$1/spicetify-$1-$target.tar.gz
+	tag=$1
 	echo "FETCHING Version $1"
 else
-	download_uri=$shortcut/download/$tag/spicetify-${tag#v}-$target.tar.gz
-	echo "FETCHING Latest Version"
+	tag=$(curl -LsH 'Accept: application/json' $shortcut/latest)
+	tag=${tag%\,\"update_url*}
+	tag=${tag##*tag_name\":\"}
+	tag=${tag%\"}
+	echo "FETCHING Latest Version $1"
 fi
+
+download_uri=$shortcut/download/$tag/spicetify-${tag#v}-$target.tar.gz
 
 # locations
 spicetify_install="$HOME/.spicetify"

--- a/install.sh
+++ b/install.sh
@@ -21,16 +21,16 @@ command -v grep >/dev/null || { echo "grep isn't installed\!" >&2; exit 1; }
 shortcut=https://github.com/spicetify/spicetify-cli/releases
 if [ $# -gt 0 ]; then
 	tag=$1
-	echo "FETCHING Version $1"
 else
 	tag=$(curl -LsH 'Accept: application/json' $shortcut/latest)
 	tag=${tag%\,\"update_url*}
 	tag=${tag##*tag_name\":\"}
 	tag=${tag%\"}
-	echo "FETCHING Latest Version $1"
 fi
 
 tag=${tag#v}
+
+echo "FETCHING Version $tag"
 
 download_uri=$shortcut/download/v$tag/spicetify-$tag-$target.tar.gz
 

--- a/install.sh
+++ b/install.sh
@@ -18,11 +18,11 @@ command -v tar >/dev/null || { echo "tar isn't installed\!" >&2; exit 1; }
 command -v grep >/dev/null || { echo "grep isn't installed\!" >&2; exit 1; }
 
 # download uri
-shortcut=https://github.com/spicetify/spicetify-cli/releases
+releases_uri=https://github.com/spicetify/spicetify-cli/releases
 if [ $# -gt 0 ]; then
 	tag=$1
 else
-	tag=$(curl -LsH 'Accept: application/json' $shortcut/latest)
+	tag=$(curl -LsH 'Accept: application/json' $releases_uri/latest)
 	tag=${tag%\,\"update_url*}
 	tag=${tag##*tag_name\":\"}
 	tag=${tag%\"}
@@ -32,7 +32,7 @@ tag=${tag#v}
 
 echo "FETCHING Version $tag"
 
-download_uri=$shortcut/download/v$tag/spicetify-$tag-$target.tar.gz
+download_uri=$releases_uri/download/v$tag/spicetify-$tag-$target.tar.gz
 
 # locations
 spicetify_install="$HOME/.spicetify"

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,9 @@ else
 	echo "FETCHING Latest Version $1"
 fi
 
-download_uri=$shortcut/download/$tag/spicetify-${tag#v}-$target.tar.gz
+tag=${tag#v}
+
+download_uri=$shortcut/download/v$tag/spicetify-$tag-$target.tar.gz
 
 # locations
 spicetify_install="$HOME/.spicetify"
@@ -84,5 +86,5 @@ case $SHELL in
 esac
 
 echo
-echo "spicetify $tag was installed successfully to $spicetify_install"
+echo "spicetify v$tag was installed successfully to $spicetify_install"
 echo "Run 'spicetify --help' to get started"


### PR DESCRIPTION
Changes:
* Doesn't print "spicetify v2.9.4 was installed successfully" when specifying a version anymore.
* Doesn't request the latest version when specifying a version anymore.
* Allows to input both `x.y.z` and `vx.y.z` (for example: `2.9.2` and `v2.9.2`)
* Now prints "FETCHING Version x.y.z" instead of "FETCHING Latest Version" when fetching the latest version.
* Renamed "shortcut" variable to "releases_uri" for better clarification.

Note: Hope I did the pull request correctly. I've never made a pull request for code that's still not in the main branch.