### PR TITLE
Update css-map.json with latest main-trackInfo-*

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1732,5 +1732,8 @@
     "es9mguuOfkp6pBe1Bjlw": "x-toggle-indicator",
     "Js64TOfWtHksI6TQ6knT": "x-toggle-indicatorWrapper",
     "n8tsDTs8wDH73kejYfXs": "x-toggle-input",
-    "JWYoNAyrIIdW30u4PSGE": "x-toggle-wrapper"
+    "JWYoNAyrIIdW30u4PSGE": "x-toggle-wrapper",
+    "KKJUKKP3FyKKKdRjWDVj": "main-trackInfo-container",
+    "tyIiSOWsTxiyox1_LW7F": "main-trackInfo-name",
+    "M6PIsRD7BGqgMv0WZ_Sv": "main-trackInfo-artists"
 }


### PR DESCRIPTION
Updated for Spotify: v1.1.83.956

Are their any plans for a more global css map update?
AFAIK, some of the devs here have tools to make it easy to map naming changes