### PR TITLE
feat(restart): check if process is running

### DIFF
--- a/src/cmd/restart.go
+++ b/src/cmd/restart.go
@@ -38,8 +38,8 @@ func RestartSpotify(flags ...string) {
 			exec.Command(filepath.Join(spotifyPath, "spotify"), flags...).Start()
 		}
 	case "darwin":
-		isRunning := exec.Command("pgrep", "Spotify")
-		_, err := isRunning.Output()
+        isRunning := exec.Command("sh", "-c", "ps aux | grep 'Spotify' | grep -v grep")
+		_, err := isRunning.CombinedOutput()
 		if err == nil {
 			exec.Command("pkill", "Spotify").Run()
 			flags = append([]string{"-a", "/Applications/Spotify.app"}, flags...)

--- a/src/cmd/restart.go
+++ b/src/cmd/restart.go
@@ -38,7 +38,7 @@ func RestartSpotify(flags ...string) {
 			exec.Command(filepath.Join(spotifyPath, "spotify"), flags...).Start()
 		}
 	case "darwin":
-        isRunning := exec.Command("sh", "-c", "ps aux | grep 'Spotify' | grep -v grep")
+		isRunning := exec.Command("sh", "-c", "ps aux | grep 'Spotify' | grep -v grep")
 		_, err := isRunning.CombinedOutput()
 		if err == nil {
 			exec.Command("pkill", "Spotify").Run()


### PR DESCRIPTION
Small QoL change, resolves #1469 
Spicetify should check whether process is running and would not launch it if it isn't
Tested and working for Windows
If `pgrep` output is accurately stated [here](https://linuxize.com/post/pgrep-command-in-linux/):
> The command returns 0 when at least one running process matches the requested name. Otherwise, the exit code is 1. This can be useful when writing shell scripts.

Then the result should be the same for Linux/MacOS