### PR TITLE
fix: Lyrics Plus not showing full lyrics

### DIFF
--- a/CustomApps/lyrics-plus/ProviderGenius.js
+++ b/CustomApps/lyrics-plus/ProviderGenius.js
@@ -93,13 +93,15 @@ const ProviderGenius = (function () {
             return lyrics;
         }
 
-        lyricsSections = body.match(/<div ([\w-]+=[\w"]+ )+class="Lyrics__Container.+?>.+?<\/div>/gs);
+        lyricsSections = body.match(/<div ([\w-]+=[\w"]+ )+class="Lyrics__Container.+?>.+?(<\/div><\/div>.+?)?<\/div>/gs);
         if (lyricsSections) {
             lyrics = "";
             for (const section of lyricsSections) {
-                const fragment = section.match(/<div ([\w-]+=[\w"]+ )+class="Lyrics__Container.+?>(.+?)<\/div>/s);
+                const fragment = section.match(/<div ([\w-]+=[\w"]+ )+class="Lyrics__Container.+?>(.+?)(<\/div><\/div>(.+?))?<\/div>/s);
                 if (fragment) {
-                    lyrics += fragment[2];
+                    for (let i = 2; i < fragment.length; i++) {
+                        lyrics += fragment[i];
+                    }
                 }
             }
             return lyrics;


### PR DESCRIPTION
Updates Regex to exclude the `<div>` element inside of `Lyrics__Container`
![image](https://user-images.githubusercontent.com/77577746/165922543-5076ab5b-feb2-42f8-8d8b-2d076cff90f0.png)
Tested and is working as expected
![image](https://user-images.githubusercontent.com/77577746/165922586-a40791cb-19ee-42f4-90da-0bf2ae72e729.png)
![image](https://user-images.githubusercontent.com/77577746/165922591-6d0cffba-6eae-4215-a760-af9a2ada580e.png)
