### PR TITLE
fix(lyrics-plus): add null check

### DIFF
--- a/CustomApps/lyrics-plus/ProviderGenius.js
+++ b/CustomApps/lyrics-plus/ProviderGenius.js
@@ -100,7 +100,9 @@ const ProviderGenius = (function () {
                 const fragment = section.match(/<div ([\w-]+=[\w"]+ )+class="Lyrics__Container.+?>(.+?)(<\/div><\/div>(.+?))?<\/div>/s);
                 if (fragment) {
                     for (let i = 2; i < fragment.length; i++) {
-                        lyrics += fragment[i];
+                        if (fragment[i]) {
+                            lyrics += fragment[i];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Add null check for Lyrics Plus since Regex returns unexpected matches (for that I apologize for my carelessness)

<details>
<summary>Tested and working as expected</summary>

- Before:
![image](https://user-images.githubusercontent.com/77577746/165974072-20469969-b0a9-4138-b2fc-f64d204491ed.png)
- After:
![image](https://user-images.githubusercontent.com/77577746/165974101-02abed39-0a6d-419d-bd5c-ddaff7bdab9a.png)
</details>