### PR TITLE
fix(lyrics-plus): switch to `wg://` protocol for colors

### DIFF
--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -162,10 +162,8 @@ class LyricsContainer extends react.Component {
     async fetchColors(uri) {
         let prominent = 0;
         try {
-            const colors = await CosmosAsync.get(
-                `https://spclient.wg.spotify.com/color-lyrics/v2/track/${uri.split(":")[2]}/?format=json&vocalRemoval=false&market=from_token`
-            );
-            prominent = colors.colors.background;
+            const colors = await CosmosAsync.get(`wg://colorextractor/v1/extract-presets?uri=${uri}&format=json`);
+            prominent = colors.entries[0].color_swatches[4].color;
         } catch {
             prominent = 0;
         }


### PR DESCRIPTION
This is just more reliable and fetches the color regardless of, if the lyrics are present, unlike the old "fix".