### PR TITLE
feat(backup): change error message

### DIFF
--- a/src/cmd/backup.go
+++ b/src/cmd/backup.go
@@ -48,7 +48,7 @@ func Backup(spicetifyVersion string) {
 	if totalApp > 0 {
 		utils.PrintGreen("OK")
 	} else {
-		utils.PrintError("Cannot backup app files. Reinstall Spotify and try again.")
+		utils.PrintError("Cannot backup app files. Does Spicetify have permissions to access Spotify files?")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Proposal PR, feel free to close if this is not appropriate.
- As #1601 points out that the [note](https://spicetify.app/docs/advanced-usage/installation#note-for-linux-users) sections can be neglected, thus checking if Spicetify have permissions to access app files _should be_ the first thing a user should check instead of reinstalling Spotify, which is relatively more of a hassle to do.
- Of course, this might _not_ be the common case and might be not that good to generalize it