### PR TITLE
fix(sidebar-config): get elements by classname

### DIFF
--- a/jsHelper/sidebarConfig.js
+++ b/jsHelper/sidebarConfig.js
@@ -1,8 +1,8 @@
 (function SidebarConfig() {
     // STICKY container
     const appItems = document.querySelector(".main-navBar-entryPoints");
-    const playlistItems = document.querySelector(".main-rootlist-rootlistPlaylistsScrollNode .os-content");
-    const personalLibrary = document.querySelector(".main-rootlist-rootlistContent");
+    const playlistItems = document.querySelector(".main-navBar-navBar .os-content");
+    const personalLibrary = playlistItems?.parentElement;
 
     if (!appItems || !playlistItems || !personalLibrary) {
         setTimeout(SidebarConfig, 300);


### PR DESCRIPTION
Spotify 1.1.84 changed a lot of classnames, including the ones used in the sidebar config querySelectors. Funnily enough, the old version still worked on macOs. It did however break on Windows and possibly Linux.

Changes have been tested on macOs and Windows.

Fixes #1629