### PR TITLE
fix: rename old exe to current exe in case of failure extracting

### DIFF
--- a/src/cmd/upgrade.go
+++ b/src/cmd/upgrade.go
@@ -97,6 +97,7 @@ func Upgrade(currentVersion string) {
 		err = exec.Command("tar", "-xzf", location, "-C", utils.GetExecutableDir()).Run()
 	}
 	if err != nil {
+		os.Rename(exeOld, exe)
 		permissionError(err)
 	}
 


### PR DESCRIPTION
Have done this development ages ago, but I guess I just forgot to push it.