### PR TITLE
feat: improve handling of new Spotify versions

### DIFF
--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -18,6 +18,7 @@ type Flag struct {
 	HomeConfig    bool
 	ExpFeatures   bool
 	SpicetifyVer  string
+	SpotifyVer    string
 }
 
 // AdditionalOptions .
@@ -198,6 +199,11 @@ func insertCustomApp(jsPath string, flags Flag) {
 			content,
 			[]string{
 				REACT_ELEMENT_REGEX})
+
+		if (len(reactSymbs) < 2) || (len(eleSymbs) == 0) {
+			utils.PrintError("Spotify version mismatch with Spicetify\nSpicetify currently only supports until Spotify v" + flags.SpotifyVer)
+			return content
+		}
 
 		appMap := ""
 		appReactMap := ""

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -76,6 +76,7 @@ func Apply(spicetifyVersion string) {
 		HomeConfig:    featureSection.Key("home_config").MustBool(false),
 		ExpFeatures:   featureSection.Key("experimental_features").MustBool(false),
 		SpicetifyVer:  backupSection.Key("with").MustString(""),
+		SpotifyVer:    supportedSpotifyVersion,
 	})
 	utils.PrintGreen("OK")
 

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -13,12 +13,11 @@ import (
 )
 
 var (
+	supportedSpotifyVersion = "1.1.84"
 	spicetifyFolder         = utils.GetSpicetifyFolder()
 	rawFolder, themedFolder = getExtractFolder()
 	backupFolder            = utils.GetUserFolder("Backup")
 	userThemesFolder        = utils.GetUserFolder("Themes")
-	userExtensionsFolder    = utils.GetUserFolder("Extensions")
-	userAppsFolder          = utils.GetUserFolder("CustomApps")
 	quiet                   bool
 	isAppX                  = false
 	spotifyPath             string
@@ -260,8 +259,10 @@ func CheckUpgrade(version string) {
 		return
 	}
 
+	utils.PrintNote("Full Spicetify functionality is not guaranteed above Spotify's v" + supportedSpotifyVersion)
+
 	if latestTag == version {
-		utils.PrintInfo("spicetify up-to-date")
+		utils.PrintInfo("Spicetify up-to-date")
 	} else {
 		utils.PrintWarning("New version available!")
 		utils.PrintWarning(`Run "spicetify upgrade" or using package manager to upgrade spicetify`)

--- a/src/utils/print.go
+++ b/src/utils/print.go
@@ -45,6 +45,11 @@ func PrintGreen(text string) {
 	log.Println(Green(text))
 }
 
+// PrintNote prints a warning message
+func PrintNote(text string) {
+	log.Println(Bold(Yellow("note")), Bold(text))
+}
+
 // PrintWarning prints a warning message
 func PrintWarning(text string) {
 	log.Println(Yellow("warning"), text)


### PR DESCRIPTION
We're always getting reports of the Cannot find index of React app. This fixes that and improves how we communicate to users that we only support until a certain release of Spotify. This also means that we should update the `supportedSpotifyVersion` every time that we release a new version to support a new Spotify version.

<img width="556" alt="image" src="https://user-images.githubusercontent.com/19473034/169661297-bd8d61ec-e868-40c3-a1cc-daeb29b8a95f.png">
