### PR TITLE
fix(keyboardShortcut.js): next/prevSong selectors

### DIFF
--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -145,11 +145,11 @@
     }
 
     function nextSong() {
-        document.querySelector(".main-skipForwardButton-button").click();
+        document.querySelector("button[aria-label='Next']").click();
     }
 
     function previousSong() {
-        document.querySelector(".main-skipBackButton-button").click();
+        document.querySelector("button[aria-label='Previous']").click();
     }
 
     function increaseVolume() {


### PR DESCRIPTION
The selectors for `nextSong` and `previousSong` no longer work in Spotify version 1.1.86.857.g3751ee08.


![](https://i.imgur.com/Rr9lQhM.png)