### PR TITLE
revert(preprocess): replace `#fff` with variable

### DIFF
--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -186,7 +186,6 @@ func colorVariableReplace(content string) string {
 	utils.Replace(&content, "#282828", "var(--spice-card)")
 
 	utils.Replace(&content, "#121212", "var(--spice-main)")
-	utils.Replace(&content, "#fff", "var(--spice-main)")
 
 	utils.Replace(&content, "#000", "var(--spice-sidebar)")
 	utils.Replace(&content, "#000000", "var(--spice-sidebar)")


### PR DESCRIPTION
Reverts #1781 
`#fff` has already been replaced inside the file

![image](https://user-images.githubusercontent.com/77577746/175909733-efd2ee84-e0de-44a8-89fa-e1748f31d90e.png)

and the new change breaks themes as `#fff` is meant to be the text color

![image](https://user-images.githubusercontent.com/77577746/175909754-4974ce6b-e4ff-4c8a-8b85-e3cdb804c92a.png)
