### PR TITLE
fix(vcs): don't panic on empty `TagName`

### DIFF
--- a/src/utils/vcs.go
+++ b/src/utils/vcs.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
 )
@@ -24,6 +25,10 @@ func FetchLatestTag() (string, error) {
 	var release GithubRelease
 	if err = json.Unmarshal(body, &release); err != nil {
 		return "", err
+	}
+
+	if release.TagName == "" {
+		return "", errors.New("No tag found")
 	}
 
 	return release.TagName[1:], nil


### PR DESCRIPTION
Stops CLI from panicking as it tries to slice an empty string
![image](https://user-images.githubusercontent.com/77577746/177075811-cdbe3a96-293c-444d-95a4-cd8043b2d0da.png)
