### PR TITLE
feat(keyboardShortcut): smooth scrolling

### DIFF
--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -12,7 +12,7 @@
         return;
     }
 
-    const SCROLL_STEP = 50;
+    const SCROLL_STEP = 25;
 
     /**
      * Register your own keybind with function `registerBind`
@@ -123,14 +123,24 @@
     function appScrollDown() {
         const app = focusOnApp();
         if (app) {
-            app.scrollBy(0, SCROLL_STEP);
+            const scrollInterval = setInterval(() => {
+                app.scrollTop += SCROLL_STEP;
+            }, 10);
+            document.addEventListener("keyup", () => {
+                clearInterval(scrollInterval);
+            });
         }
     }
 
     function appScrollUp() {
         const app = focusOnApp();
         if (app) {
-            app.scrollBy(0, -SCROLL_STEP);
+            const scrollInterval = setInterval(() => {
+                app.scrollTop -= SCROLL_STEP;
+            }, 10);
+            document.addEventListener("keyup", () => {
+                clearInterval(scrollInterval);
+            });
         }
     }
 
@@ -209,7 +219,8 @@
     }
 
     /**
-     * @returns {number}
+     * @returns {number | undefined}
+     * @param {NodeListOf<Element>} allItems
      */
     function findActiveIndex(allItems) {
         const active = document.querySelector(
@@ -398,6 +409,9 @@ function VimBind() {
         }
     }
 
+    /**
+     * @param {{ hasAttribute: (arg0: string) => any; tagName: string; click: () => void; querySelector: (arg0: string) => any; firstChild: { innerText: string; }; }} element
+     */
     function click(element) {
         if (element.hasAttribute("href") || element.tagName === "BUTTON") {
             element.click();
@@ -424,6 +438,12 @@ function VimBind() {
         }
     }
 
+    /**
+     * @param {Element} target
+     * @param {string} key
+     * @param {string | number} top
+     * @param {string | number} left
+     */
     function createKey(target, key, top, left) {
         const div = document.createElement("span");
         div.classList.add("vim-key");


### PR DESCRIPTION
- Enables smooth(er) scrolling for `j` & `k` key bindings (Resolves #1800)
![Spotify_KiwZzIe6b3](https://user-images.githubusercontent.com/77577746/177687470-70cdc554-6ae3-4d7a-918b-c9031477d801.gif)
- Infer types for a few functions
