### PR TITLE
fix(css-map): correct class name for `statusIcons`

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1770,7 +1770,7 @@
     "whXv9jYuEgS1DPTmPCe_": "main-rootlist-rootlistItem",
     "utSR0FVkHnII_aL8TOcu": "main-rootlist-rootlistItemLink",
     "VjIb8SfYTkc4wMpqqj3f": "main-rootlist-textWrapper",
-    "g_jOSq3pLY5p4tldskrw": "main-rootlist-statusIcon",
+    "g_jOSq3pLY5p4tldskrw": "main-rootlist-statusIcons",
     "K8Rs3qAYirS8wJ1hR8gn": "main-rootlist-rootlistItemLinkActive",
     "I_aApN9pSlbGcpLtFQWw": "main-rootlist-expandArrow",
     "r9YzlaAPnM2LGK97GSfa": "main-collectionLinkButton-collectionLinkButton"


### PR DESCRIPTION
Changed `statusIcon` to `statusIcons` in newest CSS map addition