### PR TITLE
fix(css-map): update `1.1.90` classes

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1779,5 +1779,9 @@
     "ZYPWoTzgB8bUDbQRpbTr": "main-home-content",
     "npFSJSO1wsu3mEEGb5bh": "main-playbackBarRemainingTime-container",
     "zDK1f3nL_R49a1mOvaO1": "main-collectionLinkButton-selected",
-    "ot6VAZq1Xfbw2Vh8Qt_A": "main-collectionLinkButton-collectionLinkText"
+    "ot6VAZq1Xfbw2Vh8Qt_A": "main-collectionLinkButton-collectionLinkText",
+    "AINMAUImkAYJd4ertQxy": "main-rootlist-rootlistItemOverlay",
+    "qnYVzttodnzg9WdrVQ1p": "main-rootlist-bottomSentinel",
+    "lyVkg68L7ycnwyOcO3vj": "main-rootlist-topSentinel",
+    "JUa6JJNj7R_Y3i4P8YUX": "main-rootlist-wrapper"
 }

--- a/css-map.json
+++ b/css-map.json
@@ -1783,5 +1783,8 @@
     "AINMAUImkAYJd4ertQxy": "main-rootlist-rootlistItemOverlay",
     "qnYVzttodnzg9WdrVQ1p": "main-rootlist-bottomSentinel",
     "lyVkg68L7ycnwyOcO3vj": "main-rootlist-topSentinel",
-    "JUa6JJNj7R_Y3i4P8YUX": "main-rootlist-wrapper"
+    "JUa6JJNj7R_Y3i4P8YUX": "main-rootlist-wrapper",
+    "CoLO4pdSl8LGWyVZA00t": "main-actionBarBackground-background",
+    "E4q8ogfdWtye7YgotBlN": "main-actionBar-ActionBar",
+    "eSg4ntPU2KQLfpLGXAww": "main-actionBar-ActionBarRow"
 }

--- a/css-map.json
+++ b/css-map.json
@@ -1786,5 +1786,6 @@
     "JUa6JJNj7R_Y3i4P8YUX": "main-rootlist-wrapper",
     "CoLO4pdSl8LGWyVZA00t": "main-actionBarBackground-background",
     "E4q8ogfdWtye7YgotBlN": "main-actionBar-ActionBar",
-    "eSg4ntPU2KQLfpLGXAww": "main-actionBar-ActionBarRow"
+    "eSg4ntPU2KQLfpLGXAww": "main-actionBar-ActionBarRow",
+    "tp8rO9vtqBGPLOhwcdYv": "main-avatar-avatar"
 }


### PR DESCRIPTION
New class `main-rootlist-rootlistItemOverlay`, was added around .85 - .88
![image](https://user-images.githubusercontent.com/77577746/179440210-2e024e54-086f-411f-8f8e-cc6fef788794.png)
