### PR TITLE
feat(fullAppDisplay): Add mouse binding to open config

### DIFF
--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -776,4 +776,6 @@ button.switch.disabled {
     );
 
     Spicetify.Mousetrap.bind("f11", toggleFad);
+    Spicetify.Mousetrap.bind("f6", openConfig);
+
 })();


### PR DESCRIPTION
For me, right clicking the Full App Display button does not work. This fixes that by setting f6 as a keybind for opening the config menu.