### PR TITLE
feat(LyricsPlus): seek to lyrics on click

### DIFF
--- a/CustomApps/lyrics-plus/Pages.js
+++ b/CustomApps/lyrics-plus/Pages.js
@@ -173,7 +173,7 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
                         key: lineNumber,
                         dir: "auto",
                         ref,
-                        onDoubleClick: (event) => {
+                        onClick: (event) => {
                             if (startTime) {
                                 Spicetify.Player.seek(startTime);
                             }
@@ -398,7 +398,7 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
                     className: "lyrics-lyricsContainer-LyricsLine" + (i <= activeLineIndex ? " lyrics-lyricsContainer-LyricsLine-active" : ""),
                     dir: "auto",
                     ref: isActive ? activeLineRef : null,
-                    onDoubleClick: (event) => {
+                    onClick: (event) => {
                         if (startTime) {
                             Spicetify.Player.seek(startTime);
                         }

--- a/CustomApps/lyrics-plus/style.css
+++ b/CustomApps/lyrics-plus/style.css
@@ -128,6 +128,7 @@
 }
 
 .lyrics-lyricsContainer-SyncedLyrics .lyrics-lyricsContainer-LyricsLine {
+    cursor: pointer;
     transform: translateY(calc(var(--position-index) * var(--lyrics-line-height) + var(--offset)));
     transform-origin: var(--lyrics-align-text);
     transition-timing-function: cubic-bezier(0, 0, 0.58, 1);


### PR DESCRIPTION
Resolves #1846
Apparently the ability to seek to lyrics was already available but required the user to double-click (which will highlight some of the texts) and had the default `text` cursor so it was probably not the most intuitive way to let users know such features existed.

![Spotify_kEqgKoFtlF](https://user-images.githubusercontent.com/77577746/182017399-4716ef91-4046-4427-99e1-c757ac77f4df.gif)
 