### PR TITLE
fix(CustomApps): dropdown items not present

### DIFF
--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -12,9 +12,13 @@ const OptionsMenuItemIcon = react.createElement(
 );
 
 const OptionsMenuItem = react.memo(({ onSelect, value, isSelected }) => {
+    let className = "lyrics-plus-sort-option";
+    if (isSelected) className += " is-selected";
+
     return react.createElement(
-        Spicetify.ReactComponent.MenuItem,
+        "div",
         {
+            className,
             onClick: onSelect,
             icon: isSelected ? OptionsMenuItemIcon : null,
         },

--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -16,13 +16,13 @@ const OptionsMenuItem = react.memo(({ onSelect, value, isSelected }) => {
     if (isSelected) className += " is-selected";
 
     return react.createElement(
-        "div",
+        "li",
         {
             className,
             onClick: onSelect,
-            icon: isSelected ? OptionsMenuItemIcon : null,
         },
-        value
+        value,
+        isSelected ? OptionsMenuItemIcon : null
     );
 });
 

--- a/CustomApps/lyrics-plus/style.css
+++ b/CustomApps/lyrics-plus/style.css
@@ -616,11 +616,14 @@ button.switch.small {
     border-bottom-right-radius: 8px;
     border-bottom-left-radius: 8px;
 }
-.lyrics-plus-sort-option.is-selected {
-    background-color: rgba(var(--spice-rgb-text), 0.7);
-    color: var(--spice-sidebar);
+.lyrics-plus-option.is-selected {
+    background-color: rgba(var(--spice-rgb-selected-row), 0.1);
+    color: var(--spice-text);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 .lyrics-plus-sort-option:hover {
-    background-color: rgb(var(--spice-rgb-text));
-    color: var(--spice-sidebar);
+    background-color: rgba(var(--spice-rgb-selected-row), 0.3);
+    color: var(--spice-text);
 }

--- a/CustomApps/lyrics-plus/style.css
+++ b/CustomApps/lyrics-plus/style.css
@@ -604,3 +604,23 @@ button.switch.small {
 .lyrics-lyricsContainer-UnsyncedLyricsPage .split > div {
     flex: 50%;
 }
+
+.lyrics-plus-sort-option {
+    box-sizing: border-box;
+    color: rgba(var(--spice-rgb-text), 0.7);
+    cursor: pointer;
+    display: block;
+    padding: 8px 10px;
+}
+.lyrics-plus-sort-option:last-child {
+    border-bottom-right-radius: 8px;
+    border-bottom-left-radius: 8px;
+}
+.lyrics-plus-sort-option.is-selected {
+    background-color: rgba(var(--spice-rgb-text), 0.7);
+    color: var(--spice-sidebar);
+}
+.lyrics-plus-sort-option:hover {
+    background-color: rgb(var(--spice-rgb-text));
+    color: var(--spice-sidebar);
+}

--- a/CustomApps/lyrics-plus/style.css
+++ b/CustomApps/lyrics-plus/style.css
@@ -617,13 +617,11 @@ button.switch.small {
     border-bottom-left-radius: 8px;
 }
 .lyrics-plus-option.is-selected {
-    background-color: rgba(var(--spice-rgb-selected-row), 0.1);
-    color: var(--spice-text);
     display: flex;
     justify-content: space-between;
     align-items: center;
 }
 .lyrics-plus-sort-option:hover {
-    background-color: rgba(var(--spice-rgb-selected-row), 0.3);
+    background-color: rgba(var(--spice-rgb-selected-row), 0.1);
     color: var(--spice-text);
 }

--- a/CustomApps/lyrics-plus/style.css
+++ b/CustomApps/lyrics-plus/style.css
@@ -612,10 +612,6 @@ button.switch.small {
     display: block;
     padding: 8px 10px;
 }
-.lyrics-plus-sort-option:last-child {
-    border-bottom-right-radius: 8px;
-    border-bottom-left-radius: 8px;
-}
 .lyrics-plus-option.is-selected {
     display: flex;
     justify-content: space-between;

--- a/CustomApps/reddit/OptionsMenu.js
+++ b/CustomApps/reddit/OptionsMenu.js
@@ -12,9 +12,13 @@ const OptionsMenuItemIcon = react.createElement(
 );
 
 const OptionsMenuItem = react.memo(({ onSelect, value, isSelected }) => {
+    let className = "reddit-sort-option";
+    if (isSelected) className += " is-selected";
+
     return react.createElement(
-        Spicetify.ReactComponent.MenuItem,
+        "div",
         {
+            className,
             onClick: onSelect,
             icon: isSelected ? OptionsMenuItemIcon : null,
         },

--- a/CustomApps/reddit/OptionsMenu.js
+++ b/CustomApps/reddit/OptionsMenu.js
@@ -16,13 +16,13 @@ const OptionsMenuItem = react.memo(({ onSelect, value, isSelected }) => {
     if (isSelected) className += " is-selected";
 
     return react.createElement(
-        "div",
+        "li",
         {
             className,
             onClick: onSelect,
-            icon: isSelected ? OptionsMenuItemIcon : null,
         },
-        value
+        value,
+        isSelected ? OptionsMenuItemIcon : null
     );
 });
 

--- a/CustomApps/reddit/style.css
+++ b/CustomApps/reddit/style.css
@@ -150,3 +150,19 @@ div.reddit-tabBar-headerItemLink {
 .reddit-longDescription {
     display: flex;
 }
+
+.reddit-sort-option {
+    box-sizing: border-box;
+    color: rgba(var(--spice-rgb-text), 0.7);
+    cursor: pointer;
+    display: block;
+    padding: 8px 10px;
+}
+.reddit-sort-option.is-selected {
+    background-color: rgba(var(--spice-rgb-text), 0.7);
+    color: var(--spice-sidebar);
+}
+.reddit-sort-option:hover {
+    background-color: rgb(var(--spice-rgb-text));
+    color: var(--spice-sidebar);
+}

--- a/CustomApps/reddit/style.css
+++ b/CustomApps/reddit/style.css
@@ -159,10 +159,13 @@ div.reddit-tabBar-headerItemLink {
     padding: 8px 10px;
 }
 .reddit-sort-option.is-selected {
-    background-color: rgba(var(--spice-rgb-text), 0.7);
-    color: var(--spice-sidebar);
+    background-color: rgba(var(--spice-rgb-selected-row), 0.1);
+    color: var(--spice-text);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 .reddit-sort-option:hover {
-    background-color: rgb(var(--spice-rgb-text));
-    color: var(--spice-sidebar);
+    background-color: rgba(var(--spice-rgb-selected-row), 0.3);
+    color: var(--spice-text);
 }

--- a/CustomApps/reddit/style.css
+++ b/CustomApps/reddit/style.css
@@ -159,13 +159,11 @@ div.reddit-tabBar-headerItemLink {
     padding: 8px 10px;
 }
 .reddit-sort-option.is-selected {
-    background-color: rgba(var(--spice-rgb-selected-row), 0.1);
-    color: var(--spice-text);
     display: flex;
     justify-content: space-between;
     align-items: center;
 }
 .reddit-sort-option:hover {
-    background-color: rgba(var(--spice-rgb-selected-row), 0.3);
+    background-color: rgba(var(--spice-rgb-selected-row), 0.1);
     color: var(--spice-text);
 }


### PR DESCRIPTION
Resolves #1837 

![image](https://user-images.githubusercontent.com/77577746/182033087-747dea73-7f8a-43b6-88ac-415f50562000.png)

<details>
<summary>Reason behind dumping <code>Spicetify.ReactComponent.MenuItem</code> & findings</summary>

Spotify has hard-locked `MenuItem` usage for artists and profiles only (as seen through `O().isArtist(e)` and `O().isProfile(e)`), both of these boolean values return `false` which explains why Spotify refuses to render dropdown list items:
![image](https://user-images.githubusercontent.com/77577746/182031830-e5b8da8b-0035-44c3-8bc6-47392f461bed.png)

When trying to force render those items, a bunch of gibberish items are present instead, those of which are only present when right-clicking artist and profile links:
![image](https://user-images.githubusercontent.com/77577746/182031951-78bb043b-815b-4722-8867-971d95d4822e.png)
None of those buttons actually leads to the option props passed and thus far I have not found a way of manipulating these items hence why a generic `li` element was used instead
</details>