### PR TITLE
feat(wrapper): add `getFontStyle` method

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -416,12 +416,12 @@ declare namespace Spicetify {
             deregister(): void;
         }
     }
-    
+
     /**
      * Keyboard shortcut library
-     * 
+     *
      * Documentation: https://craig.is/killing/mice v1.6.5
-     * 
+     *
      * Spicetify.Keyboard is wrapper of this library to be compatible with legacy Spotify,
      * so new extension should use this library instead.
      */
@@ -1293,21 +1293,21 @@ declare namespace Spicetify {
         };
         /**
          * Generic context menu provider
-         * 
+         *
          * Props:
          * @see Spicetify.ReactComponent.ContextMenuProps
          */
         const ContextMenu: any;
         /**
          * Wrapper of ReactComponent.ContextMenu with props: action = 'toggle' and trigger = 'right-click'
-         * 
+         *
          * Props:
          * @see Spicetify.ReactComponent.ContextMenuProps
          */
         const RightClickMenu: any;
         /**
          * Outer layer contain ReactComponent.MenuItem(s)
-         * 
+         *
          * Props:
          * @see Spicetify.ReactComponent.MenuProps
          */
@@ -1315,14 +1315,14 @@ declare namespace Spicetify {
         /**
          * Component to construct menu item
          * Used as ReactComponent.Menu children
-         * 
+         *
          * Props:
          * @see Spicetify.ReactComponent.MenuItemProps
          */
         const MenuItem: any;
         /**
          * Tailored ReactComponent.Menu for specific type of object
-         * 
+         *
          * Props: {
          *      uri: string;
          *      onRemoveCallback?: (uri: string) => void;
@@ -1349,9 +1349,16 @@ declare namespace Spicetify {
     }
 
     /**
-     * SVG icons 
+     * SVG icons
      */
     namespace SVGIcons {
         const check: string;
     }
+
+    /**
+     * Return font styling used by Spotify.
+     * @param font Name of the font.
+     * Can match any of the fonts listed in `Spicetify._fontStyle` or returns a generic style otherwise.
+     */
+    function getFontStyle(font: string): string;
 }

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -108,7 +108,8 @@ const Spicetify = {
             "test",
             "Platform",
             "getFontStyle",
-            "_fontStyle"
+            "_fontStyle",
+            "version"
         ];
 
         const PLAYER_METHOD = [
@@ -145,7 +146,8 @@ const Spicetify = {
             "togglePlay",
             "toggleRepeat",
             "toggleShuffle",
-            "origin"
+            "origin",
+            "playUri"
         ]
 
         let count = SPICETIFY_METHOD.length;

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -248,7 +248,7 @@ Spicetify.LocalStorage = {
 };
 
 Spicetify.getFontStyle = (font) => {
-    if (!font) return;
+    if (!font || !Spicetify._fontStyle) return;
     let rawStyle = Spicetify._fontStyle({ variant: font }).filter(style => typeof style === "string").join("");
     // Clean up empty rulesets
     rawStyle = rawStyle.replace(new RegExp("\\w+-\\w+:;", "g"), "").trim();

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -106,7 +106,9 @@ const Spicetify = {
             "SVGIcons",
             "colorExtractor",
             "test",
-            "Platform"
+            "Platform",
+            "getFontStyle",
+            "_fontStyle"
         ];
 
         const PLAYER_METHOD = [
@@ -244,6 +246,29 @@ Spicetify.LocalStorage = {
     remove: (key) => localStorage.removeItem(key),
     set: (key, value) => localStorage.setItem(key, value),
 };
+
+Spicetify.getFontStyle = (font) => {
+    if (!font) return;
+    let rawStyle = Spicetify._fontStyle({ variant: font }).filter(style => typeof style === "string").join("");
+    // Clean up empty rulesets
+    rawStyle = rawStyle.replace(new RegExp("\\w+-\\w+:;", "g"), "").trim();
+    // Split special rulesets
+    const mediaStyle = rawStyle.split("@");
+    let returnStyle = `.main-type-${font}`;
+
+    mediaStyle.map((ruleset, index) => {
+        if (index === 0) {
+            return returnStyle += `{${ruleset}}`;
+        } else {
+            if (ruleset.endsWith(";")) ruleset = ruleset.slice(0, -1);
+            ruleset = ruleset.split(")").join(`){.main-type-${font}`);
+            return returnStyle += `@${ruleset}}`;
+        }
+    });
+
+    if (returnStyle.endsWith(";")) returnStyle = returnStyle.slice(0, -1);
+    return returnStyle.replaceAll(";;", ";");
+}
 
 (function waitMouseTrap() {
     if (!Spicetify.Mousetrap) {
@@ -471,6 +496,15 @@ Spicetify.SVGIcons = {
     "x": "<path d=\"M14.354 2.353l-.708-.707L8 7.293 2.353 1.646l-.707.707L7.293 8l-5.647 5.646.707.708L8 8.707l5.646 5.647.708-.708L8.707 8z\"/>"
 };
 
+function appendFontStyle(fontName) {
+    if (document.querySelector(`style#${fontName}`)) return;
+    const fontStyle = document.createElement("style");
+    fontStyle.className = "spicetify-font";
+    fontStyle.id = fontName;
+    fontStyle.innerHTML = Spicetify.getFontStyle(fontName);
+    document.head.appendChild(fontStyle);
+}
+
 class _HTMLContextMenuItem extends HTMLLIElement {
     constructor({
         name,
@@ -490,6 +524,7 @@ class _HTMLContextMenuItem extends HTMLLIElement {
         if (icon && Spicetify.SVGIcons[icon]) {
             icon = `<svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons[icon]}</svg>`;
         }
+        appendFontStyle("mesto");
         this.innerHTML = `
 <button class="main-contextMenu-menuItemButton ${this.disabled ? "main-contextMenu-disabled" : ""} ${this.divider ? "main-contextMenu-dividerAfter" : ""}">
     <span class="ellipsis-one-line main-type-mesto" dir="auto">${this.name}</span>
@@ -830,7 +865,7 @@ Spicetify.ContextMenu = (function () {
         } else if (props.context?.uri) {
             contextUri = props.context.uri;
         }
-        
+
         const elemList = [];
         for (const item of itemList) {
             if (!item.shouldAdd(uris, uids, contextUri)) {
@@ -942,6 +977,7 @@ Spicetify._cloneSidebarItem = function(list) {
         )
         reactObjs.push(obj);
     }
+    appendFontStyle("mestoBold");
     return reactObjs;
 }
 
@@ -959,6 +995,7 @@ class _HTMLGenericModal extends HTMLElement {
         content,
         isLarge = false,
     }) {
+        appendFontStyle("alto");
         this.innerHTML = `
 <div class="GenericModal__overlay" style="z-index: 100;">
     <div class="GenericModal" tabindex="-1" role="dialog" aria-label="${title}" aria-modal="true">

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -496,14 +496,19 @@ Spicetify.SVGIcons = {
     "x": "<path d=\"M14.354 2.353l-.708-.707L8 7.293 2.353 1.646l-.707.707L7.293 8l-5.647 5.646.707.708L8 8.707l5.646 5.647.708-.708L8.707 8z\"/>"
 };
 
-function appendFontStyle(fontName) {
-    if (document.querySelector(`style#${fontName}`)) return;
+(function appendAllFontStyle() {
+    if (!Spicetify._fontStyle) {
+        setTimeout(appendAllFontStyle, 1000);
+        return;
+    }
+    const fontList = Spicetify._fontStyle.toString().match(new RegExp('"\\w+"',"g")).map(font => font.replaceAll('"', ""));
     const fontStyle = document.createElement("style");
     fontStyle.className = "spicetify-font";
-    fontStyle.id = fontName;
-    fontStyle.innerHTML = Spicetify.getFontStyle(fontName);
-    document.head.appendChild(fontStyle);
-}
+    fontList.forEach(font => {
+        fontStyle.innerHTML += Spicetify.getFontStyle(font);
+    });
+    return document.head.appendChild(fontStyle);
+})()
 
 class _HTMLContextMenuItem extends HTMLLIElement {
     constructor({
@@ -524,7 +529,6 @@ class _HTMLContextMenuItem extends HTMLLIElement {
         if (icon && Spicetify.SVGIcons[icon]) {
             icon = `<svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons[icon]}</svg>`;
         }
-        appendFontStyle("mesto");
         this.innerHTML = `
 <button class="main-contextMenu-menuItemButton ${this.disabled ? "main-contextMenu-disabled" : ""} ${this.divider ? "main-contextMenu-dividerAfter" : ""}">
     <span class="ellipsis-one-line main-type-mesto" dir="auto">${this.name}</span>
@@ -977,7 +981,6 @@ Spicetify._cloneSidebarItem = function(list) {
         )
         reactObjs.push(obj);
     }
-    appendFontStyle("mestoBold");
     return reactObjs;
 }
 
@@ -995,7 +998,6 @@ class _HTMLGenericModal extends HTMLElement {
         content,
         isLarge = false,
     }) {
-        appendFontStyle("alto");
         this.innerHTML = `
 <div class="GenericModal__overlay" style="z-index: 100;">
     <div class="GenericModal" tabindex="-1" role="dialog" aria-label="${title}" aria-modal="true">

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -423,7 +423,7 @@ if (${1}.popper?.firstChild?.id === "context-menu") {
 
 	utils.ReplaceOnce(
 		&input,
-		`\(function\(\w+\)\{return \w+\.variant\?function\(\w+\)\{switch`,
+		`\(function\(\w+\)\{return \w+\.variant\?function\(\w+\)\{`,
 		`Spicetify._fontStyle=${0}`)
 
 	return input

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -421,6 +421,11 @@ if (${1}.popper?.firstChild?.id === "context-menu") {
 		`((\w+)\.createPortal=\w+,)`,
 		`${1}Spicetify.ReactDOM=${2},`)
 
+	utils.ReplaceOnce(
+		&input,
+		`\(function\(\w+\)\{return \w+\.variant\?function\(\w+\)\{switch`,
+		`Spicetify._fontStyle=${0}`)
+
 	return input
 }
 


### PR DESCRIPTION
Resolves #1849 

![image](https://user-images.githubusercontent.com/77577746/182185412-784bc22b-4ad2-4c41-b1a7-c6bee68e0257.png)

I could not find any other way Spotify had used this for their components so this will be an alternative.
Should provide compatibility for custom apps/extensions using `main-type` prefixed classnames also