### PR TITLE
feat: reimplement `Experimental Features`

### DIFF
--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -50,11 +50,11 @@ func AdditionalOptions(appsFolderPath string, flags Flag) {
 			filepath.Join(appsFolderPath, "xpui", "helper"))
 	}
 
-	/*if flags.ExpFeatures {
+	if flags.ExpFeatures {
 		utils.CopyFile(
 			filepath.Join(utils.GetJsHelperDir(), "expFeatures.js"),
 			filepath.Join(appsFolderPath, "xpui", "helper"))
-	}*/
+	}
 }
 
 // UserCSS creates colors.css user.css files in "xpui".
@@ -99,9 +99,9 @@ func htmlMod(htmlPath string, flags Flag) {
 		helperHTML += `<script defer src="helper/homeConfig.js"></script>` + "\n"
 	}
 
-	/*if flags.ExpFeatures {
+	if flags.ExpFeatures {
 		helperHTML += `<script defer src="helper/expFeatures.js"></script>` + "\n"
-	}*/
+	}
 
 	if flags.SpicetifyVer != "" {
 		helperHTML += `<script>Spicetify.version="` + flags.SpicetifyVer + `";</script>` + "\n"
@@ -311,7 +311,7 @@ func insertExpFeatures(jsPath string, flags Flag) {
 	utils.ModifyFile(jsPath, func(content string) string {
 		utils.ReplaceOnce(
 			&content,
-			`(function \w+\((\w+)\)\{)(return \w+\(\{name:\w+\.name,description)`,
+			`(function \w+\((\w+)\)\{)(const \w+\=\w\.name;if\("internal")`,
 			`${1}${2}=Spicetify.expFeatureOverride(${2});${3}`)
 		return content
 	})


### PR DESCRIPTION
Resolves #1485 (for real)
Tested and working for both Spotify `1.1.90` and `1.1.91`
![Spotify_YVFlpqsAGv](https://user-images.githubusercontent.com/77577746/184286341-13de4821-3af9-4010-b984-6621cf6ad13f.gif)

<details>
<summary>Technical stuff</summary>

Since `RemoteConfigResolver` is no longer available from `1.1.78`, raw data is fetched from `vendor~xpui` and modified in there instead, using only one method to fetch and override instead of two like before.

Also because there is only one method to fetch these features, there is no effective way to cross-reference and see if old experimental features are still available in newer versions, thus why a `Reset` button is added.

![image](https://user-images.githubusercontent.com/77577746/184286627-ab806fc1-672c-4d62-842c-2e42a2bb2d87.png)

</details>
