### PR TITLE
feat(lyrics-plus): copy lyrics on right-click & stylings

### DIFF
--- a/CustomApps/lyrics-plus/Pages.js
+++ b/CustomApps/lyrics-plus/Pages.js
@@ -166,6 +166,7 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
                     {
                         className,
                         style: {
+                            cursor: "pointer",
                             "--position-index": animationIndex,
                             "--animation-index": (animationIndex < 0 ? 0 : animationIndex) + 1,
                             "--blur-index": Math.abs(animationIndex),
@@ -396,6 +397,9 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
                 "p",
                 {
                     className: "lyrics-lyricsContainer-LyricsLine" + (i <= activeLineIndex ? " lyrics-lyricsContainer-LyricsLine-active" : ""),
+                    style: {
+                        cursor: "pointer",
+                    },
                     dir: "auto",
                     ref: isActive ? activeLineRef : null,
                     onClick: (event) => {

--- a/CustomApps/lyrics-plus/Pages.js
+++ b/CustomApps/lyrics-plus/Pages.js
@@ -9,9 +9,7 @@ const CreditFooter = react.memo(({ provider, copyright }) => {
         react.createElement(
             "p",
             {
-                as: "p",
-                variant: "main-type-mesto",
-                className: "lyrics-lyricsContainer-Provider",
+                className: "lyrics-lyricsContainer-Provider main-type-mesto",
                 dir: "auto",
             },
             credit.join(" • ")
@@ -121,6 +119,26 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
         offset += -(activeLineEle.current.offsetTop + activeLineEle.current.clientHeight / 2);
     }
 
+    const rawLyrics = lyrics
+        .map((line) => {
+            let startTimeString = "";
+
+            if (!isNaN(line.startTime)) {
+                let minutes = Math.trunc(line.startTime / 60000),
+                    seconds = ((line.startTime - minutes * 60000) / 1000).toFixed(2);
+
+                if (minutes < 10) minutes = "0" + minutes;
+                if (seconds < 10) seconds = "0" + seconds;
+
+                startTimeString = `${minutes}:${seconds}`;
+            } else {
+                startTimeString = line.startTime.toString();
+            }
+
+            return `[${startTimeString}] ${line.text}`;
+        })
+        .join("\n");
+
     return react.createElement(
         "div",
         {
@@ -178,6 +196,11 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
                             if (startTime) {
                                 Spicetify.Player.seek(startTime);
                             }
+                        },
+                        onAuxClick: async (event) => {
+                            await Spicetify.Platform.ClipboardAPI.copy(rawLyrics)
+                                .then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
+                                .catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
                         },
                     },
                     !isKara ? text : react.createElement(KaraokeLine, { text, startTime, position, isActive })
@@ -362,6 +385,26 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
         }
     }
 
+    const rawLyrics = lyrics
+        .map((line) => {
+            let startTimeString = "";
+
+            if (!isNaN(line.startTime)) {
+                let minutes = Math.trunc(line.startTime / 60000),
+                    seconds = ((line.startTime - minutes * 60000) / 1000).toFixed(2);
+
+                if (minutes < 10) minutes = "0" + minutes;
+                if (seconds < 10) seconds = "0" + seconds;
+
+                startTimeString = `${minutes}:${seconds}`;
+            } else {
+                startTimeString = line.startTime.toString();
+            }
+
+            return `[${startTimeString}] ${line.text}`;
+        })
+        .join("\n");
+
     useEffect(() => {
         if (activeLineRef.current && (!intialScroll[0] || isInViewport(activeLineRef.current))) {
             activeLineRef.current.scrollIntoView({
@@ -384,6 +427,7 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
             className: "lyrics-lyricsContainer-LyricsUnsyncedPadding",
         }),
         padded.map(({ text, startTime }, i) => {
+            console.log(startTime);
             if (i == 0) {
                 return react.createElement(IdlingIndicator, {
                     isActive: activeLineIndex == 0,
@@ -407,6 +451,11 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
                             Spicetify.Player.seek(startTime);
                         }
                     },
+                    onAuxClick: async (event) => {
+                        await Spicetify.Platform.ClipboardAPI.copy(rawLyrics)
+                            .then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
+                            .catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
+                    },
                 },
                 !isKara ? text : react.createElement(KaraokeLine, { text, startTime, position, isActive })
             );
@@ -423,6 +472,8 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 });
 
 const UnsyncedLyricsPage = react.memo(({ lyrics, provider, copyright }) => {
+    const rawLyrics = lyrics.map((lyrics) => lyrics.text).join("\n");
+
     return react.createElement(
         "div",
         {
@@ -437,6 +488,11 @@ const UnsyncedLyricsPage = react.memo(({ lyrics, provider, copyright }) => {
                 {
                     className: "lyrics-lyricsContainer-LyricsLine lyrics-lyricsContainer-LyricsLine-active",
                     dir: "auto",
+                    onAuxClick: async (event) => {
+                        await Spicetify.Platform.ClipboardAPI.copy(rawLyrics)
+                            .then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
+                            .catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
+                    },
                 },
                 text
             );
@@ -560,8 +616,7 @@ const GeniusPage = react.memo(
                 className: "lyrics-lyricsContainer-UnsyncedLyricsPage",
             },
             react.createElement("p", {
-                variant: "main-type-ballad",
-                className: "lyrics-lyricsContainer-LyricsUnsyncedPadding",
+                className: "lyrics-lyricsContainer-LyricsUnsyncedPadding main-type-ballad",
             }),
             react.createElement("div", { className: shouldSplit ? "split" : "" }, mainContainer),
             react.createElement(CreditFooter, {

--- a/CustomApps/lyrics-plus/Pages.js
+++ b/CustomApps/lyrics-plus/Pages.js
@@ -427,7 +427,6 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
             className: "lyrics-lyricsContainer-LyricsUnsyncedPadding",
         }),
         padded.map(({ text, startTime }, i) => {
-            console.log(startTime);
             if (i == 0) {
                 return react.createElement(IdlingIndicator, {
                     isActive: activeLineIndex == 0,

--- a/CustomApps/lyrics-plus/Pages.js
+++ b/CustomApps/lyrics-plus/Pages.js
@@ -121,6 +121,7 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
 
     const rawLyrics = lyrics
         .map((line) => {
+            if (!line.startTime) return line.text;
             let startTimeString = "";
 
             if (!isNaN(line.startTime)) {
@@ -387,6 +388,7 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 
     const rawLyrics = lyrics
         .map((line) => {
+            if (!line.startTime) return line.text;
             let startTimeString = "";
 
             if (!isNaN(line.startTime)) {

--- a/CustomApps/lyrics-plus/style.css
+++ b/CustomApps/lyrics-plus/style.css
@@ -128,7 +128,6 @@
 }
 
 .lyrics-lyricsContainer-SyncedLyrics .lyrics-lyricsContainer-LyricsLine {
-    cursor: pointer;
     transform: translateY(calc(var(--position-index) * var(--lyrics-line-height) + var(--offset)));
     transform-origin: var(--lyrics-align-text);
     transition-timing-function: cubic-bezier(0, 0, 0.58, 1);
@@ -153,8 +152,16 @@
     color: var(--lyrics-color-active);
 }
 
+.lyrics-lyricsContainer-UnsyncedLyricsPage .lyrics-lyricsContainer-LyricsLine:hover {
+    color: var(--lyrics-color-active);
+}
+
 .lyrics-lyricsContainer-SyncedLyrics .lyrics-lyricsContainer-LyricsLine {
     color: var(--lyrics-color-inactive);
+}
+
+.lyrics-lyricsContainer-SyncedLyrics .lyrics-lyricsContainer-LyricsLine:hover {
+    color: var(--lyrics-color-active);
 }
 
 .lyrics-lyricsContainer-SyncedLyrics .lyrics-lyricsContainer-LyricsLine.lyrics-lyricsContainer-LyricsLine-active {


### PR DESCRIPTION
- Resolves #1868 (in a different way than suggested)
![Spotify_O8mECE4Xa2](https://user-images.githubusercontent.com/77577746/184540008-e625aca8-98f7-422d-9c37-70b647cfd94e.gif)
Saves lyrics upon right-click in a `.lrc` text format

- Hover stuff
![image](https://user-images.githubusercontent.com/77577746/184380880-43de780e-a397-4766-8813-aafb9d1fc951.png)

