### PR TITLE
feat(expFeatures): update new features upon mismatch

### DIFF
--- a/jsHelper/expFeatures.js
+++ b/jsHelper/expFeatures.js
@@ -23,14 +23,16 @@
         if (!overrideList.version) overrideList.version = SpotifyVersion;
 
         if (overrideList.version !== SpotifyVersion) {
-            const notice = document.createElement("p");
-            notice.style.cssText = "font-weight: bold;";
-            notice.textContent = "Spotify version mismatch. Reload Spotify to apply new changes.";
-            content.insertBefore(notice, content.firstChild);
+            if (!content.querySelector("p.notice")) {
+                const notice = document.createElement("p");
+                notice.className = "notice";
+                notice.style.cssText = "font-weight: bold;";
+                notice.textContent = "Spotify version mismatch. Reload Spotify to apply new changes.";
+                content.insertBefore(notice, content.firstChild);
+            }
 
             newFeatures.push(feature.name);
             localStorage.setItem("spicetify-exp-features:update", JSON.stringify(newFeatures));
-            overrideList.version = SpotifyVersion;
         }
 
         if (typeof feature.default === "boolean") {
@@ -171,15 +173,14 @@ button.reset:hover {
             setTimeout(waitForRemoteConfigResolver, 500);
             return;
         } */
-
+        const listLength = Object.keys(overrideList).length - 1;
         Object.keys(overrideList).forEach((key, index) => {
             if (newFeatures.length > 0 && !newFeatures.includes(key) && key !== "version") {
-                console.log(key);
                 delete overrideList[key];
-                overrideList.version = SpotifyVersion;
+                console.log(`Removed ${key} from override list`);
                 localStorage.setItem("spicetify-exp-features", JSON.stringify(overrideList));
             }
-            if (index === Object.keys(overrideList).length - 1) {
+            if (index === listLength) {
                 newFeatures = [];
                 localStorage.removeItem("spicetify-exp-features:update");
             }
@@ -224,6 +225,10 @@ button.reset:hover {
                 setTimeout(showOptions, 500);
                 return;
             }
+
+            overrideList.version = SpotifyVersion;
+            localStorage.setItem("spicetify-exp-features", JSON.stringify(overrideList));
+
             Object.keys(overrideList).forEach((name) => {
                 const feature = overrideList[name];
                 content.querySelector("p.placeholder")?.remove();

--- a/jsHelper/expFeatures.js
+++ b/jsHelper/expFeatures.js
@@ -28,6 +28,7 @@
             notice.textContent = "Spotify version mismatch. Reload Spotify to apply new changes.";
             content.insertBefore(notice, content.firstChild);
 
+            newFeatures.push(feature.name);
             localStorage.setItem("spicetify-exp-features:update", JSON.stringify(newFeatures));
             overrideList.version = SpotifyVersion;
         }

--- a/jsHelper/expFeatures.js
+++ b/jsHelper/expFeatures.js
@@ -75,56 +75,13 @@ button.switch[disabled] {
     color: rgba(var(--spice-rgb-text), .3);
 }
 button.reset {
-    box-sizing: border-box;
-    font-family:
-      var(--font-family, spotify-circular),
-      Helvetica,
-      Arial,
-      sans-serif;
-    -webkit-tap-highlight-color: transparent;
-    font-size: 1rem;
-    line-height: 1.5rem;
     font-weight: 700;
-    background-color: transparent;
-    border: 0px;
-    border-radius: 500px;
-    display: inline-block;
-    position: relative;
-    text-align: center;
-    text-decoration: none;
-    text-transform: none;
-    touch-action: manipulation;
-    transition-duration: 33ms;
-    transition-property:
-      background-color,
-      border-color,
-      color,
-      box-shadow,
-      filter,
-      transform;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    user-select: none;
-    vertical-align: middle;
-    transform: translate3d(0px, 0px, 0px);
-    padding: 0px;
-    min-inline-size: 0px;
-    align-self: center;
-    position: relative;
     background-color: var(--spice-text);
     color: var(--spice-main);
     border-radius: 500px;
     font-size: inherit;
     padding-block: 12px;
     padding-inline: 32px;
-}
-@media screen and (min-width: 768px) {
-    .button.reset {
-      font-size: 1rem;
-      line-height: 1.5rem;
-      text-transform: none;
-      letter-spacing: normal;
-    }
 }
 button.reset:hover {
     transform: scale(1.04);


### PR DESCRIPTION
~~Everything is done, for real this time~~
Resolves several inconveniences mentioned in #1865 such as:
~~- Feature list will now automatically updates upon Spotify version mismatch (the `Reset` button stays tho, just in case)
Will now have a notice on the top that tells users to reload for the new changes to apply.~~
Apparently I don't even need this anymore, it just purge the old ones now.

![image](https://user-images.githubusercontent.com/77577746/184391555-c3ab6307-706b-43f2-b19e-5156b894e365.png)

- List will not be shown if hooks are not patched/hasn't loaded yet, which will remove the need for the placeholder text I added before (again, it will stay in case it *does* break again, at least we will know what broke it)
https://github.com/spicetify/spicetify-cli/blob/cf1598dd66d3a27875e01c67369f742d291bc8d3/jsHelper/expFeatures.js#L189