### PR TITLE
fix(preprocess): patch correct component for `MenuItem`

### DIFF
--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -12,17 +12,13 @@ const OptionsMenuItemIcon = react.createElement(
 );
 
 const OptionsMenuItem = react.memo(({ onSelect, value, isSelected }) => {
-    let className = "lyrics-plus-sort-option";
-    if (isSelected) className += " is-selected";
-
     return react.createElement(
-        "li",
+        Spicetify.ReactComponent.MenuItem,
         {
-            className,
             onClick: onSelect,
+            icon: isSelected ? OptionsMenuItemIcon : null,
         },
-        value,
-        isSelected ? OptionsMenuItemIcon : null
+        value
     );
 });
 

--- a/CustomApps/lyrics-plus/style.css
+++ b/CustomApps/lyrics-plus/style.css
@@ -605,20 +605,3 @@ button.switch.small {
 .lyrics-lyricsContainer-UnsyncedLyricsPage .split > div {
     flex: 50%;
 }
-
-.lyrics-plus-sort-option {
-    box-sizing: border-box;
-    color: rgba(var(--spice-rgb-text), 0.7);
-    cursor: pointer;
-    display: block;
-    padding: 8px 10px;
-}
-.lyrics-plus-option.is-selected {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-.lyrics-plus-sort-option:hover {
-    background-color: rgba(var(--spice-rgb-selected-row), 0.1);
-    color: var(--spice-text);
-}

--- a/CustomApps/reddit/OptionsMenu.js
+++ b/CustomApps/reddit/OptionsMenu.js
@@ -12,17 +12,13 @@ const OptionsMenuItemIcon = react.createElement(
 );
 
 const OptionsMenuItem = react.memo(({ onSelect, value, isSelected }) => {
-    let className = "reddit-sort-option";
-    if (isSelected) className += " is-selected";
-
     return react.createElement(
-        "li",
+        Spicetify.ReactComponent.MenuItem,
         {
-            className,
             onClick: onSelect,
+            icon: isSelected ? OptionsMenuItemIcon : null,
         },
-        value,
-        isSelected ? OptionsMenuItemIcon : null
+        value
     );
 });
 

--- a/CustomApps/reddit/style.css
+++ b/CustomApps/reddit/style.css
@@ -150,20 +150,3 @@ div.reddit-tabBar-headerItemLink {
 .reddit-longDescription {
     display: flex;
 }
-
-.reddit-sort-option {
-    box-sizing: border-box;
-    color: rgba(var(--spice-rgb-text), 0.7);
-    cursor: pointer;
-    display: block;
-    padding: 8px 10px;
-}
-.reddit-sort-option.is-selected {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-.reddit-sort-option:hover {
-    background-color: rgba(var(--spice-rgb-selected-row), 0.1);
-    color: var(--spice-text);
-}

--- a/css-map.json
+++ b/css-map.json
@@ -1843,5 +1843,6 @@
     "uAJxc_psYWeimY8N9bH9": "x-filterBox-overlay",
     "CIVozJ8XNPJ60uMN23Yg": "x-filterBox-searchIcon",
     "_bjbHn5TABOW2s5LsEGX": "x-filterBox-searchIconContainer",
-    "w6j_vX6SF5IxSXrrkYw5": "x-sortBox-sortDropdown"
+    "w6j_vX6SF5IxSXrrkYw5": "x-sortBox-sortDropdown",
+    "PDPsYDh4ntfQE3B4duUI": "main-contextMenu-menuItemText"
 }

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -341,7 +341,7 @@ Spicetify.React.useEffect(() => {
 	// React Component: Context Menu - Menu Item
 	utils.Replace(
 		&input,
-		`=(?:\w+=>|function)(?:\{let|\(\w+\)\{var \w+,\w+=\w+.children,\w+=\w+.icon)(?:\{children:\w+,icon:\w+)?`,
+		`\=\(\{children:\w+\,icon:\w+,disabled:\w+`,
 		`=Spicetify.ReactComponent.MenuItem${0}`)
 
 	// React Component: Album Context Menu items


### PR DESCRIPTION
Apparently `MenuItem` was not hard-locked, just that it was hooked to the wrong component.
This should return its original functionality for extensions and custom apps' usage (tested with previous commit of Reddit and Lyrics Plus)
Works on as far back as `1.1.88` (haven't tested below)
![image](https://user-images.githubusercontent.com/77577746/184605149-34836630-1867-4e8d-9c09-25c319f0dd0a.png)
![image](https://user-images.githubusercontent.com/77577746/184605159-597743c9-a43c-4b45-8d89-15ab13517fd3.png)

Also revert custom `MenuItem` commit for both of them and use Spotify's component.