### PR TITLE
fix(shuffle+): fail to put track to queue

### DIFF
--- a/Extensions/shuffle+.js
+++ b/Extensions/shuffle+.js
@@ -297,7 +297,7 @@
      * Replace queue and play first track immediately.
      * @param {string[]} list
      */
-    async function playList(list, context) {
+    async function playList(list, context = null) {
         if (list[0] === "playedstation") {
             return;
         }
@@ -310,7 +310,7 @@
         }
         list.push("spotify:delimiter");
 
-        Spicetify.Platform.PlayerAPI.clearQueue();
+        await Spicetify.Platform.PlayerAPI.clearQueue();
 
         const isQueue = !context;
 


### PR DESCRIPTION
Resolves #1871 
Conflict caused because `.clearQueue()` is an asynchronous method.
![image](https://user-images.githubusercontent.com/77577746/184639699-174df014-c76c-4777-aeaa-8fcc848ad26b.png)
