### PR TITLE
fix(preprocess): special `ReactDOM` case

### DIFF
--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -416,10 +416,19 @@ if (${1}.popper?.firstChild?.id === "context-menu") {
 	}
 };0`)
 
-	utils.ReplaceOnce(
-		&input,
-		`((\w+)\.createPortal=\w+,)`,
-		`${1}Spicetify.ReactDOM=${2},`)
+	// ReactDOM fallback if string doesn't match
+	match, _ := regexp.MatchString(`((\w+)\.createPortal=\w+,)`, input)
+	if match {
+		utils.ReplaceOnce(
+			&input,
+			`((\w+)\.createPortal=\w+,)`,
+			`${1}Spicetify.ReactDOM=${2},`)
+	} else {
+		utils.ReplaceOnce(
+			&input,
+			`(\w+)=(\{createPortal)`,
+			`${1}=Spicetify.ReactDOM=${2}`)
+	}
 
 	utils.ReplaceOnce(
 		&input,


### PR DESCRIPTION
Apparently there is a special ReactDOM structure used within Spotify that doesn't match RegExp, where `createPortal` is not assigned through conventional means.
Fix aims to use this as a fallback if the original RegExp doesn't match.
[Conversation proving the changes working, along with screenshots of the new section added](https://discord.com/channels/842219447716151306/842818627164962828/1009666775459299338)

![image](https://user-images.githubusercontent.com/77577746/185292237-cd9b1555-5e3d-45cf-bfbd-68b55fe636a1.png)