### PR TITLE
fix(config): check AppX path before apply to `config-xpui`

### DIFF
--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -189,7 +189,8 @@ func FindPrefFilePath() string {
 		path := winPrefs()
 		if len(path) == 0 && len(winXApp()) != 0 {
 			path = winXPrefs()
-		} else if len(path) == 0 {
+		}
+		if len(path) == 0 {
 			PrintError("No valid path options found, ensure you have Spotify installed and have ran it for at least 30 seconds.")
 		}
 		return path

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -246,13 +246,16 @@ func winXPrefs() string {
 
 	stdOut, err := cmd.CombinedOutput()
 	if err == nil {
-		return filepath.Join(
+		path := filepath.Join(
 			os.Getenv("LOCALAPPDATA"),
 			"Packages",
 			strings.TrimSpace(string(stdOut)),
 			"LocalState",
 			"Spotify",
 			"prefs")
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
 	}
 
 	return ""


### PR DESCRIPTION
Check AppX path before applying to `config-xpui` to prevent cases like #1810 (way too often) and allow for a second `prefs_path` check in subsequent launches instead of throwing path errors.
Should display a more descriptive error also.
https://github.com/spicetify/spicetify-cli/blob/aacda02ad322adc1d6ac69eb35e715f844c01bdd/src/utils/config.go#L193