### PR TITLE
fix(preprocess): menu hooks

### DIFF
--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -347,25 +347,25 @@ Spicetify.React.useEffect(() => {
 	// React Component: Album Context Menu items
 	utils.Replace(
 		&input,
-		`(const \w+)(=\w+\(\)\.memo\(\(\(\{uri:\w+,sharingInfo:\w+,onRemoveCallback:\w+\}\)=>\w+\(\)\.createElement\([\w\.]+,\{value:"album"\})`,
+		`(const \w+)(=\w+\.memo\(\(function\(\{uri:\w+,sharingInfo:\w+,onRemoveCallback:\w+\}\)\{(?:const\{spec:\w+\}=\(0,[\w\.]+\)\(\w+\);)?return \w+\.createElement\([\w\.]+,\{value:"album"\})`,
 		`${1}=Spicetify.ReactComponent.AlbumMenu${2}`)
 
 	// React Component: Show Context Menu items
 	utils.Replace(
 		&input,
-		`(const \w+)(=\w+\(\)\.memo\(\(\(\{uri:\w+,sharingInfo:\w+,onRemoveCallback:\w+\}\)=>\w+\(\)\.createElement\([\w\.]+,\{value:"show"\})`,
+		`(const \w+)(=\w+\.memo\(\(function\(\{uri:\w+,sharingInfo:\w+\}\)\{(?:const\{spec:\w+\}=[\(\)\w0-9,.]+;)?return \w+\.createElement\([\w\.]+,\{value:"show"\})`,
 		`${1}=Spicetify.ReactComponent.PodcastShowMenu${2}`)
 
 	// React Component: Artist Context Menu items
 	utils.Replace(
 		&input,
-		`(const \w+)(=\w+\(\)\.memo\(\(\(\{uri:\w+,sharingInfo:\w+,onRemoveCallback:\w+\}\)=>\w+\(\)\.createElement\([\w\.]+,\{value:"artist"\})`,
+		`(const \w+)(=\w+\.memo\(\(function\(\{uri:\w+,sharingInfo:\w+,onRemoveCallback:\w+\}\)\{(?:const\{spec:\w+\}=\(0,[\w\.]+\)\(\w+\);)?return \w+\.createElement\([\w\.]+,\{value:"artist"\})`,
 		`${1}=Spicetify.ReactComponent.ArtistMenu${2}`)
 
 	// React Component: Playlist Context Menu items
 	utils.Replace(
 		&input,
-		`(const \w+)(=\w+\(\)\.memo\(\(\(\{uri:\w+,onRemoveCallback:\w+\}\))`,
+		`(const \w+)(=\w+\.memo\(\(function\(\{uri:\w+,onRemoveCallback:\w+,isEnhanced:\w+\}\))`,
 		`${1}=Spicetify.ReactComponent.PlaylistMenu${2}`)
 
 	// Locale

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -347,7 +347,7 @@ Spicetify.React.useEffect(() => {
 	// React Component: Album Context Menu items
 	utils.Replace(
 		&input,
-		`(const \w+)(=\w+\.memo\(\(function\(\{uri:\w+,sharingInfo:\w+,onRemoveCallback:\w+\}\)\{(?:const\{spec:\w+\}=\(0,[\w\.]+\)\(\w+\);)?return \w+\.createElement\([\w\.]+,\{value:"album"\})`,
+		`(const \w+)(=\w+\.memo\(\(function\(\{uri:\w+,sharingInfo:\w+,onRemoveCallback:\w+\}\)\{(?:const\{spec:\w+\}=[\(\)\w0-9,.]+;)?return \w+\.createElement\([\w\.]+,\{value:"album"\})`,
 		`${1}=Spicetify.ReactComponent.AlbumMenu${2}`)
 
 	// React Component: Show Context Menu items
@@ -359,7 +359,7 @@ Spicetify.React.useEffect(() => {
 	// React Component: Artist Context Menu items
 	utils.Replace(
 		&input,
-		`(const \w+)(=\w+\.memo\(\(function\(\{uri:\w+,sharingInfo:\w+,onRemoveCallback:\w+\}\)\{(?:const\{spec:\w+\}=\(0,[\w\.]+\)\(\w+\);)?return \w+\.createElement\([\w\.]+,\{value:"artist"\})`,
+		`(const \w+)(=\w+\.memo\(\(function\(\{uri:\w+,sharingInfo:\w+,onRemoveCallback:\w+\}\)\{(?:const\{spec:\w+\}=[\(\)\w0-9,.]+;)?return \w+\.createElement\([\w\.]+,\{value:"artist"\})`,
 		`${1}=Spicetify.ReactComponent.ArtistMenu${2}`)
 
 	// React Component: Playlist Context Menu items

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -341,31 +341,31 @@ Spicetify.React.useEffect(() => {
 	// React Component: Context Menu - Menu Item
 	utils.Replace(
 		&input,
-		`\=\(\{children:\w+\,icon:\w+,disabled:\w+`,
+		`=(?:function\(\w+\)|\(|[\w\=\>]*)?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:children|icon|disabled)[:\w]*,){3,}`,
 		`=Spicetify.ReactComponent.MenuItem${0}`)
 
 	// React Component: Album Context Menu items
 	utils.Replace(
 		&input,
-		`(const \w+)(=\w+\.memo\(\(function\(\{uri:\w+,sharingInfo:\w+,onRemoveCallback:\w+\}\)\{(?:const\{spec:\w+\}=[\(\)\w0-9,.]+;)?return \w+\.createElement\([\w\.]+,\{value:"album"\})`,
+		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function\([\{\w\}:,]+\)|\()?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w=\(\).,]*;?(?:return |=>)\w+[\(\)]?\.createElement\([\w\.]+,\{value:"album"\})`,
 		`${1}=Spicetify.ReactComponent.AlbumMenu${2}`)
 
 	// React Component: Show Context Menu items
 	utils.Replace(
 		&input,
-		`(const \w+)(=\w+\.memo\(\(function\(\{uri:\w+,sharingInfo:\w+\}\)\{(?:const\{spec:\w+\}=[\(\)\w0-9,.]+;)?return \w+\.createElement\([\w\.]+,\{value:"show"\})`,
+		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function\([\{\w\}:,]+\)|\()?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w=\(\).,]*;?(?:return |=>)\w+[\(\)]?\.createElement\([\w\.]+,\{value:"show"\})`,
 		`${1}=Spicetify.ReactComponent.PodcastShowMenu${2}`)
 
 	// React Component: Artist Context Menu items
 	utils.Replace(
 		&input,
-		`(const \w+)(=\w+\.memo\(\(function\(\{uri:\w+,sharingInfo:\w+,onRemoveCallback:\w+\}\)\{(?:const\{spec:\w+\}=[\(\)\w0-9,.]+;)?return \w+\.createElement\([\w\.]+,\{value:"artist"\})`,
+		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function\([\{\w\}:,]+\)|\()?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w=\(\).,]*;?(?:return |=>)\w+[\(\)]?\.createElement\([\w\.]+,\{value:"artist"\})`,
 		`${1}=Spicetify.ReactComponent.ArtistMenu${2}`)
 
 	// React Component: Playlist Context Menu items
 	utils.Replace(
 		&input,
-		`(const \w+)(=\w+\.memo\(\(function\(\{uri:\w+,onRemoveCallback:\w+,isEnhanced:\w+\}\))`,
+		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function\([\{\w\}:,]+\)|\()?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:uri|isEnhanced|onRemoveCallback)[:\w]*,?){3,})`,
 		`${1}=Spicetify.ReactComponent.PlaylistMenu${2}`)
 
 	// Locale


### PR DESCRIPTION
~~I'm not sure if anybody uses this, but since it was a function it's better to restore it ig~~
Fixes right-clicking cards in `new-releases` and `reddit`
https://github.com/spicetify/spicetify-cli/blob/253da830d365760a59a5e3c9ad7e8f9a196d2460/CustomApps/reddit/Card.js#L9-L25

![image](https://user-images.githubusercontent.com/77577746/186431213-e0b7cc45-8190-4995-8f9f-1cf7e09ab4e2.png)
Works on as far back as `1.1.90` (haven't tested below)