### PR TITLE
fix(wrapper): `Queue` binds

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -214,11 +214,11 @@ const Spicetify = {
         Spicetify.Player.dispatchEvent(event);
     }, 100);
 
-    Spicetify.addToQueue = async (uri) => {
-        await Spicetify.Player.origin._queue.addToQueue(uri);
+    Spicetify.addToQueue = (uri) => {
+        return Spicetify.Player.origin._queue.addToQueue(uri);
     };
     Spicetify.removeFromQueue = async (uri) => {
-        await Spicetify.Player.origin._queue.removeFromQueue(uri);
+        return Spicetify.Player.origin._queue.removeFromQueue(uri);
     };
 })();
 

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -217,7 +217,7 @@ const Spicetify = {
     Spicetify.addToQueue = (uri) => {
         return Spicetify.Player.origin._queue.addToQueue(uri);
     };
-    Spicetify.removeFromQueue = async (uri) => {
+    Spicetify.removeFromQueue = (uri) => {
         return Spicetify.Player.origin._queue.removeFromQueue(uri);
     };
 })();

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -214,8 +214,12 @@ const Spicetify = {
         Spicetify.Player.dispatchEvent(event);
     }, 100);
 
-    Spicetify.addToQueue = Spicetify.Player.origin._queue.addToQueue;
-    Spicetify.removeFromQueue = Spicetify.Player.origin._queue.removeFromQueue;
+    Spicetify.addToQueue = async (uri) => {
+        await Spicetify.Player.origin._queue.addToQueue(uri);
+    };
+    Spicetify.removeFromQueue = async (uri) => {
+        await Spicetify.Player.origin._queue.removeFromQueue(uri);
+    };
 })();
 
 Spicetify.getAudioData = async (uri) => {


### PR DESCRIPTION
Resolves #1891 
Spotify doesn't bind their function to `_queue` so it will break when reassigned to another property/object
![image](https://user-images.githubusercontent.com/77577746/186797675-2c4e8b92-faf2-46f4-a795-17a5e3d13e26.png)
