### PR TITLE
fix(preprocess): update `disableSentry` hook

### DIFF
--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -231,7 +231,7 @@ func colorVariableReplaceForJS(content string) string {
 }
 
 func disableSentry(input string) string {
-	utils.Replace(&input, `prototype\.bindClient=function\(\w+\)\{`, "${0}return;")
+	utils.Replace(&input, `bindClient\(\w+\)\{`, "${0}return;")
 	return input
 }
 

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -231,7 +231,7 @@ func colorVariableReplaceForJS(content string) string {
 }
 
 func disableSentry(input string) string {
-	utils.Replace(&input, `bindClient\(\w+\)\{`, "${0}return;")
+	utils.Replace(&input, `(?:prototype\.)?bindClient(?:=function)?\(\w+\)\{`, "${0}return;")
 	return input
 }
 


### PR DESCRIPTION
Should be working again. Network tab no longer reports Sentry requests.
![image](https://user-images.githubusercontent.com/77577746/187429850-e2b414cc-6bba-48bd-803d-b1ddbab4386d.png)
