### PR TITLE
feat: general QoL changes

### DIFF
--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -12,6 +12,8 @@ import (
 
 // Flag enables/disables additional feature
 type Flag struct {
+	CurrentTheme  string
+	ColorScheme   string
 	Extension     []string
 	CustomApp     []string
 	SidebarConfig bool
@@ -104,7 +106,24 @@ func htmlMod(htmlPath string, flags Flag) {
 	}
 
 	if flags.SpicetifyVer != "" {
-		helperHTML += `<script>Spicetify.version="` + flags.SpicetifyVer + `";</script>` + "\n"
+		var extList string
+		for _, ext := range flags.Extension {
+			extList += `"` + ext +`",`
+		}
+
+		var customAppList string
+		for _, app := range flags.CustomApp {
+			customAppList += `"` + app +`",`
+		}
+
+		helperHTML += `<script>
+			Spicetify.Config={};
+			Spicetify.Config["version"]="` + flags.SpicetifyVer + `";
+			Spicetify.Config["current_theme"]="` + flags.CurrentTheme + `";
+			Spicetify.Config["color_scheme"]="` + flags.ColorScheme + `";
+			Spicetify.Config["extensions"] = [` + extList + `];
+			Spicetify.Config["custom_apps"] = [` + customAppList + `];
+			</script>` + "\n"
 	}
 
 	for _, v := range flags.Extension {

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -108,12 +108,12 @@ func htmlMod(htmlPath string, flags Flag) {
 	if flags.SpicetifyVer != "" {
 		var extList string
 		for _, ext := range flags.Extension {
-			extList += `"` + ext +`",`
+			extList += `"` + ext + `",`
 		}
 
 		var customAppList string
 		for _, app := range flags.CustomApp {
-			customAppList += `"` + app +`",`
+			customAppList += `"` + app + `",`
 		}
 
 		helperHTML += `<script>

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -71,6 +71,8 @@ func Apply(spicetifyVersion string) {
 
 	utils.PrintBold(`Applying additional modifications:`)
 	apply.AdditionalOptions(appDestPath, apply.Flag{
+		CurrentTheme:  settingSection.Key("current_theme").MustString(""),
+		ColorScheme:   settingSection.Key("color_scheme").MustString(""),
 		Extension:     extensionList,
 		CustomApp:     customAppsList,
 		SidebarConfig: featureSection.Key("sidebar_config").MustBool(false),

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -50,7 +50,7 @@ func DisplayAllConfig() {
 	}
 
 	log.Println()
-	utils.PrintBold("AdditionFeatures")
+	utils.PrintBold("AdditionalFeatures")
 	for _, key := range featureSection.Keys() {
 		name := key.Name()
 		if name == "extensions" || name == "custom_apps" || name == "spotify_launch_flags" {
@@ -59,14 +59,18 @@ func DisplayAllConfig() {
 			if listLen == 0 {
 				log.Println(name)
 			} else {
-				log.Println(name + strings.Repeat(" ", maxLen-len(name)) + list[0])
-				for _, ext := range list[1:] {
-					log.Println(strings.Repeat(" ", maxLen) + ext)
-				}
+				log.Println(name + strings.Repeat(" ", maxLen-len(name)) + strings.Join(list, " | "))
 			}
 		} else {
 			log.Println(name + strings.Repeat(" ", maxLen-len(name)) + key.Value())
 		}
+	}
+
+	log.Println()
+	utils.PrintBold("Backup")
+	for _, key := range backupSection.Keys() {
+		name := key.Name()
+		log.Println(name + strings.Repeat(" ", maxLen-len(name)) + key.Value())
 	}
 }
 

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -199,7 +199,11 @@ func colorVariableReplace(content string) string {
 
 	utils.Replace(&content, "#1db954", "var(--spice-button)")
 	utils.Replace(&content, "#1877f2", "var(--spice-button)")
+
 	utils.Replace(&content, "#1ed760", "var(--spice-button-active)")
+	utils.Replace(&content, "#1fdf64", "var(--spice-button-active)")
+	utils.Replace(&content, "#169c46", "var(--spice-button-active)")
+
 	utils.Replace(&content, "#535353", "var(--spice-button-disabled)")
 
 	utils.Replace(&content, "#333", "var(--spice-tab-active)")


### PR DESCRIPTION
- Extension/Custom Apps developers now have an easier way to check for dependencies and ensure that their script is working with the intended bundle by porting some of the `config-xpui` values to `Spicetify.Config` (Resolves #1920)
![image](https://user-images.githubusercontent.com/77577746/189157506-0f57e8ff-0190-4842-9a0c-f7605ebb3519.png)

- `spicetify config` now prints out Spicetify/Spotify versions also which helps speed up support process for Helpers, and also improve readability for array-like strings by merging them into one line
![image](https://user-images.githubusercontent.com/77577746/189157959-ab4bb4bd-3b0f-4a92-a051-ca9dd6b7f80e.png)

- New color values for `preprocess` fixing button colors on `active` and `focus`
![image](https://user-images.githubusercontent.com/77577746/189158433-5eb314ef-905d-46cb-b789-b998cf369717.png)
