### PR TITLE
feat(wrapper): add function to change key bindings

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -288,7 +288,7 @@ declare namespace Spicetify {
         function del(url: string, body?: Body, headers?: Headers): Promise<Response["body"]>;
         function patch(url: string, body?: Body, headers?: Headers): Promise<Response["body"]>;
         function sub(url: string, callback: ((b: Response["body"]) => void), onError?: ((e: Error) => void), body?: Body, headers?: Headers): Promise<Response["body"]>;
-        function postSub(url: string, body?: Body, callback: ((b: Response["body"]) => void), onError?: ((e: Error) => void)): Promise<Response["body"]>;
+        function postSub(url: string, body: Body | null, callback: ((b: Response["body"]) => void), onError?: ((e: Error) => void)): Promise<Response["body"]>;
         function request(method: Method, url: string, body?: Body, headers?: Headers): Promise<Response>;
         function resolve(method: Method, url: string, body?: Body, headers?: Headers): Promise<Response>;
     }

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1340,7 +1340,7 @@ declare namespace Spicetify {
      */
     namespace Topbar {
         class Button {
-            constructor(label: string, icon: string, onClick: (self: Button) => void, disabled: boolean);
+            constructor(label: string, icon: string, onClick: (self: Button) => void, disabled?: boolean);
             label: string;
             icon: string;
             onClick: (self: Button) => void;

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -10,7 +10,7 @@ declare namespace Spicetify {
         blocked?: string[];
         provider?: string;
     };
-    interface ContextOption {
+    type ContextOption = {
         contextURI?: string;
         index?: number;
         trackUri?: string;
@@ -183,7 +183,7 @@ declare namespace Spicetify {
          * @param context
          * @param options
          */
-        async function playUri(uri: string, context: any = {}, options: Options = {});
+        function playUri(uri: string, context: any, options: any): Promise<void>;
         /**
          * Unregister added event listener `type`.
          * @param type
@@ -278,17 +278,17 @@ declare namespace Spicetify {
             headers: Headers;
             status: number;
             uri: string;
-            static isSuccessStatus(status: number): boolean;
+            isSuccessStatus(status: number): boolean;
         }
 
         function head(url: string, headers?: Headers): Promise<Headers>;
-        function get(url: string, body?: Body, headers?: Headers): Promise<Response.body>;
-        function post(url: string, body?: Body, headers?: Headers): Promise<Response.body>;
-        function put(url: string, body?: Body, headers?: Headers): Promise<Response.body>;
-        function del(url: string, body?: Body, headers?: Headers): Promise<Response.body>;
-        function patch(url: string, body?: Body, headers?: Headers): Promise<Response.body>;
-        function sub(url: string, callback: ((b: Response.body) => void), onError?: ((e: Error) => void), body?: Body, headers?: Headers): Promise<Response.body>;
-        function postSub(url: string, body?: Body, callback: ((b: Response.body) => void), onError?: ((e: Error) => void)): Promise<Response.body>;
+        function get(url: string, body?: Body, headers?: Headers): Promise<Response["body"]>;
+        function post(url: string, body?: Body, headers?: Headers): Promise<Response["body"]>;
+        function put(url: string, body?: Body, headers?: Headers): Promise<Response["body"]>;
+        function del(url: string, body?: Body, headers?: Headers): Promise<Response["body"]>;
+        function patch(url: string, body?: Body, headers?: Headers): Promise<Response["body"]>;
+        function sub(url: string, callback: ((b: Response["body"]) => void), onError?: ((e: Error) => void), body?: Body, headers?: Headers): Promise<Response["body"]>;
+        function postSub(url: string, body?: Body, callback: ((b: Response["body"]) => void), onError?: ((e: Error) => void)): Promise<Response["body"]>;
         function request(method: Method, url: string, body?: Body, headers?: Headers): Promise<Response>;
         function resolve(method: Method, url: string, body?: Body, headers?: Headers): Promise<Response>;
     }
@@ -327,12 +327,12 @@ declare namespace Spicetify {
             meta?: boolean;
         };
         const KEYS: Record<ValidKey, string>;
-        function registerShortcut(keys: KeysDefine, callback: (event: KeyboardEvent) => void);
-        function registerIsolatedShortcut(keys: KeysDefine, callback: (event: KeyboardEvent) => void);
-        function registerImportantShortcut(keys: KeysDefine, callback: (event: KeyboardEvent) => void);
-        function _deregisterShortcut(keys: KeysDefine);
-        function deregisterImportantShortcut(keys: KeysDefine);
-        function changeShortcut(keys: KeysDefine, newKeys: KeysDefine);
+        function registerShortcut(keys: KeysDefine, callback: (event: KeyboardEvent) => void): void;
+        function registerIsolatedShortcut(keys: KeysDefine, callback: (event: KeyboardEvent) => void): void;
+        function registerImportantShortcut(keys: KeysDefine, callback: (event: KeyboardEvent) => void): void;
+        function _deregisterShortcut(keys: KeysDefine): void;
+        function deregisterImportantShortcut(keys: KeysDefine): void;
+        function changeShortcut(keys: KeysDefine, newKeys: KeysDefine): void;
     };
 
     /**
@@ -1249,18 +1249,18 @@ declare namespace Spicetify {
             /**
              * The menu UI to render inside of the context menu.
              */
-            menu: Spicetify.ReactComponent.Menu |
-                Spicetify.ReactComponent.AlbumMenu |
-                Spicetify.ReactComponent.PodcastShowMenu |
-                Spicetify.ReactComponent.ArtistMenu |
-                Spicetify.ReactComponent.PlaylistMenu;
+            menu: typeof Spicetify.ReactComponent.Menu |
+                typeof Spicetify.ReactComponent.AlbumMenu |
+                typeof Spicetify.ReactComponent.PodcastShowMenu |
+                typeof Spicetify.ReactComponent.ArtistMenu |
+                typeof Spicetify.ReactComponent.PlaylistMenu;
             /**
              * A child of the context menu. Should be `<button>`, `<a>`,
              * a custom react component that forwards a ref to a `<button>` or `<a>`,
              * or a function. If a function is passed it will be called with
              * (`isOpen`, `handleContextMenu`, `ref`) as arguments.
              */
-            children: ContextMenuChildren;
+            children: Element | ((isOpen?: boolean, handleContextMenu?: (e: MouseEvent) => void, ref?: (e: Element) => void) => Element);
         };
         type MenuProps = {
             /**
@@ -1340,7 +1340,7 @@ declare namespace Spicetify {
      */
     namespace Topbar {
         class Button {
-            constructor(label: string, icon: string, onClick: (self: Button) => void, disabled = false);
+            constructor(label: string, icon: string, onClick: (self: Button) => void, disabled: boolean);
             label: string;
             icon: string;
             onClick: (self: Button) => void;

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -332,6 +332,7 @@ declare namespace Spicetify {
         function registerImportantShortcut(keys: KeysDefine, callback: (event: KeyboardEvent) => void);
         function _deregisterShortcut(keys: KeysDefine);
         function deregisterImportantShortcut(keys: KeysDefine);
+        function changeShortcut(keys: KeysDefine, newKeys: KeysDefine);
     };
 
     /**
@@ -1361,4 +1362,15 @@ declare namespace Spicetify {
      * Can match any of the fonts listed in `Spicetify._fontStyle` or returns a generic style otherwise.
      */
     function getFontStyle(font: string): string;
+
+    /**
+     * A filtered copy of user's `config-xpui` file.
+     */
+    namespace Config {
+        const version: string;
+        const current_theme: string;
+        const color_scheme: string;
+        const extensions: string[];
+        const custom_apps: string[];
+    }
 }

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -416,6 +416,15 @@ Spicetify.getFontStyle = (font) => {
         _deregisterShortcut: (keys) => {
             Spicetify.Mousetrap.unbind(formatKeys(keys));
         },
+        changeShortcut: (keys, newKeys) => {
+            if (!keys || !newKeys) throw "Spicetify.Keyboard.changeShortcut: Invalid keys";
+
+            const callback = Object.keys(Spicetify.Mousetrap.trigger()._directMap).find(key => key.startsWith(formatKeys(keys)));
+            if (!callback) throw "Spicetify.Keyboard.changeShortcut: Shortcut not found";
+
+            Spicetify.Keyboard.registerShortcut(newKeys, Spicetify.Mousetrap.trigger()._directMap[callback]);
+            Spicetify.Keyboard._deregisterShortcut(keys);
+        },
     };
     Spicetify.Keyboard.registerIsolatedShortcut = Spicetify.Keyboard.registerShortcut;
     Spicetify.Keyboard.registerImportantShortcut = Spicetify.Keyboard.registerShortcut;


### PR DESCRIPTION
Some additional toys for devs.
![image](https://user-images.githubusercontent.com/77577746/190849362-49bf12a1-04fb-447b-a2de-c7869071d779.png)
Users and devs can now easily change their keybinds for internal Spotify functions and extensions to their preference without having to modify the extension themselves (not really an option before with default Spotify shortcuts)