### PR TITLE
fix: handling usernames with unicode characters

### DIFF
--- a/spicetify.go
+++ b/spicetify.go
@@ -139,7 +139,11 @@ func main() {
 		return
 
 	case "config-dir":
-		cmd.ShowConfigDirectory()
+		if quiet {
+			log.SetOutput(os.Stderr)
+			os.Stdout = os.Stderr
+		}
+		cmd.ShowConfigDirectory(quiet)
 		return
 
 	case "path":

--- a/src/cmd/config-dir.go
+++ b/src/cmd/config-dir.go
@@ -1,12 +1,18 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spicetify/spicetify-cli/src/utils"
 )
 
 // ShowConfigDirectory shows config directory in user's default file manager application
-func ShowConfigDirectory() {
+func ShowConfigDirectory(quiet bool) {
 	configDir := utils.GetSpicetifyFolder()
+	if quiet {
+		fmt.Println(configDir)
+		return
+	}
 	err := utils.ShowDirectory(configDir)
 	if err != nil {
 		utils.PrintError("Error opening config directory:")


### PR DESCRIPTION
This error is exclusive to Windows user afaik
Because [Powershell has a *very* bad way of printing out Unicode characters and still doesn't have full support for it](https://devblogs.microsoft.com/commandline/windows-command-line-inside-the-windows-console/#handling-unicode), using their internal functions to manipulate strings with those characters will print out gibberish that will throw errors on Marketplace install scripts or anything that relies on `spicetify -c | Split-Path` 
Screenshot is using latest stable version of PS, showing the error still persists to this day
![image](https://user-images.githubusercontent.com/77577746/190896274-e618844a-639e-4eb5-a067-ced6decb4a13.png)

Running the current install script will give out such ([taken by person with the errors themselves](https://discord.com/channels/842219447716151306/1015684719712686150/1015894752517967932)):
![image](https://user-images.githubusercontent.com/77577746/190896466-c377f63d-0291-49df-996f-e177f57fcdbf.png)

This should provide a way to print out config folder path without having to rely on Powershell functions