### PR TITLE
fix(shuffle-plus): display liked songs option on relevant page

### DIFF
--- a/Extensions/shuffle+.js
+++ b/Extensions/shuffle+.js
@@ -68,7 +68,7 @@ async function initShufflePlus() {
                 }
                 .popup-row .div-title {
                     color: var(--spice-text);
-                }                
+                }
                 .popup-row .divider {
                     height: 2px;
                     border-width: 0;
@@ -224,9 +224,11 @@ async function initShufflePlus() {
 
     function shouldAddShufflePlusLiked(uri) {
         let uriObj = Spicetify.URI.fromString(uri[0]);
-        switch (uriObj.type) {
-            case Type.TRACK:
-                return true;
+        if (Spicetify.Platform.History.location.pathname === "/collection/tracks") {
+            switch (uriObj.type) {
+                case Type.TRACK:
+                    return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
Some users find it annoying that the option displays at all times and imo rightfully so when they don't have the intention of using the option on anywhere else other than `Liked Songs` page.
![Spotify_V4BJCa0L8y](https://user-images.githubusercontent.com/77577746/191000818-6940af0f-d937-4c97-ac24-dad96456e5ae.gif)
