### PR TITLE
fix(css-map): update new layout classes

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1888,5 +1888,16 @@
     "W_EplVEAbZrZURqfLiQC": "lyrics-lyricsContent-provider",
     "E64X_eoy6xsJmDdKKHja": "lyrics-lyricsContent-unsynced",
     "iq4cgi0YEKr6DGaTtzUj": "lyrics-lyricsContent-description",
-    "gvcgOXnAiNKEe_z92_lw": "x-settings-restartAppButton"
+    "gvcgOXnAiNKEe_z92_lw": "x-settings-restartAppButton",
+    "eBrbJuUWgMoCkOgWs5uw": "main-topBar-topBarContainer",
+    "fWwn9sakqBBjgiNti7LD": "main-topBar-historyButtons",
+    "J6VTd7VdGN2PM_oXCAyH": "main-topBar-button",
+    "ixoXjnviB4U2pl1ll8Wh": "main-topBar-forward",
+    "ou0osOf3R1ZRWQ1xzFd9": "main-topBar-icon",
+    "btOYheZlYlaVEyO9iEBk": "main-topBar-sectionWrapper",
+    "cqO5c3gPyN6tXIddpWfr": "main-topBar-left",
+    "d67gRLGIEn9nZFCTcaTc": "main-topBar-center",
+    "fl1Ov5aB9YCKnMkJYpEu": "main-topBar-right",
+    "g3Xinb8x23n81ejvS9Uj": "main-topBar-searchBar",
+    "t2K4_iLmAyDtH7mcT5Wy": "x-searchInput-searchInputIconContainer"
 }


### PR DESCRIPTION
- Most are new classes never seen before in accordance with the new UI changes.
- `main-topBar-container` is now changed to `main-topBar-contentContainer` due to conflicting CSS rules in xpui between both new and legacy topBar.
- `collection-searchBar-searchBar` is now changed to `main-topBar-searchBar` due to the search bar is now a permanent part of `topBar` and has (somewhat) different styling.

Should fix problems with `Spicetify.Topbar` also with these mappings:
![image](https://user-images.githubusercontent.com/77577746/191730917-fcee4786-0bd6-437b-a531-41fa1949864c.png)
