### PR TITLE
fix: compatibility with `1.1.95`

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -109,7 +109,7 @@ const Spicetify = {
             "Platform",
             "getFontStyle",
             "_fontStyle",
-            "version"
+            "Config"
         ];
 
         const PLAYER_METHOD = [

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -109,7 +109,8 @@ const Spicetify = {
             "Platform",
             "getFontStyle",
             "_fontStyle",
-            "Config"
+            "Config",
+            "expFeatureOverride"
         ];
 
         const PLAYER_METHOD = [

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -207,7 +207,7 @@ func getColorCSS(scheme map[string]string) string {
 func insertCustomApp(jsPath string, flags Flag) {
 	utils.ModifyFile(jsPath, func(content string) string {
 		const REACT_REGEX = `(\w+(?:\(\))?)\.lazy\(\((?:\(\)=>|function\(\)\{return )(\w+)\.(\w+)\(\d+\)\.then\(\w+\.bind\(\w+,\d+\)\)\}?\)\)`
-		const REACT_ELEMENT_REGEX = `(\w+(?:\(\))?)\.createElement\(([\w\.]+),\{path:"\/collection"(?:,[:\.\w,]+)?\}`
+		const REACT_ELEMENT_REGEX = `(\w+(?:\(\))?\.createElement|\([\w$\.,]+\))\(([\w\.]+),\{path:"\/collection"(?:,[:\.\w,\{\}\(\)]+)?\}`
 		reactSymbs := utils.FindSymbol(
 			"Custom app React symbols",
 			content,
@@ -241,7 +241,7 @@ func insertCustomApp(jsPath string, flags Flag) {
 				appName, reactSymbs[1], reactSymbs[1], appName)
 
 			appEleMap += fmt.Sprintf(
-				`%s.createElement(%s,{path:"/%s"},%s.createElement(spicetifyApp%d,null)),`,
+				`%s(%s,{path:"/%s",children:%s(spicetifyApp%d,{})}),`,
 				eleSymbs[0], eleSymbs[1], app, eleSymbs[0], index)
 
 			cssEnableMap += fmt.Sprintf(`,"%s":1`, appName)
@@ -264,7 +264,7 @@ func insertCustomApp(jsPath string, flags Flag) {
 
 		utils.Replace(
 			&content,
-			`[\w()]+\.createElement\("li",\{className:[\w$\.]+\},[\w()]+\.createElement\(\w+,\{uri:"spotify:user:@:collection",to:"/collection"(,onDrop:\w+,onNavigate:\w+)?\}`,
+			`\([\w$\.,]+\)\("li",\{className:[\w$\.]+\}?,(?:children:)?\([\w$\.,]+\)\(\w+,\{uri:"spotify:user:@:collection",to:"/collection"`,
 			`Spicetify._sidebarItemToClone=${0}`)
 
 		utils.ReplaceOnce(
@@ -274,7 +274,7 @@ func insertCustomApp(jsPath string, flags Flag) {
 
 		sidebarItemMatch := utils.SeekToCloseParen(
 			content,
-			`\("li",\{className:[\w$\.]+\},[\w()]+\.createElement\(\w+,\{uri:"spotify:user:@:collection",to:"/collection"(,onDrop:\w+,onNavigate:\w+)?\}`,
+			`\("li",\{className:[\w$\.]+\}?,(?:children:)?\([\w$\.,]+\)\(\w+,\{uri:"spotify:user:@:collection",to:"/collection"`,
 			'(', ')')
 
 		content = strings.Replace(

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -264,7 +264,7 @@ func insertCustomApp(jsPath string, flags Flag) {
 
 		utils.Replace(
 			&content,
-			`\([\w$\.,]+\)\("li",\{className:[\w$\.]+\}?,(?:children:)?\([\w$\.,]+\)\(\w+,\{uri:"spotify:user:@:collection",to:"/collection"`,
+			`(?:\w+(?:\(\))?\.createElement|\([\w$\.,]+\))\("li",\{className:[\w$\.]+\}?,(?:children:)?[\w$\.,()]+\(\w+,\{uri:"spotify:user:@:collection",to:"/collection"`,
 			`Spicetify._sidebarItemToClone=${0}`)
 
 		utils.ReplaceOnce(
@@ -274,7 +274,7 @@ func insertCustomApp(jsPath string, flags Flag) {
 
 		sidebarItemMatch := utils.SeekToCloseParen(
 			content,
-			`\("li",\{className:[\w$\.]+\}?,(?:children:)?\([\w$\.,]+\)\(\w+,\{uri:"spotify:user:@:collection",to:"/collection"`,
+			`\("li",\{className:[\w$\.]+\}?,(?:children:)?[\w$\.,()]+\(\w+,\{uri:"spotify:user:@:collection",to:"/collection"`,
 			'(', ')')
 
 		content = strings.Replace(

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -333,7 +333,7 @@ Spicetify.React.useEffect(() => {
 	// React Component: Context Menu and Right Click Menu
 	utils.Replace(
 		&input,
-		`=(?:function\()?(\w+)(?:=>|\)\{return )(\w+(?:\(\))?\.createElement\(([\w\.]+),\w*\((?:\w+,[\w\.]+)?\)\(\{\},\w+,\{action:"open",trigger:"right-click"\}\)\))(?:\}(\}))?`,
+		`=(?:function\()?(\w+)(?:=>|\)\{return ?)((?:\w+(?:\(\))?\.createElement|\([\w$\.,]+\))\(([\w\.]+),[\w(){},\.]+,[\w{}]+,\{action:"open",trigger:"right-click"\}\)\))(?:\}(\}))?`,
 		`=Spicetify.ReactComponent.RightClickMenu=${1}=>${2};Spicetify.ReactComponent.ContextMenu=${3};${4}`)
 
 	// React Component: Context Menu - Menu
@@ -351,19 +351,19 @@ Spicetify.React.useEffect(() => {
 	// React Component: Album Context Menu items
 	utils.Replace(
 		&input,
-		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function\([\{\w\}:,]+\)|\()?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w=\(\).,]*;?(?:return |=>)\w+[\(\)]?\.createElement\([\w\.]+,\{value:"album"\})`,
+		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function\([\{\w\}:,]+\)|\()?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w=\(\).,]*;?(?:return ?|=>)[\w$\.,()]+\([\w\.]+,\{value:"album")`,
 		`${1}=Spicetify.ReactComponent.AlbumMenu${2}`)
 
 	// React Component: Show Context Menu items
 	utils.Replace(
 		&input,
-		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function\([\{\w\}:,]+\)|\()?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w=\(\).,]*;?(?:return |=>)\w+[\(\)]?\.createElement\([\w\.]+,\{value:"show"\})`,
+		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function\([\{\w\}:,]+\)|\()?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w=\(\).,]*;?(?:return ?|=>)[\w$\.,()]+\([\w\.]+,\{value:"show")`,
 		`${1}=Spicetify.ReactComponent.PodcastShowMenu${2}`)
 
 	// React Component: Artist Context Menu items
 	utils.Replace(
 		&input,
-		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function\([\{\w\}:,]+\)|\()?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w=\(\).,]*;?(?:return |=>)\w+[\(\)]?\.createElement\([\w\.]+,\{value:"artist"\})`,
+		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function\([\{\w\}:,]+\)|\()?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w=\(\).,]*;?(?:return ?|=>)[\w$\.,()]+\([\w\.]+,\{value:"artist")`,
 		`${1}=Spicetify.ReactComponent.ArtistMenu${2}`)
 
 	// React Component: Playlist Context Menu items


### PR DESCRIPTION
Resolves #1939 (I hope)
Fix custom apps hook on Spotify version `1.1.95`
![image](https://user-images.githubusercontent.com/77577746/192151379-688e38cd-954e-4857-985d-8931cf710a73.png)

Backwards compatible & tested.