### PR TITLE
feat: allow running `config-dir` without valid path

### DIFF
--- a/spicetify.go
+++ b/spicetify.go
@@ -114,6 +114,13 @@ func init() {
 }
 
 func main() {
+	// Show config directory without needing to initialize config
+	switch commands[0] {
+	case "config-dir":
+		cmd.ShowConfigDirectory()
+		return
+	}
+
 	cmd.InitPaths()
 
 	// Unchainable commands
@@ -136,10 +143,6 @@ func main() {
 		} else {
 			cmd.EditColor(commands)
 		}
-		return
-
-	case "config-dir":
-		cmd.ShowConfigDirectory()
 		return
 
 	case "path":


### PR DESCRIPTION
Would make troubleshooting for the average user a lot easier
![image](https://user-images.githubusercontent.com/77577746/192681001-9e40dd04-5fca-40d8-b544-65eb92cfd31f.png)
