### PR TITLE
fix: clear path if invalid AppX path is used

### DIFF
--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -104,12 +104,6 @@ func Apply(spicetifyVersion string) {
 
 	utils.PrintSuccess("Spotify is spiced up!")
 
-	if isAppX {
-		utils.PrintInfo(`You are using Spotify Windows Store version, which is only partly supported.
-Stop using Spicetify with Windows Store version unless you absolutely CANNOT install normal Spotify from installer.
-Modded Spotify cannot be launched using original Shortcut/Start menu tile. To correctly launch Spotify with modification, please make a desktop shortcut that execute "spicetify auto". After that, you can change its icon, pin to start menu or put in startup folder.`)
-	}
-
 	backupSpicetifyVersion := backupSection.Key("with").MustString("")
 	if spicetifyVersion != backupSpicetifyVersion {
 		utils.PrintInfo(`Preprocessed Spotify data is outdated. Please run "spicetify restore backup apply" to receive new features and bug fixes`)

--- a/src/cmd/backup.go
+++ b/src/cmd/backup.go
@@ -16,6 +16,14 @@ import (
 // Backup stores original apps packages, extracts them and preprocesses
 // extracted apps' assets
 func Backup(spicetifyVersion string) {
+	if isAppX {
+		utils.PrintInfo(`You are using Spotify Windows Store version, which is only partly supported.
+Stop using Spicetify with Windows Store version unless you absolutely CANNOT install normal Spotify from installer.
+Modded Spotify cannot be launched using original Shortcut/Start menu tile. To correctly launch Spotify with modification, please make a desktop shortcut that execute "spicetify auto". After that, you can change its icon, pin to start menu or put in startup folder.`)
+		if !ReadAnswer("Continue backing up anyway? [y/N]: ", false, true) {
+			os.Exit(1)
+		}
+	}
 	backupVersion := backupSection.Key("version").MustString("")
 	backStat := backupstatus.Get(prefsPath, backupFolder, backupVersion)
 	if !backStat.IsEmpty() {


### PR DESCRIPTION
- Reset path if `prefs_path` is of AppX and invalid (which is the majority case if `prefs_path` issue on Windows), hopefully this solves a handful of issues like this (if not all). This should also ease up the switching process from AppX to normal version after the user reads the message mentioned below:
![Code_GLV8UpIaOJ](https://user-images.githubusercontent.com/77577746/192688108-c1646f59-925c-41fe-9c0c-902039371334.gif)
Also found out that the AppX `spotify_path` may still exist after an uninstallation, so added an extra check to be sure.

- Shows MS Store version warn message on backup along with the `Spicetify not apply on restart` solution and forces the user to respond (and hopefully read) before continuing:
![Code_dNty039Xrw](https://user-images.githubusercontent.com/77577746/192689283-8a9250b3-4324-416c-8696-1e01f86b44e2.png)
