### PR TITLE
feat(expFeatures): general overhaul

### DIFF
--- a/jsHelper/expFeatures.js
+++ b/jsHelper/expFeatures.js
@@ -15,24 +15,26 @@
         hooksPatched = true;
         newFeatures.push(feature.name);
 
-        if (feature.type === "enum") {
-            if (overrideList[feature.name] === undefined) {
-                overrideList[feature.name] = { description: feature.description, value: feature.default, values: feature.values };
-            }
-            feature.default = overrideList[feature.name].value;
-            localStorage.setItem("spicetify-exp-features", JSON.stringify(overrideList));
-        } else if (typeof feature.default === "boolean") {
-            if (overrideList[feature.name] === undefined) {
-                overrideList[feature.name] = { description: feature.description, value: feature.default };
-            }
-            feature.default = overrideList[feature.name].value;
-            localStorage.setItem("spicetify-exp-features", JSON.stringify(overrideList));
+        switch (feature.type) {
+            case "enum":
+                if (!overrideList[feature.name]) {
+                    overrideList[feature.name] = { description: feature.description, value: feature.default, values: feature.values };
+                }
+                feature.default = overrideList[feature.name].value;
+                break;
+            case "bool":
+                if (!overrideList[feature.name]) {
+                    overrideList[feature.name] = { description: feature.description, value: feature.default };
+                }
+                feature.default = overrideList[feature.name].value;
+                break;
         }
 
         // Internal stuff may changes after updates, filter if so
         if (overrideList[feature.name] && typeof overrideList[feature.name].value !== typeof feature.default) {
             newFeatures = newFeatures.filter((f) => f !== feature.name);
         }
+        localStorage.setItem("spicetify-exp-features", JSON.stringify(overrideList));
         return feature;
     };
 
@@ -86,7 +88,6 @@ button.reset:hover {
     transform: scale(1.04);
 }`;
     content.appendChild(style);
-    content.innerHTML += `<p class="placeholder">Experimental features not found/is initializing. Try re-opening this modal.</p>`;
 
     new Spicetify.Menu.Item("Experimental features", false, () => {
         Spicetify.PopupModal.display({

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -290,6 +290,13 @@ func insertCustomApp(jsPath string, flags Flag) {
 				`return true${1}${2}?.uri||""`)
 		}
 
+		if flags.ExpFeatures {
+			utils.ReplaceOnce(
+				&content,
+				`(([\w$.]+\.fromJSON)\(\w+\)+;)(return ?[\w{}().,]+[\w$]+\.Provider,)(\{value:\{localConfiguration)`,
+				`${1}Spicetify.createInternalMap=${2};${3}Spicetify.RemoteConfigResolver=${4}`)
+		}
+
 		return content
 	})
 }


### PR DESCRIPTION
Works on `1.1.92` and later.
`expFeatures` now override active properties and apply changes in real-time instead of just replacing the default value locally. This also means that **remotely enabled/disabled features** can now be overwritten, and the client no longer needs to reload every time the modal is closed:
![Spotify_2iv85IQL2B](https://user-images.githubusercontent.com/77577746/193368600-badc499a-3c9d-4741-8af1-86ad82edcfa8.gif)
Add search modal:
![Spotify_0x4euF0OuZ](https://user-images.githubusercontent.com/77577746/193404241-943e73c5-d9b4-42ea-8470-232bc7516d52.gif)
