### PR TITLE
feat: add `TooltipWrapper` React Component

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1294,6 +1294,42 @@ declare namespace Spicetify {
              */
             icon?: React.ReactNode;
         };
+        type TooltipProps = {
+            /**
+             * Label to display in the tooltip
+             */
+            label: string;
+            /**
+             * The child element that the tooltip will be attached to
+             * and will display when hovered over
+             */
+            children: React.ReactNode;
+            /**
+             * Decide whether to use the global singleton tooltip (rendered in `<body>`)
+             * or a new inline tooltip (rendered in a sibling
+             * element to `children`)
+             */
+            renderInline?: boolean;
+            /**
+             * Delay in milliseconds before the tooltip is displayed
+             * after the user hovers over the child element
+             */
+            showDelay?: number;
+            /**
+             * Determine whether the tooltip should be displayed
+             */
+            disabled?: boolean;
+            /**
+             * The preferred placement of the context menu when it opens.
+             * Relative to trigger element.
+             * @default 'top'
+             */
+            placement?: 'top' | 'top-start' | 'top-end' | 'right' | 'right-start' | 'right-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end';
+            /**
+             * Class name to apply to the tooltip
+             */
+            labelClassName?: string;
+        };
         /**
          * Generic context menu provider
          *
@@ -1335,6 +1371,14 @@ declare namespace Spicetify {
         const PodcastShowMenu: any;
         const ArtistMenu: any;
         const PlaylistMenu: any;
+        /**
+         * Component to display tooltip when hovering over element
+         * Useful for accessibility
+         *
+         * Props:
+         * @see Spicetify.ReactComponent.TooltipProps
+         */
+        const TooltipWrapper: any;
     };
 
     /**

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -372,6 +372,12 @@ Spicetify.React.useEffect(() => {
 		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function\([\{\w\}:,]+\)|\()?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:uri|isEnhanced|onRemoveCallback)[:\w]*,?){3,})`,
 		`${1}=Spicetify.ReactComponent.PlaylistMenu${2}`)
 
+	// React Component: Tooltip Wrapper
+	utils.Replace(
+		&input,
+		`(\w+)(=(?:function\([\{\w\}:,]+\)|\()\{(?:[\w. =]*(?:label|children|renderInline|showDelay)[\w:]*,?){4})`,
+		`${1}=Spicetify.ReactComponent.TooltipWrapper${2}`)
+
 	// Locale
 	utils.Replace(
 		&input,


### PR DESCRIPTION
Works from `1.1.90` to latest, has not tested below.
Add `TooltipWrapper` hook for `ReactComponent` for extensions/custom apps. Displays a tooltip while hovering/focusing on an element. Useful for accessibility and UX improvements.
![Code_YOvHgkuHdz](https://user-images.githubusercontent.com/77577746/193553159-54ac04d8-4ad6-4e6f-babe-4a32cb355c5a.png)
![Spotify_93kEhN8zhG](https://user-images.githubusercontent.com/77577746/193553172-52fb504a-5729-4c24-a006-4c7ab6a3ccd2.gif)
