### PR TITLE
fix(css-map): update `navAlt` classes

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1990,5 +1990,9 @@
     "Bl_kg24BjWgcXPokgEKy": "playlist-playlist-emptyStateContainer",
     "sAPXlA_oxu_8x1Cn0NTC": "playlist-playlist-searchResultListContainer",
     "_Z2TnFjt8GB5ryOtvyti": "playlist-playlist-emptySearchTermContainer",
-    "tzeKawjOOKFw1KfQ34mG": "playlist-playlist-icon"
+    "tzeKawjOOKFw1KfQ34mG": "playlist-playlist-icon",
+    "s1jyNJBxq16eqkqCf6Ax": "main-trackInfo-enhanced",
+    "IcyWfMS5VkeOhaI7OWIx": "main-coverSlotCollapsed-navAltContainer",
+    "qvXMfQh1CjESoKKX49Bl": "main-topBar-buttonActive",
+    "OOsg_GCQDERDXc1d0EmC": "main-topBar-navLinks"
 }


### PR DESCRIPTION
Class names concluded after inspecting `xpui.js` and `xpui.css`.
![image](https://user-images.githubusercontent.com/77577746/193824645-73175b3f-3e26-4cdc-ad6f-feca262d6701.png)
![image](https://user-images.githubusercontent.com/77577746/193825247-3438d3ac-4ed2-428a-ab9e-69ec87e688d1.png)
