### PR TITLE
fix(types): optional param declaration for `playUri`

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -183,7 +183,7 @@ declare namespace Spicetify {
          * @param context
          * @param options
          */
-        function playUri(uri: string, context: any, options: any): Promise<void>;
+        function playUri(uri: string, context?: any, options?: any): Promise<void>;
         /**
          * Unregister added event listener `type`.
          * @param type


### PR DESCRIPTION
They are given a default value in spicetifyWrapper.js (see below), so should be optional in the ts types.
https://github.com/spicetify/spicetify-cli/blob/c7d4cffbd3beb5b115980c573c4b274cb77e8dc9/jsHelper/spicetifyWrapper.js#L64

Otherwise my ts code complains about `Expected 3 arguments, but got 1.ts(2554)`, but I have no idea what values I should be putting in there, and the code still works without, because of the defaults.