### PR TITLE
fix: excess symbol on empty color scheme

### DIFF
--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -351,7 +351,7 @@ func insertVersionInfo(jsPath string, flags Flag) {
 			`(\w+(?:\(\))?\.createElement|\([\w$\.,]+\))\([\w\."]+,[\w{}():,]+\.containerVersion\}?\),`,
 			`${0}${1}("details",{children: [
 				${1}("summary",{children: "Spicetify v" + Spicetify.Config.version}),
-				${1}("li",{children: "Theme: " + Spicetify.Config.current_theme + " / " + Spicetify.Config.color_scheme}),
+				${1}("li",{children: "Theme: " + Spicetify.Config.current_theme + (Spicetify.Config.color_scheme && " / ") + Spicetify.Config.color_scheme}),
 				${1}("li",{children: "Extensions: " + Spicetify.Config.extensions.join(", ")}),
 				${1}("li",{children: "Custom apps: " + Spicetify.Config.custom_apps.join(", ")}),
 				]}),`)


### PR DESCRIPTION
Thanks @xerta555 for pointing it out
![image](https://user-images.githubusercontent.com/77577746/196300601-cfbef32e-7eb5-450b-bb36-a32b10f7d050.png)

Remove excess symbol on empty color scheme
![image](https://user-images.githubusercontent.com/77577746/196300651-f31c7f8c-e7e0-4954-bb06-e350a51ba20e.png)
