### PR TITLE
fix: add support for `1.1.97`

### DIFF
--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -534,28 +534,29 @@ class LyricsContainer extends react.Component {
                 react.createElement(AdjustmentsMenu, { mode })
             ),
             activeItem,
-            react.createElement(TopBarContent, {
-                links: this.availableModes,
-                activeLink: CONFIG.modes[mode],
-                lockLink: CONFIG.modes[this.state.lockMode],
-                switchCallback: (label) => {
-                    const mode = CONFIG.modes.findIndex((a) => a === label);
-                    if (mode !== this.state.mode) {
-                        this.setState({ explicitMode: mode });
+            !!document.querySelector(".main-topBar-topbarContentWrapper") &&
+                react.createElement(TopBarContent, {
+                    links: this.availableModes,
+                    activeLink: CONFIG.modes[mode],
+                    lockLink: CONFIG.modes[this.state.lockMode],
+                    switchCallback: (label) => {
+                        const mode = CONFIG.modes.findIndex((a) => a === label);
+                        if (mode !== this.state.mode) {
+                            this.setState({ explicitMode: mode });
+                            this.fetchLyrics(Player.data.track, mode);
+                        }
+                    },
+                    lockCallback: (label) => {
+                        let mode = CONFIG.modes.findIndex((a) => a === label);
+                        if (mode === this.state.lockMode) {
+                            mode = -1;
+                        }
+                        this.setState({ explicitMode: mode, lockMode: mode });
                         this.fetchLyrics(Player.data.track, mode);
-                    }
-                },
-                lockCallback: (label) => {
-                    let mode = CONFIG.modes.findIndex((a) => a === label);
-                    if (mode === this.state.lockMode) {
-                        mode = -1;
-                    }
-                    this.setState({ explicitMode: mode, lockMode: mode });
-                    this.fetchLyrics(Player.data.track, mode);
-                    CONFIG.locked = mode;
-                    localStorage.setItem("lyrics-plus:lock-mode", mode);
-                },
-            })
+                        CONFIG.locked = mode;
+                        localStorage.setItem("lyrics-plus:lock-mode", mode);
+                    },
+                })
         );
 
         if (this.state.isFullscreen) {

--- a/CustomApps/reddit/index.js
+++ b/CustomApps/reddit/index.js
@@ -276,11 +276,12 @@ class Grid extends react.Component {
                 !this.state.endOfList &&
                     (this.state.rest ? react.createElement(LoadMoreIcon, { onClick: this.loadMore.bind(this) }) : react.createElement(LoadingIcon))
             ),
-            react.createElement(TopBarContent, {
-                switchCallback: this.switchTo.bind(this),
-                links: CONFIG.services,
-                activeLink: CONFIG.lastService,
-            })
+            !!document.querySelector(".main-topBar-topbarContentWrapper") &&
+                react.createElement(TopBarContent, {
+                    switchCallback: this.switchTo.bind(this),
+                    links: CONFIG.services,
+                    activeLink: CONFIG.lastService,
+                })
         );
     }
 }

--- a/jsHelper/expFeatures.js
+++ b/jsHelper/expFeatures.js
@@ -144,7 +144,7 @@ input.search {
         Object.keys(overrideList).forEach((key) => {
             if (newFeatures.length > 0 && !newFeatures.includes(key)) {
                 delete overrideList[key];
-                console.log(`Removed ${key} from override list`);
+                console.warn(`[spicetify-exp-features] Removed ${key} from override list`);
                 localStorage.setItem("spicetify-exp-features", JSON.stringify(overrideList));
             }
         });

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -294,7 +294,7 @@ func exposeAPIs_main(input string) string {
 		`"data-testid":`,
 		`"":`)
 
-	reAllAPIPromises := regexp.MustCompile(`return ?(?:function\(\))?(?:[\w$\.]+\([\w$\.]+\).)*\{(?:[ \w.$,(){}]+:[\w\d!$_.()]+,)*(?:return [\w.\(,\)}]+)?(?:get\w+:(?:[()=>{}\w]+new Promise[()=>{}]+),)?((?:get\w+:(?:\(\)=>|function\(\)\{return ?)(?:[\w$]+|[(){}]+)\}?,?)+?)[})]+;?`)
+	reAllAPIPromises := regexp.MustCompile(`return ?(?:function\(\))?(?:[\w$\.]+[\w$\.()=!]+.)*\{(?:[ \w.$,(){}]+:[\w\d!$_.()]+,)*(?:return [\w.\(,\)}]+)?(?:get\w+:(?:[()=>{}\w]+new Promise[()=>{}]+),)?((?:get\w+:(?:\(\)=>|function\(\)\{return ?)(?:[\w$]+|[(){}]+)\}?,?)+?)[})]+;?`)
 	allAPIPromises := reAllAPIPromises.FindAllStringSubmatch(input, -1)
 	for _, found := range allAPIPromises {
 		splitted := strings.Split(found[1], ",")
@@ -333,7 +333,7 @@ Spicetify.React.useEffect(() => {
 	// React Component: Context Menu and Right Click Menu
 	utils.Replace(
 		&input,
-		`=(?:function\()?(\w+)(?:=>|\)\{return ?)((?:\w+(?:\(\))?\.createElement|\([\w$\.,]+\))\(([\w\.]+),[\w(){},\.]+,[\w{}]+,\{action:"open",trigger:"right-click"\}\)\))(?:\}(\}))?`,
+		`=(?:function\()?(\w+)(?:=>|\)\{return ?)((?:\w+(?:\(\))?\.createElement|\([\w$\.,]+\))\(([\w\.]+),(?:[\w(){},\.]+,[\w{}]+,)?\{[.,\w+]*action:"open",trigger:"right-click"\}\)\)?)(?:\}(\}))?`,
 		`=Spicetify.ReactComponent.RightClickMenu=${1}=>${2};Spicetify.ReactComponent.ContextMenu=${3};${4}`)
 
 	// React Component: Context Menu - Menu
@@ -357,7 +357,7 @@ Spicetify.React.useEffect(() => {
 	// React Component: Show Context Menu items
 	utils.Replace(
 		&input,
-		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function\([\{\w\}:,]+\)|\()?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w=\(\).,]*;?(?:return ?|=>)[\w$\.,()]+\([\w\.]+,\{value:"show")`,
+		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function[()\{\w\}:,]+|\()?\{(?:\w+ ?[\w\{\}\(\)=,:.!]*)?(?:[\w=\.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w=\(\).,]*;?(?:return ?|=>)[\w$\.,()]+\([\w\.]+,\{value:"show")`,
 		`${1}=Spicetify.ReactComponent.PodcastShowMenu${2}`)
 
 	// React Component: Artist Context Menu items
@@ -369,7 +369,7 @@ Spicetify.React.useEffect(() => {
 	// React Component: Playlist Context Menu items
 	utils.Replace(
 		&input,
-		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function\([\{\w\}:,]+\)|\()?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:uri|isEnhanced|onRemoveCallback)[:\w]*,?){3,})`,
+		`(\w+)(=\w+[\(\)]*\.memo\(\((?:function[\{\w\}:,()]*|\()?\{(?:\w+ ?[\w\{\}\(\)=,:]*)?(?:[\w=\.]*(?:uri|isEnhanced|onRemoveCallback)[:\w]*,?){3,})`,
 		`${1}=Spicetify.ReactComponent.PlaylistMenu${2}`)
 
 	// React Component: Tooltip Wrapper


### PR DESCRIPTION
- Compatibility with/hotfix for Spotify `1.1.97`
- Fixes issue where launching FAD with Lyrics Plus enabled while on home page crashes the client on the aforementioned version.

Backwards compatible & tested.