### PR TITLE
fix(action/prettier): cloning branch in fork

### DIFF
--- a/.github/workflows/lintpr.yml
+++ b/.github/workflows/lintpr.yml
@@ -1,17 +1,17 @@
 name: Lint Pull Request
 
 on:
-    pull_request_target:
-        types:
-            - opened
-            - edited
-            - synchronize
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
 
 jobs:
-    lintpr:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Lint pull request title
-              uses: amannn/action-semantic-pull-request@v5
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  lintpr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lint pull request title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -2,10 +2,6 @@ name: Prettier
 
 on: [pull_request]
 
-permissions:
-  pull-requests: write
-  contents: write
-
 jobs:
   prettier:
     runs-on: ubuntu-latest

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,11 +1,6 @@
 name: Prettier
 
-on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
+on: [pull_request]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,6 +1,11 @@
 name: Prettier
 
-on: [pull_request]
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
 
 permissions:
   pull-requests: write
@@ -9,12 +14,11 @@ permissions:
 jobs:
   prettier:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
           persist-credentials: false
 


### PR DESCRIPTION
This pull request targets fixing Prettier Action cloning branches outside our repo (forks) and to lint `lintpr.yml` file