### PR TITLE
fix(wrapper): append active class on custom app location

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -934,6 +934,14 @@ Spicetify._cloneSidebarItem = function(list) {
         return null;
     }
 
+    function conditionalAppend(baseClassname, conditionalClassname, location) {
+        if (Spicetify.Platform?.History?.location && Spicetify.Platform.History.location.pathname.startsWith(location)) {
+            baseClassname += " " + conditionalClassname;
+        }
+
+        return baseClassname;
+    }
+
     const React = Spicetify.React;
     const reactObjs = [];
     for (const app of list) {
@@ -967,6 +975,7 @@ Spicetify._cloneSidebarItem = function(list) {
                 {
                     to: appLink,
                     isActive: (e, {pathname: t})=> t.startsWith(appLink),
+                    className: conditionalAppend("link-subtle main-navBar-navBarLink", "main-navBar-navBarLinkActive", appLink),
                 },
                 React.createElement(
                     "div",


### PR DESCRIPTION
Spotify deprecated `isActive` on `1.2.1`, thus active class name is not appended when visiting respective custom apps but shows up only when `Your Library` is active.
![Spotify_TBnwLTeYhl](https://user-images.githubusercontent.com/77577746/209343169-2b5c80b7-163b-4fa7-ade5-10bbe2d888e6.gif)
The prop is still kept for backwards compatibility
![Spotify_vukr98IYy9](https://user-images.githubusercontent.com/77577746/209343208-d7b20d0b-9e88-4209-bc7d-84ebed89736b.gif)
