### PR TITLE
chore: ignore spicetify binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Executables
 bin/
+spicetify-cli
+spicetify
 *.exe
 
 # MacOS


### PR DESCRIPTION
(gitignore) ignore spicetify-cli executable

Summary: Ignore the `spicetify-cli` executable generated from `go build` on Unix

Test Plan: N/A

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/spicetify/spicetify-cli/pull/2085).
* __->__ #2085
