### PR TITLE
feat(installer): write log to file for support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ bin/
 node_modules
 package-lock.json
 package.json
+
+# Logs
+install.log

--- a/install.ps1
+++ b/install.ps1
@@ -10,9 +10,34 @@ if ($v) {
     $version = $v
 }
 
+$log_file_dir = "$sp_dir\install.log"
+
+# Function to log output to file.
+Function Log {
+  Param([String] $ActionText, [String[]] $Texts, [Boolean[]] $Emphasized, [Boolean] $NewLine)
+  if (-not (Test-Path $log_file_dir)) {
+    New-Item -Path $log_file_dir -ItemType File -Force | Out-Null
+  }
+  if (-not ([String]::IsNullOrEmpty($ActionText))) {
+    $FormattedActionText = "{0, -15}" -f $ActionText
+    Write-Part $FormattedActionText
+  }
+  $LogText = $FormattedActionText
+  for ($i=0; $i -lt $Texts.Length -AND $Texts.Length -eq $Emphasized.Length; $i++) {
+    if ($Emphasized.Get($i)) {
+      Write-Emphasized $Texts.Get($i)
+    } else {
+      Write-Part $Texts.Get($i)
+    }
+    $LogText = $LogText + $Texts.Get($i)
+  }
+  $LogText = "[{0}] {1}" -f (Get-Date -f "HH:mm:ss yyyy-MM-dd"), $LogText
+  Add-content $log_file_dir -value $LogText -NoNewline
+}
+
 # Helper functions for pretty terminal output.
-function Write-Part ([string] $Text) {
-  Write-Host $Text -NoNewline
+function Write-Part ([String] $Text) {
+  Write-Host $Text -Nonewline
 }
 
 function Write-Emphasized ([string] $Text) {
@@ -22,13 +47,14 @@ function Write-Emphasized ([string] $Text) {
 function Write-Done {
   Write-Host " > " -NoNewline
   Write-Host "OK" -ForegroundColor "Green"
+  Add-Content $log_file_dir -value " > OK"
 }
 
 function RemoveOldPath {
   $oldsp_dir = "${HOME}\spicetify-cli"
   $isinpath = $paths -contains $oldsp_dir -or $paths -contains "${oldsp_dir}\"
   if ($isinpath) {
-    Write-Part "REMOVING       "; Write-Emphasized $oldsp_dir; Write-Part " from Path"
+    Log "REMOVING" -Texts $oldsp_dir, " from Path" -Emphasized $true, $false
 
     $replacedpath = $path.replace(";$oldsp_dir", "")
     [Environment]::SetEnvironmentVariable("PATH", $replacedpath, $user)
@@ -41,10 +67,10 @@ function MigrateCfgFolder {
   $oldsp_dircontent = "${HOME}\spicetify-cli\*"
   $oldsp_dir = "${HOME}\spicetify-cli"
   if (Test-Path -Path $oldsp_dir) {
-    Write-Part "MIGRATING      "; Write-Emphasized $oldsp_dir; Write-Part " into ";  Write-Emphasized $sp_dir
+    Log "MIGRATING" -Texts $oldsp_dir, " into", $sp_dir -Emphasized $true, $false, $true
     Copy-item -Force -Recurse $oldsp_dircontent -Destination $sp_dir
     Write-Done
-    Write-Part "REMOVING       "; Write-Emphasized $oldsp_dir
+    Log "REMOVING" -Texts $oldsp_dir -Emphasized $true
     Remove-Item -LiteralPath $oldsp_dir -Force -Recurse
     Write-Done
   }
@@ -56,23 +82,22 @@ if ($PSVersionTable.PSVersion.Major -gt $PSMinVersion) {
   # Enable TLS 1.2 since it is required for connections to GitHub.
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
+  # Create %localappdata%\spicetify directory if it doesn't already exist
+  $sp_dir = "$env:LOCALAPPDATA\spicetify"
+  if (-not (Test-Path $sp_dir)) {
+    Log "MAKING FOLDER" -Texts $sp_dir -Emphasized $true
+    Write-Done
+  }
+
   if (-not $version) {
     # Determine latest Spicetify release via GitHub API.
     $latest_release_uri =
     "https://api.github.com/repos/spicetify/spicetify-cli/releases/latest"
-    Write-Part "DOWNLOADING    "; Write-Emphasized $latest_release_uri
+    Log "DOWNLOADING" -Texts $latest_release_uri -Emphasized $true
     $latest_release_json = Invoke-WebRequest -Uri $latest_release_uri -UseBasicParsing
     Write-Done
 
     $version = ($latest_release_json | ConvertFrom-Json).tag_name -replace "v", ""
-  }
-
-  # Create %localappdata%\spicetify directory if it doesn't already exist
-  $sp_dir = "$env:LOCALAPPDATA\spicetify"
-  if (-not (Test-Path $sp_dir)) {
-    Write-Part "MAKING FOLDER  "; Write-Emphasized $sp_dir
-    New-Item -Path $sp_dir -ItemType Directory | Out-Null
-    Write-Done
   }
 
   # Migrate old spicetify folder to new location.
@@ -83,19 +108,18 @@ if ($PSVersionTable.PSVersion.Major -gt $PSMinVersion) {
   $zip_file = "${sp_dir}\spicetify-${version}-windows-${architecture}.zip"
   $download_uri = "https://github.com/spicetify/spicetify-cli/releases/download/" +
   "v${version}/spicetify-${version}-windows-${architecture}.zip"
-  Write-Part "DOWNLOADING    "; Write-Emphasized $download_uri
+  Log "DOWNLOADING" -Texts $download_uri -Emphasized $true
   Invoke-WebRequest -Uri $download_uri -UseBasicParsing -OutFile $zip_file
   Write-Done
 
   # Extract spicetify.exe and assets from .zip file.
-  Write-Part "EXTRACTING     "; Write-Emphasized $zip_file
-  Write-Part " into "; Write-Emphasized ${sp_dir};
+  Log "EXTRACTING" -Texts $zip_file, " into ", ${sp_dir} -Emphasized $true, $false, $true
   # Using -Force to overwrite spicetify.exe and assets if it already exists
   Expand-Archive -Path $zip_file -DestinationPath $sp_dir -Force
   Write-Done
 
   # Remove .zip file.
-  Write-Part "REMOVING       "; Write-Emphasized $zip_file
+  Log "REMOVING" -Texts $zip_file -Emphasized $true
   Remove-Item -Path $zip_file
   Write-Done
 
@@ -112,8 +136,7 @@ if ($PSVersionTable.PSVersion.Major -gt $PSMinVersion) {
 
   # Add Spicetify dir to PATH if it hasn't been added already.
   if (-not $is_in_path) {
-    Write-Part "ADDING         "; Write-Emphasized $sp_dir; Write-Part " to the "
-    Write-Emphasized "PATH"; Write-Part " environment variable..."
+    Log "ADDING" -Texts $sp_dir, " to the ", "PATH", " environment variable..." -Emphasized $true, $false, $true, $false
     [Environment]::SetEnvironmentVariable("PATH", "${path};${sp_dir}", $user)
     # Add Spicetify to the PATH variable of the current terminal session
     # so `spicetify` can be used immediately without restarting the terminal.
@@ -121,9 +144,9 @@ if ($PSVersionTable.PSVersion.Major -gt $PSMinVersion) {
     Write-Done
   }
 
-  Write-Part "spicetify-cli was installed successfully."; Write-Done
-  Write-Part "Run "; Write-Emphasized "spicetify --help"; Write-Host " to get started.`n"
+  Log -Texts "spicetify-cli was installed successfully." -Emphasized $false; Write-Done
+  Log -Texts "Run ", "spicetify --help", " to get started.`n" -Emphasized $false, $true, $false
 } else {
-  Write-Part "`nYour Powershell version is lesser than "; Write-Emphasized "$PSMinVersion";
-  Write-Part "`nPlease, update your Powershell downloading the "; Write-Emphasized "'Windows Management Framework'"; Write-Part " greater than "; Write-Emphasized "$PSMinVersion"
+  Log -Texts "`nYour Powershell version is lesser than ", "$PSMinVersion" -Emphasized $false, $true
+  Log -Texts "`nPlease, update your Powershell downloading the ", "'Windows Management Framework'", " greater than ", "$PSMinVersion" -Emphasized $false, $true, $false, $true
 }

--- a/install.sh
+++ b/install.sh
@@ -4,18 +4,26 @@
 
 set -e
 
+# wipe existing log
+> install.log
+
+log() {
+	echo $1
+	echo "["$(date +'%H:%M:%S %Y-%m-%d')"]" $1 >> install.log
+}
+
 case $(uname -sm) in
 	"Darwin x86_64") target="darwin-amd64" ;;
 	"Darwin arm64") target="darwin-arm64" ;;
 	"Linux x86_64") target="linux-amd64" ;;
 	"Linux aarch64") target="linux-arm64" ;;
-	*) echo "Unsupported platform $(uname -sm). x86_64 and arm64 binaries for Linux and Darwin are available."; exit ;;
+	*) log "Unsupported platform $(uname -sm). x86_64 and arm64 binaries for Linux and Darwin are available."; exit ;;
 esac
 
 # check for dependencies
-command -v curl >/dev/null || { echo "curl isn't installed\!" >&2; exit 1; }
-command -v tar >/dev/null || { echo "tar isn't installed\!" >&2; exit 1; }
-command -v grep >/dev/null || { echo "grep isn't installed\!" >&2; exit 1; }
+command -v curl >/dev/null || { log "curl isn't installed\!" >&2; exit 1; }
+command -v tar >/dev/null || { log "tar isn't installed\!" >&2; exit 1; }
+command -v grep >/dev/null || { log "grep isn't installed\!" >&2; exit 1; }
 
 # download uri
 releases_uri=https://github.com/spicetify/spicetify-cli/releases
@@ -30,7 +38,7 @@ fi
 
 tag=${tag#v}
 
-echo "FETCHING Version $tag"
+log "FETCHING Version $tag"
 
 download_uri=$releases_uri/download/v$tag/spicetify-$tag-$target.tar.gz
 
@@ -40,18 +48,18 @@ exe="$spicetify_install/spicetify"
 tar="$spicetify_install/spicetify.tar.gz"
 
 # installing
-[ ! -d "$spicetify_install" ] && echo "CREATING $spicetify_install" && mkdir -p "$spicetify_install"
+[ ! -d "$spicetify_install" ] && log "CREATING $spicetify_install" && mkdir -p "$spicetify_install"
 
-echo "DOWNLOADING $download_uri"
+log "DOWNLOADING $download_uri"
 curl --fail --location --progress-bar --output "$tar" "$download_uri"
 
-echo "EXTRACTING $tar"
+log "EXTRACTING $tar"
 tar xzf "$tar" -C "$spicetify_install"
 
-echo "SETTING EXECUTABLE PERMISSIONS TO $exe"
+log "SETTING EXECUTABLE PERMISSIONS TO $exe"
 chmod +x "$exe"
 
-echo "REMOVING $tar"
+log "REMOVING $tar"
 rm "$tar"
 
 notfound() {
@@ -72,21 +80,21 @@ check() {
 
 	# Create shellrc if it doesn't exist
 	if ! [ -f $shellrc ]; then
-		echo "CREATING $shellrc"
+		log "CREATING $shellrc"
 		touch $shellrc
 	fi
 
 	# Still checking again, in case touch command failed
 	if [ -f $shellrc ]; then
 		if ! grep -q $spicetify_install $shellrc; then
-			echo "APPENDING $spicetify_install to PATH in $shellrc"
+			log "APPENDING $spicetify_install to PATH in $shellrc"
 			if ! endswith_newline $shellrc; then
 				echo >> $shellrc
 			fi
 			echo ${2:-$path} >> $shellrc
-			echo "Restart your shell to have spicetify in your PATH."
+			log "Restart your shell to have spicetify in your PATH."
 		else
-			echo "spicetify path already set in $shellrc, continuing..."
+			log "spicetify path already set in $shellrc, continuing..."
 		fi
 	else
 		notfound
@@ -104,5 +112,5 @@ case $SHELL in
 esac
 
 echo
-echo "spicetify v$tag was installed successfully to $spicetify_install"
-echo "Run 'spicetify --help' to get started"
+log "spicetify v$tag was installed successfully to $spicetify_install"
+log "Run 'spicetify --help' to get started"


### PR DESCRIPTION
A user in the Discord server was having issues with the installer not automatically setting up their shell's PATH to the Spicetify command line executable. I proposed to @theRealPadster that we should start logging installs so if this does happen again, we can review the logs and determine where the problem resides.

This feature:
- Implements a log function in the installer script that continues to log to the standard output as normal, but also logs to a `install.log` file. Each log in the `install.log` file includes a timestamp for convenience.
- Resets the `install.log` file each time the installer script is ran. In hindsight, this could probably be removed if this script gets ran each time Spicetify is updated (via AUR, or whatever package manager/method). We can retain a log of this on machine over time so we can tell when an issue started occurring.  
- Adds the `install.log` file to `.gitignore` to prevent it from being picked up in commits.