### PR TITLE
fix(lyrics-plus): spelling mistakes

### DIFF
--- a/CustomApps/lyrics-plus/README.md
+++ b/CustomApps/lyrics-plus/README.md
@@ -23,7 +23,7 @@ Lyrics in Unsynced and Genius modes can be search and jump to. Hit Ctrl + Shift 
 
 ![search](./search.png)
 
-Choose between different option of displaying Japanese lyrics. (Furigana, Romaji, Hirgana, Katakana)
+Choose between different option of displaying Japanese lyrics. (Furigana, Romaji, Hiragana, Katakana)
 
 ![conversion](./conversion.png)
 

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -228,7 +228,7 @@ class LyricsContainer extends react.Component {
 	}
 
 	async fetchLyrics(track, mode = -1) {
-		this.state.furigana = this.state.romaji = this.state.hirgana = this.state.katakana = this.state.neteaseTranslation = null;
+		this.state.furigana = this.state.romaji = this.state.hiragana = this.state.katakana = this.state.neteaseTranslation = null;
 		const info = this.infoFromTrack(track);
 		if (!info) {
 			this.setState({ error: "No track info" });


### PR DESCRIPTION
The word "Hiragana" was misspelled in some source code.