### PR TITLE
feat: add `Text` and `Icon` hooks

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1331,6 +1331,74 @@ declare namespace Spicetify {
              */
             labelClassName?: string;
         };
+        type IconComponentProps = {
+            /**
+             * Icon size
+             * @default 24
+             */
+            iconSize: number;
+            /**
+             * Icon color
+             * Might not be used by component
+             * @default 'currentColor'
+             */
+            color: string;
+            /**
+             * Semantic color name
+             * Matches color variables used in xpui
+             * @default Inherit from parent
+             */
+            semanticColor?: 'textBase' | 'textSubdued' | 'textBrightAccent' | 'textNegative' | 'textWarning' | 'textPositive' | 'textAnnouncement' | 'essentialBase' | 'essentialSubdued' | 'essentialBrightAccent' | 'essentialNegative' | 'essentialWarning' | 'essentialPositive' | 'essentialAnnouncement' | 'decorativeBase' | 'decorativeSubdued' | 'backgroundBase' | 'backgroundHighlight' | 'backgroundPress' | 'backgroundElevatedBase' | 'backgroundElevatedHighlight' | 'backgroundElevatedPress' | 'backgroundTintedBase' | 'backgroundTintedHighlight' | 'backgroundTintedPress' | 'backgroundUnsafeForSmallTextBase' | 'backgroundUnsafeForSmallTextHighlight' | 'backgroundUnsafeForSmallTextPress';
+            /**
+             * Icon title
+             * @default ''
+             */
+            title?: string;
+            /**
+             * Title ID (internal)
+             */
+            titleId?: string;
+            /**
+             * Icon description
+             */
+            desc?: string;
+            /**
+             * Description ID (internal)
+             */
+            descId?: string;
+            /**
+             * Auto mirror icon
+             * @default false
+             */
+            autoMirror?: boolean;
+        }
+        type TextComponentProps = {
+            /**
+             * Text color
+             * Might not be used by component
+             * @default 'currentColor'
+             */
+            color?: string;
+            /**
+             * Semantic color name
+             * Matches color variables used in xpui
+             * @default Inherit from parent
+             */
+            semanticColor?: 'textBase' | 'textSubdued' | 'textBrightAccent' | 'textNegative' | 'textWarning' | 'textPositive' | 'textAnnouncement' | 'essentialBase' | 'essentialSubdued' | 'essentialBrightAccent' | 'essentialNegative' | 'essentialWarning' | 'essentialPositive' | 'essentialAnnouncement' | 'decorativeBase' | 'decorativeSubdued' | 'backgroundBase' | 'backgroundHighlight' | 'backgroundPress' | 'backgroundElevatedBase' | 'backgroundElevatedHighlight' | 'backgroundElevatedPress' | 'backgroundTintedBase' | 'backgroundTintedHighlight' | 'backgroundTintedPress' | 'backgroundUnsafeForSmallTextBase' | 'backgroundUnsafeForSmallTextHighlight' | 'backgroundUnsafeForSmallTextPress';
+            /**
+             * Text style variant
+             * @default 'viola'
+             */
+            variant: 'bass' | 'forte' | 'brio' | 'altoBrio' | 'alto' | 'canon' | 'celloCanon' | 'cello' | 'ballad' | 'balladBold' | 'viola' | 'violaBold' | 'mesto' | 'mestoBold' | 'metronome' | 'finale' | 'finaleBold' | 'minuet' | 'minuetBold';
+            /**
+             * Bottom padding size
+             */
+            paddingBottom?: string;
+            /**
+             * Font weight
+             */
+            weight?: 'book' | 'bold' | 'black';
+        }
         /**
          * Generic context menu provider
          *
@@ -1382,6 +1450,7 @@ declare namespace Spicetify {
         const TooltipWrapper: any;
         /**
          * Component to render Spotify-style icon
+         * @since Spotify `1.1.95`
          *
          * Props:
          * @see Spicetify.ReactComponent.IconComponentProps
@@ -1389,6 +1458,7 @@ declare namespace Spicetify {
         const IconComponent: any;
         /**
          * Component to render Spotify-style text
+         * @since Spotify `1.1.95`
          *
          * Props:
          * @see Spicetify.ReactComponent.TextComponentProps

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1336,13 +1336,13 @@ declare namespace Spicetify {
              * Icon size
              * @default 24
              */
-            iconSize: number;
+            iconSize?: number;
             /**
              * Icon color
              * Might not be used by component
              * @default 'currentColor'
              */
-            color: string;
+            color?: string;
             /**
              * Semantic color name
              * Matches color variables used in xpui
@@ -1389,7 +1389,7 @@ declare namespace Spicetify {
              * Text style variant
              * @default 'viola'
              */
-            variant: 'bass' | 'forte' | 'brio' | 'altoBrio' | 'alto' | 'canon' | 'celloCanon' | 'cello' | 'ballad' | 'balladBold' | 'viola' | 'violaBold' | 'mesto' | 'mestoBold' | 'metronome' | 'finale' | 'finaleBold' | 'minuet' | 'minuetBold';
+            variant?: 'bass' | 'forte' | 'brio' | 'altoBrio' | 'alto' | 'canon' | 'celloCanon' | 'cello' | 'ballad' | 'balladBold' | 'viola' | 'violaBold' | 'mesto' | 'mestoBold' | 'metronome' | 'finale' | 'finaleBold' | 'minuet' | 'minuetBold';
             /**
              * Bottom padding size
              */

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1380,6 +1380,20 @@ declare namespace Spicetify {
          * @see Spicetify.ReactComponent.TooltipProps
          */
         const TooltipWrapper: any;
+        /**
+         * Component to render Spotify-style icon
+         *
+         * Props:
+         * @see Spicetify.ReactComponent.IconComponentProps
+         */
+        const IconComponent: any;
+        /**
+         * Component to render Spotify-style text
+         *
+         * Props:
+         * @see Spicetify.ReactComponent.TextComponentProps
+         */
+        const TextComponent: any;
     };
 
     /**

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -445,6 +445,16 @@ if (${1}.popper?.firstChild?.id === "context-menu") {
 		`\(function\(\w+\)\{return \w+\.variant\?function\(\w+\)\{`,
 		`Spicetify._fontStyle=${0}`)
 
+	utils.ReplaceOnce(
+		&input,
+		`=[\w$\.,]+\.forwardRef\(\((?:\([\w,]+\)=>|function\([\w,]+\)\{)\w\.color`,
+		`=Spicetify.ReactComponent.TextComponent${0}`)
+
+	utils.ReplaceOnce(
+		&input,
+		`=(?:\(\w\)=>|function\(\w\)\{)\w+ ?\w=\w\.iconSize`,
+		`=Spicetify.ReactComponent.IconComponent${0}`)
+
 	return input
 }
 


### PR DESCRIPTION
Add `ReactComponent` hooks for text and icon element, works on `1.1.95` and above
Useful in cases where we need to clone Spotify's styling and these element classes aren't mappable
![image](https://user-images.githubusercontent.com/77577746/213863875-d18a1e2a-cd9c-43e9-8a31-b30ce627a5c5.png)
![image](https://user-images.githubusercontent.com/77577746/213863877-ded9773e-15b3-4839-b9a9-e54b35c3d2d5.png)
