### PR TITLE
fix(lyrics-plus): inject Translator lib when translate option is enabled

### DIFF
--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -88,6 +88,8 @@ const OptionsMenu = react.memo(({ options, onSelect, selected, defaultValue, bol
 const TranslationMenu = react.memo(({ showTranslationButton, translatorLoaded, isJapanese, hasNeteaseTranslation }) => {
 	if (!showTranslationButton) return null;
 
+	let translator = new Translator();
+
 	let menuOptions = null;
 	if (isJapanese) {
 		menuOptions = {
@@ -111,7 +113,7 @@ const TranslationMenu = react.memo(({ showTranslationButton, translatorLoaded, i
 				Spicetify.ReactComponent.Menu,
 				{},
 				react.createElement("h3", null, " Conversions"),
-				translatorLoaded || !isJapanese
+				translatorLoaded || isJapanese
 					? react.createElement(OptionList, {
 							items: [
 								{
@@ -134,6 +136,8 @@ const TranslationMenu = react.memo(({ showTranslationButton, translatorLoaded, i
 								CONFIG.visual[name] = value;
 								localStorage.setItem(`${APP_NAME}:visual:${name}`, value);
 								lyricContainerUpdate && lyricContainerUpdate();
+								CONFIG.visual[name] ? Spicetify.showNotification("Translating...", false, 500) : null;
+								translator.includeExternal("inject");
 							}
 					  })
 					: react.createElement(

--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -113,39 +113,32 @@ const TranslationMenu = react.memo(({ showTranslationButton, translatorLoaded, i
 				Spicetify.ReactComponent.Menu,
 				{},
 				react.createElement("h3", null, " Conversions"),
-				translatorLoaded || isJapanese
-					? react.createElement(OptionList, {
-							items: [
-								{
-									desc: "Mode",
-									key: "translation-mode",
-									type: ConfigSelection,
-									options: menuOptions,
-									renderInline: true
-								},
-								{
-									desc: "Convert",
-									key: "translate",
-									type: ConfigSlider,
-									trigger: "click",
-									action: "toggle",
-									renderInline: true
-								}
-							],
-							onChange: (name, value) => {
-								CONFIG.visual[name] = value;
-								localStorage.setItem(`${APP_NAME}:visual:${name}`, value);
-								lyricContainerUpdate && lyricContainerUpdate();
-								CONFIG.visual[name] ? Spicetify.showNotification("Translating...", false, 500) : null;
-								translator.includeExternal("inject");
-							}
-					  })
-					: react.createElement(
-							"div",
-							null,
-							react.createElement("p1", null, "Loading"),
-							react.createElement("div", { class: "lyrics-translation-spinner" }, "")
-					  )
+				react.createElement(OptionList, {
+					items: [
+						{
+							desc: "Mode",
+							key: "translation-mode",
+							type: ConfigSelection,
+							options: menuOptions,
+							renderInline: true
+						},
+						{
+							desc: "Convert",
+							key: "translate",
+							type: ConfigSlider,
+							trigger: "click",
+							action: "toggle",
+							renderInline: true
+						}
+					],
+					onChange: (name, value) => {
+						CONFIG.visual[name] = value;
+						localStorage.setItem(`${APP_NAME}:visual:${name}`, value);
+						lyricContainerUpdate && lyricContainerUpdate();
+						CONFIG.visual[name] ? Spicetify.showNotification("Translating...", false, 500) : null;
+						translator.injectExternals();
+					}
+				})
 			),
 			trigger: "click",
 			action: "toggle",

--- a/CustomApps/lyrics-plus/Translator.js
+++ b/CustomApps/lyrics-plus/Translator.js
@@ -14,17 +14,17 @@ class Translator {
 	}
 
 	includeExternal(url) {
-		if (url == "inject") {
-			this.includeExternal(kuroshiroPath);
-			this.includeExternal(kuromojiPath);
-			return;
-		}
-		if (!document.querySelector(`script[src="${url}"]`) && CONFIG.visual.translate) {
+		if (CONFIG.visual.translate && !document.querySelector(`script[src="${url}"]`)) {
 			var script = document.createElement("script");
 			script.setAttribute("type", "text/javascript");
 			script.setAttribute("src", url);
 			document.body.appendChild(script);
 		}
+	}
+
+	injectExternals() {
+		this.includeExternal(kuroshiroPath);
+		this.includeExternal(kuromojiPath);
 	}
 
 	/**

--- a/CustomApps/lyrics-plus/Translator.js
+++ b/CustomApps/lyrics-plus/Translator.js
@@ -14,12 +14,17 @@ class Translator {
 	}
 
 	includeExternal(url) {
-		var s = document.createElement("script");
-		s.setAttribute("type", "text/javascript");
-		s.setAttribute("src", url);
-		var nodes = document.getElementsByTagName("*");
-		var node = nodes[nodes.length - 1].parentNode;
-		node.appendChild(s);
+		if (url == "inject") {
+			this.includeExternal(kuroshiroPath);
+			this.includeExternal(kuromojiPath);
+			return;
+		}
+		if (!document.querySelector(`script[src="${url}"]`) && CONFIG.visual.translate) {
+			var script = document.createElement("script");
+			script.setAttribute("type", "text/javascript");
+			script.setAttribute("src", url);
+			document.body.appendChild(script);
+		}
 	}
 
 	/**

--- a/CustomApps/lyrics-plus/style.css
+++ b/CustomApps/lyrics-plus/style.css
@@ -594,18 +594,6 @@ button.switch.small {
 	pointer-events: auto;
 }
 
-.lyrics-translation-spinner {
-	border: 2px solid #cdcdcd;
-	border-top: 3px solid rgba(255, 255, 255, 0);
-	border-radius: 50%;
-	width: 15px;
-	height: 15px;
-	margin-left: 5px;
-	margin-top: 5px;
-	display: inline-block;
-	-webkit-animation: spin 1s linear infinite;
-}
-
 @-webkit-keyframes spin {
 	0% {
 		-webkit-transform: rotate(0deg);

--- a/CustomApps/lyrics-plus/style.css
+++ b/CustomApps/lyrics-plus/style.css
@@ -580,6 +580,7 @@ button.switch.small {
 .lyrics-config-button-container {
 	-webkit-margin-end: 32px;
 	-webkit-box-pack: end;
+	pointer-events: none;
 	bottom: 32px;
 	display: flex;
 	justify-content: flex-end;
@@ -587,6 +588,10 @@ button.switch.small {
 	margin-inline-end: 32px;
 	position: sticky;
 	z-index: 2;
+}
+
+.lyrics-config-button-container > * {
+	pointer-events: auto;
 }
 
 .lyrics-translation-spinner {


### PR DESCRIPTION
Changes:
1. Injects the Translator lib when translate option is enabled
2. injects the lib only once
3. fixed menu condition from `!isJapanese` to `isJapanese`

# Bug specified in `2`
![image](https://user-images.githubusercontent.com/75513645/214333504-2fcadb33-5b35-418a-94a9-80f3a1b3ec01.png)

