### PR TITLE
fix(ContextMenu): fetch sidebar object URI

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -869,6 +869,8 @@ Spicetify.ContextMenu = (function () {
             uris = [props.uri];
         } else if (props.item?.uri) {
             uris = [props.item.uri];
+        } else if (props.reference?.uri) {
+            uris = [props.reference.uri];
         } else {
             return;
         }


### PR DESCRIPTION
Fixes injecting context menu on sidebar playlists
![image](https://user-images.githubusercontent.com/77577746/215048749-56ccc7f6-5482-4b02-8e83-69e44406b929.png)
![image](https://user-images.githubusercontent.com/77577746/215048760-78398016-46da-4722-a343-a59b6f1f5043.png)
