### PR TITLE
fix: patch for `1.2.4`

### DIFF
--- a/CustomApps/new-releases/Card.js
+++ b/CustomApps/new-releases/Card.js
@@ -2,8 +2,8 @@ class Card extends react.Component {
 	constructor(props) {
 		super(props);
 		Object.assign(this, props);
-		this.href = URI.from(this.uri).toURLPath(true);
-		this.artistHref = URI.from(this.artist.uri).toURLPath(true);
+		this.href = URI.fromString(this.uri).toURLPath(true);
+		this.artistHref = URI.fromString(this.artist.uri).toURLPath(true);
 		const uriType = Spicetify.URI.fromString(this.uri)?.type;
 		switch (uriType) {
 			case Spicetify.URI.Type.ALBUM:

--- a/Extensions/bookmark.js
+++ b/Extensions/bookmark.js
@@ -486,7 +486,7 @@
 		const base62 = uri.split(":")[2];
 		const res = await CosmosAsync.get(`https://api.spotify.com/v1/tracks/${base62}`);
 		if (context && uid && Spicetify.URI.isPlaylistV1OrV2(context)) {
-			context = Spicetify.URI.from(context).toURLPath(true) + "?uid=" + uid;
+			context = Spicetify.URI.fromString(context).toURLPath(true) + "?uid=" + uid;
 		}
 		return {
 			uri,

--- a/Extensions/shuffle+.js
+++ b/Extensions/shuffle+.js
@@ -505,7 +505,7 @@ async function initShufflePlus() {
 			} else {
 				let uriObj = Spicetify.URI.fromString(rawUri);
 				type = uriObj.type;
-				uri = uriObj._base62Id;
+				uri = uriObj._base62Id ?? uriObj.id;
 
 				switch (type) {
 					case Type.PLAYLIST:

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -275,7 +275,7 @@ if (!Spicetify.URI) Spicetify.URI = {};
         const funcName = type
             .toLowerCase()
             .split("_")
-            .map((word) => word[0].toUpperCase() + word.slice(1).toLowerCase())
+            .map((word) => word[0].toUpperCase() + word.slice(1))
             .join("");
         Spicetify.URI[`is${funcName}`] = (uri) => {
             const uriObj = Spicetify.URI.from?.(uri) ?? Spicetify.URI.fromString?.(uri);

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -170,7 +170,7 @@ const Spicetify = {
         let count = SPICETIFY_METHOD.length;
         SPICETIFY_METHOD.forEach((method) => {
             if (Spicetify[method] === undefined || Spicetify[method] === null) {
-                console.error(`Spicetify.${method} is not available. Please open an issue in Spicetify repository to inform me about it.`)
+                console.error(`Spicetify.${method} is not available. Please open an issue in the Spicetify repository to inform us about it.`)
                 count--;
             }
         })
@@ -179,7 +179,7 @@ const Spicetify = {
         count = PLAYER_METHOD.length;
         PLAYER_METHOD.forEach((method) => {
             if (Spicetify.Player[method] === undefined || Spicetify.Player[method] === null) {
-                console.error(`Spicetify.Player.${method} is not available. Please open an issue in Spicetify repository to inform me about it.`)
+                console.error(`Spicetify.Player.${method} is not available. Please open an issue in the Spicetify repository to inform us about it.`)
                 count--;
             }
         })
@@ -188,7 +188,7 @@ const Spicetify = {
         count = REACT_COMPONENT.length;
         REACT_COMPONENT.forEach((method) => {
             if (Spicetify.ReactComponent[method] === undefined || Spicetify.ReactComponent[method] === null) {
-                console.error(`Spicetify.ReactComponent.${method} is not available. Please open an issue in Spicetify repository to inform me about it.`)
+                console.error(`Spicetify.ReactComponent.${method} is not available. Please open an issue in the Spicetify repository to inform us about it.`)
                 count--;
             }
         })

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -110,7 +110,9 @@ const Spicetify = {
             "getFontStyle",
             "_fontStyle",
             "Config",
-            "expFeatureOverride"
+            "expFeatureOverride",
+            "createInternalMap",
+            "RemoteConfigResolver"
         ];
 
         const PLAYER_METHOD = [
@@ -151,6 +153,20 @@ const Spicetify = {
             "playUri"
         ]
 
+        const REACT_COMPONENT = [
+            "RightClickMenu",
+            "ContextMenu",
+            "Menu",
+            "MenuItem",
+            "AlbumMenu",
+            "PodcastShowMenu",
+            "ArtistMenu",
+            "PlaylistMenu",
+            "TooltipWrapper",
+            "TextComponent",
+            "IconComponent"
+        ]
+
         let count = SPICETIFY_METHOD.length;
         SPICETIFY_METHOD.forEach((method) => {
             if (Spicetify[method] === undefined || Spicetify[method] === null) {
@@ -169,6 +185,15 @@ const Spicetify = {
         })
         console.log(`${count}/${PLAYER_METHOD.length} Spicetify.Player methods and objects are OK.`)
 
+        count = REACT_COMPONENT.length;
+        REACT_COMPONENT.forEach((method) => {
+            if (Spicetify.ReactComponent[method] === undefined || Spicetify.ReactComponent[method] === null) {
+                console.error(`Spicetify.ReactComponent.${method} is not available. Please open an issue in Spicetify repository to inform me about it.`)
+                count--;
+            }
+        })
+        console.log(`${count}/${REACT_COMPONENT.length} Spicetify.ReactComponent methods and objects are OK.`)
+
         Object.keys(Spicetify).forEach(key => {
             if(!SPICETIFY_METHOD.includes(key)) {
                 console.log(`Spicetify method ${key} exists but is not in the method list. Consider adding it.`)
@@ -178,6 +203,12 @@ const Spicetify = {
         Object.keys(Spicetify.Player).forEach(key => {
             if(!PLAYER_METHOD.includes(key)) {
                 console.log(`Spicetify.Player method ${key} exists but is not in the method list. Consider adding it.`)
+            }
+        })
+
+        Object.keys(Spicetify.ReactComponent).forEach(key => {
+            if(!REACT_COMPONENT.includes(key)) {
+                console.log(`Spicetify.ReactComponent method ${key} exists but is not in the method list. Consider adding it.`)
             }
         })
     }
@@ -225,13 +256,36 @@ const Spicetify = {
 
 Spicetify.getAudioData = async (uri) => {
     uri = uri || Spicetify.Player.data.track.uri;
-    const uriObj = Spicetify.URI.from(uri);
-    if (!uriObj && uriObj.Type !== Spicetify.URI.Type.TRACK) {
+    const uriObj = Spicetify.URI.from?.(uri) ?? Spicetify.URI.fromString?.(uri);
+    if (!uriObj || (uriObj.Type || uriObj.type) !== Spicetify.URI.Type.TRACK) {
         throw "URI is invalid.";
     }
 
-    return await Spicetify.CosmosAsync.get(`wg://audio-attributes/v1/audio-analysis/${uriObj.getBase62Id()}`)
+    return await Spicetify.CosmosAsync.get(`wg://audio-attributes/v1/audio-analysis/${uriObj.getBase62Id?.() ?? uriObj.id}?format=json`);
 }
+
+if (!Spicetify.URI) Spicetify.URI = {};
+(function appendValidationFunc() {
+    if (!Spicetify.URI.Type) {
+        setTimeout(appendValidationFunc, 10);
+        return;
+    }
+    if (Spicetify.URI.isTrack) return;
+    for (const type in Spicetify.URI.Type) {
+        const funcName = type
+            .toLowerCase()
+            .split("_")
+            .map((word) => word[0].toUpperCase() + word.slice(1).toLowerCase())
+            .join("");
+        Spicetify.URI[`is${funcName}`] = (uri) => {
+            const uriObj = Spicetify.URI.from?.(uri) ?? Spicetify.URI.fromString?.(uri);
+            if (!uriObj) return false;
+            return uriObj.type === Spicetify.URI.Type[type];
+        };
+    }
+})();
+
+
 
 Spicetify.colorExtractor = async (uri) => {
     const body = await Spicetify.CosmosAsync.get(`wg://colorextractor/v1/extract-presets?uri=${uri}&format=json`);

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -283,6 +283,9 @@ if (!Spicetify.URI) Spicetify.URI = {};
             return uriObj.type === Spicetify.URI.Type[type];
         };
     }
+    Spicetify.URI.isPlaylistV1OrV2 = (uri) => {
+        return Spicetify.URI.isPlaylist(uri) || Spicetify.URI.isPlaylistV2(uri);
+    };
 })();
 
 

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -351,19 +351,19 @@ Spicetify.React.useEffect(() => {
 	// React Component: Album Context Menu items
 	utils.Replace(
 		&input,
-		`(\w+)(=\w+[()]*\.memo\(\((?:function\([{\w\d}:=!,]+\)|\()?\{(?:\w+ ?[\w{}()=,:]*)?(?:[\w=.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w=().,]*;?(?:return ?|=>)[\w$.,()]+\([\w.]+,\{value:"album")`,
+		`(\w+)(=\w+[()]*\.memo\(\((?:function\([{\w}=!:,]+\)|\()?\{(?:\w+ ?[\w{}()=,:]*)?(?:[\w=.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w:!=&(){}., ]*;?(?:return ?|=>)[\w$.,()]+\([\w.]+,\{value:"album")`,
 		`${1}=Spicetify.ReactComponent.AlbumMenu${2}`)
 
 	// React Component: Show Context Menu items
 	utils.Replace(
 		&input,
-		`(\w+)(=\w+[()]*\.memo\(\((?:function[(){\w}:,]+|\()?\{(?:\w+ ?[\w{}()=,:.!]*)?(?:[\w=.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w=().,]*;?(?:return ?|=>)[\w$.,()]+\([\w.]+,\{value:"show")`,
+		`(\w+)(=\w+[()]*\.memo\(\((?:function\([{\w}=!:,]+\)|\()?\{(?:\w+ ?[\w{}()=,:]*)?(?:[\w=.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w:!=&(){}., ]*;?(?:return ?|=>)[\w$.,()]+\([\w.]+,\{value:"show")`,
 		`${1}=Spicetify.ReactComponent.PodcastShowMenu${2}`)
 
 	// React Component: Artist Context Menu items
 	utils.Replace(
 		&input,
-		`(\w+)(=\w+[()]*\.memo\(\((?:function\([{\w\d}=!:,]+\)|\()?\{(?:\w+ ?[\w{}()=,:]*)?(?:[\w=.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w=().,]*;?(?:return ?|=>)[\w$.,()]+\([\w.]+,\{value:"artist")`,
+		`(\w+)(=\w+[()]*\.memo\(\((?:function\([{\w}=!:,]+\)|\()?\{(?:\w+ ?[\w{}()=,:]*)?(?:[\w=.]*(?:uri|sharingInfo|onRemoveCallback)[:\w]*,?)*[\w:!=&(){}., ]*;?(?:return ?|=>)[\w$.,()]+\([\w.]+,\{value:"artist")`,
 		`${1}=Spicetify.ReactComponent.ArtistMenu${2}`)
 
 	// React Component: Playlist Context Menu items
@@ -399,6 +399,17 @@ func exposeAPIs_vendor(input string) string {
 		&input,
 		`,(\w+)\.prototype\.toAppType`,
 		`,(globalThis.Spicetify.URI=${1})${0}`)
+
+	// URI after 1.2.4
+	utils.Replace(
+		&input,
+		`([\w$_]+)(=\{AD:"ad")`,
+		`${1}=Spicetify.URI.Type${2}`)
+
+	utils.Replace(
+		&input,
+		`function ([\w_$]+)\([\w,]+\)\{[\w&?!,;(){}= .]+[\w_$]\.allowedTypes`,
+		`Spicetify.URI.fromString=${1};${0}`)
 
 	// Mousetrap
 	utils.Replace(

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -401,15 +401,17 @@ func exposeAPIs_vendor(input string) string {
 		`,(globalThis.Spicetify.URI=${1})${0}`)
 
 	// URI after 1.2.4
-	utils.Replace(
-		&input,
-		`([\w$_]+)(=\{AD:"ad")`,
-		`${1}=Spicetify.URI.Type${2}`)
+	if !strings.Contains(input, "Spicetify.URI") {
+		utils.Replace(
+			&input,
+			`([\w$_]+)(=\{AD:"ad")`,
+			`${1}=Spicetify.URI.Type${2}`)
 
-	utils.Replace(
-		&input,
-		`function ([\w_$]+)\([\w,]+\)\{[\w&?!,;(){}= .]+[\w_$]\.allowedTypes`,
-		`Spicetify.URI.fromString=${1};${0}`)
+		utils.Replace(
+			&input,
+			`function ([\w_$]+)\([\w,]+\)\{[\w&?!,;(){}= .]+[\w_$]\.allowedTypes`,
+			`Spicetify.URI.fromString=${1};${0}`)
+	}
 
 	// Mousetrap
 	utils.Replace(


### PR DESCRIPTION
Compatibility patch for Spotify `1.2.4` (im tired)
Listed changes/breaks & fixes:
- Spotify removed the `URI` method and broke it down to several small components/hooks. This patch aims to inject frequently used methods of the `URI` class and creates a backwards-compatible method for extensions/custom apps.
![image](https://user-images.githubusercontent.com/77577746/215302644-dc549c17-e842-4f2d-8158-cd3d45011f2e.png)

- Added `ReactComponent` to the list of properties to test using `Spicetify.test` for ease of debugging
- Fixed hooks for sub menu components
![image](https://user-images.githubusercontent.com/77577746/215302498-89364fc9-03b9-45c5-bb1f-e029a35186ce.png)

Works on `1.1.90` and higher, have not tested below.