### PR TITLE
ci(github/workflows): add Winget Releaser

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,21 +97,29 @@ jobs:
         with:
           url: http://vps.itsmeow.dev:8079/
           method: GET
-      - name: Extract version
-        id: extract-version
-        run: |
-          echo "tag_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Update Homebrew tap
         uses: mislav/bump-homebrew-formula-action@v2
-        if: "!contains(github.ref, '-')"
+        if: "!contains(github.ref_name, '-')"
         with:
           formula-name: spicetify-cli
           formula-path: spicetify-cli.rb
           homebrew-tap: spicetify/homebrew-tap
-          tag-name: ${{ env.tag_name }}
+          tag-name: ${{ github.ref_name }}
           base-branch: main
-          download-url: https://github.com/spicetify/spicetify-cli/archive/${{ env.tag_name }}.tar.gz
+          download-url: https://github.com/spicetify/spicetify-cli/archive/${{ github.ref_name }}.tar.gz
           commit-message: |
             chore: {{version}} release
         env:
           COMMITTER_TOKEN: ${{ secrets.SPICETIFY_GITHUB_TOKEN }}
+
+  trigger-winget-release:
+    name: Trigger Winget Release
+    runs-on: windows-latest # Action can only run on Windows
+    needs: release
+    steps:
+      - name: Update Winget package
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: Spicetify.Spicetify
+          installers-regex: '-windows-\w+\.zip$'
+          token: ${{ secrets.SPICETIFY_GITHUB_TOKEN }}


### PR DESCRIPTION
- See #708 

[This action](https://github.com/vedantmgoyal2009/winget-releaser) automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

**Before merging this:**
1. Ensure `SPICETIFY_GITHUB_TOKEN` has the `public_repo` scope.

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @spicetify. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.

You can test out the action inputs in this [playground](https://bittu.eu.org/docs/wr-playground).

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been automatically created using 🛫 WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+automatically+created+using+%F0%9F%9B%AB+WinGet+Releaser).