### PR TITLE
fix(webnowplaying): remove extra space in ws message

### DIFF
--- a/Extensions/webnowplaying.js
+++ b/Extensions/webnowplaying.js
@@ -125,7 +125,7 @@
 		let sendData;
 
 		ws.onopen = () => {
-			ws.send("PLAYER: Spotify Desktop");
+			ws.send("PLAYER:Spotify Desktop");
 			currState = 1;
 			currentMusicInfo = {};
 			sendData = setInterval(updateInfo, 500);


### PR DESCRIPTION
In the WebNowPlaying browser extension, they just concatenate 'PLAYER:' with the name of the player. So they do 'ws.send("PLAYER:" + currPlayer);'. Therefore, youtube.com returns '`Youtube`' to my measure in rainmeter, but spicetify returns:
'` Spotify Desktop`'.