### PR TITLE
ci(github/workflows): fix Winget Releaser token error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,4 +122,4 @@ jobs:
         with:
           identifier: Spicetify.Spicetify
           installers-regex: '-windows-\w+\.zip$'
-          token: ${{ secrets.SPICETIFY_GITHUB_TOKEN }}
+          token: ${{ secrets.SPICETIFY_GITHUB_CLASSIC_TOKEN }}


### PR DESCRIPTION
Assuming from https://github.com/spicetify/spicetify-cli/pull/2147#issuecomment-1445362588, `SPICETIFY_GITHUB_TOKEN` seems to be a fine-grained token which is not supported by Winget Releaser yet (https://github.com/spicetify/spicetify-cli/pull/2147#issuecomment-1445363259).

To fix this, please create a **classic** token named `SPICETIFY_GITHUB_CLASSIC_TOKEN` with the `public_repo` scope. Thanks!
![image](https://user-images.githubusercontent.com/56180050/221414583-cd3b4654-d1b2-4cba-a771-6642a67b2d78.png)
