### PR TITLE
fix(workflows/winget): use new token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,4 +122,4 @@ jobs:
         with:
           identifier: Spicetify.Spicetify
           installers-regex: '-windows-\w+\.zip$'
-          token: ${{ secrets.SPICETIFY_GITHUB_TOKEN }}
+          token: ${{ secrets.SPICETIFY_WINGET_TOKEN }}


### PR DESCRIPTION
This token should only be used for this as it only has the `public_repo` scope.