### PR TITLE
fix(jsWrapper): removeItem() and register()

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -771,7 +771,7 @@ Spicetify.Menu = (function() {
             this._items.add(item);
         }
         removeItem(item) {
-            this._items.remove(item);
+            this._items.delete(item);
         }
 
         register() {
@@ -852,7 +852,7 @@ Spicetify.ContextMenu = (function () {
             this._items.add(item);
         }
         removeItem(item) {
-            this._items.remove(item);
+            this._items.delete(item);
         }
 
         set disabled(bool) {
@@ -873,7 +873,7 @@ Spicetify.ContextMenu = (function () {
             itemList.add(this);
         }
         deregister() {
-            itemList.remove(this);
+            itemList.delete(this);
         }
     }
 


### PR DESCRIPTION
Removing Menu and ContextMenu items and derigstering context items did not work because `remove is not a function` which is correct since `this._items` and `itemList` are both `Set`s which do not have a remove, only a `delete` function.

This fixes the following code:
```js
let m = new Spicetify.ContextMenu.SubMenu("my-context_menu", [],  () => true)
m.register()
m.deregister()
```

Before this patch:
```
Uncaught (in promise) TypeError: itemList.remove is not a function
    at SubMenu.deregister (spicetifyWrapper.js:876:22)
    at main (tagify.js:42:7)
    at async tagify.js:80:5
``` 
And the context menu item is shown: 
![grafik](https://user-images.githubusercontent.com/10383737/222731200-59c000b2-05d0-434f-8874-a439b35063d0.png)


After this patch:
The context menu item is removed as expected