### PR TITLE
fix(home-config): patch for v2

### DIFF
--- a/jsHelper/homeConfig.js
+++ b/jsHelper/homeConfig.js
@@ -9,8 +9,10 @@ SpicetifyHomeConfig = {};
 	let list;
 	// Store sections' statuses
 	const statusDic = {};
+	let mounted = false;
 
 	SpicetifyHomeConfig.arrange = function (sections) {
+		mounted = true;
 		if (list) {
 			return list;
 		}
@@ -18,20 +20,20 @@ SpicetifyHomeConfig = {};
 		const lowList = (localStorage.getItem("spicetify-home-config:low") || "").split(",");
 		let stickSections = [];
 		let lowSections = [];
-		for (const id of stickList) {
-			const index = sections.findIndex(a => a?.id === id);
+		for (const uri of stickList) {
+			const index = sections.findIndex(a => a?.uri === uri);
 			if (index !== -1) {
 				const item = sections[index];
-				statusDic[item.id] = STICKY;
+				statusDic[item.uri] = STICKY;
 				stickSections.push(item);
 				sections[index] = undefined;
 			}
 		}
-		for (const id of lowList) {
-			const index = sections.findIndex(a => a?.id === id);
+		for (const uri of lowList) {
+			const index = sections.findIndex(a => a?.uri === uri);
 			if (index !== -1) {
 				const item = sections[index];
-				statusDic[item.id] = LOWERED;
+				statusDic[item.uri] = LOWERED;
 				lowSections.push(item);
 				sections[index] = undefined;
 			}
@@ -80,25 +82,25 @@ SpicetifyHomeConfig = {};
 	function injectInteraction() {
 		const main = document.querySelector(".main-home-content");
 		elem = [...main.querySelectorAll("section")];
-		elem.forEach((item, index) => (item.dataset.id = list[index].id));
+		elem.forEach((item, index) => (item.dataset.uri = list[index].uri));
 
 		function appendItems() {
 			const stick = [],
 				low = [],
 				normal = [];
 			for (const el of elem) {
-				if (statusDic[el.dataset.id] === STICKY) stick.push(el);
-				else if (statusDic[el.dataset.id] === LOWERED) low.push(el);
+				if (statusDic[el.dataset.uri] === STICKY) stick.push(el);
+				else if (statusDic[el.dataset.uri] === LOWERED) low.push(el);
 				else normal.push(el);
 			}
 
 			localStorage.setItem(
 				"spicetify-home-config:stick",
-				stick.map(a => a.dataset.id)
+				stick.map(a => a.dataset.uri)
 			);
 			localStorage.setItem(
 				"spicetify-home-config:low",
-				low.map(a => a.dataset.id)
+				low.map(a => a.dataset.uri)
 			);
 
 			elem = [...stick, ...normal, ...low];
@@ -118,24 +120,26 @@ SpicetifyHomeConfig = {};
 
 		function onChangeStatus(item, status) {
 			container.remove();
-			const isToggle = statusDic[item.dataset.id] === status;
-			statusDic[item.dataset.id] = isToggle ? NORMAL : status;
+			const isToggle = statusDic[item.dataset.uri] === status;
+			statusDic[item.dataset.uri] = isToggle ? NORMAL : status;
 			appendItems();
 		}
 
 		elem.forEach(el => {
 			el.onmouseover = () => {
-				const status = statusDic[el.dataset.id];
+				const status = statusDic[el.dataset.uri];
 				const index = elem.findIndex(a => a === el);
 
-				if (!status || index === 0 || status !== statusDic[elem[index - 1]?.dataset.id]) {
+				console.log(status, index, statusDic);
+
+				if (!status || index === 0 || status !== statusDic[elem[index - 1]?.dataset.uri]) {
 					up.disabled = true;
 				} else {
 					up.disabled = false;
 					up.onclick = () => onSwap(el, -1);
 				}
 
-				if (!status || index === elem.length - 1 || status !== statusDic[elem[index + 1]?.dataset.id]) {
+				if (!status || index === elem.length - 1 || status !== statusDic[elem[index + 1]?.dataset.uri]) {
 					down.disabled = true;
 				} else {
 					down.disabled = false;
@@ -170,4 +174,23 @@ SpicetifyHomeConfig = {};
 		menu.isEnabled = false;
 		menu.deregister();
 	};
+
+	(function waitForHistoryAPI() {
+		if (!Spicetify.Platform?.History || !mounted) {
+			setTimeout(waitForHistoryAPI, 100);
+			return;
+		}
+		// Init
+		if (Spicetify.Platform.History.location.pathname === "/") {
+			SpicetifyHomeConfig.addToMenu();
+		}
+
+		Spicetify.Platform.History.listen(({ pathname }) => {
+			if (pathname === "/") {
+				SpicetifyHomeConfig.addToMenu();
+			} else {
+				SpicetifyHomeConfig.removeMenu();
+			}
+		});
+	})();
 })();

--- a/jsHelper/homeConfig.js
+++ b/jsHelper/homeConfig.js
@@ -130,8 +130,6 @@ SpicetifyHomeConfig = {};
 				const status = statusDic[el.dataset.uri];
 				const index = elem.findIndex(a => a === el);
 
-				console.log(status, index, statusDic);
-
 				if (!status || index === 0 || status !== statusDic[elem[index - 1]?.dataset.uri]) {
 					up.disabled = true;
 				} else {

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -29,7 +29,7 @@ func AdditionalOptions(appsFolderPath string, flags Flag) {
 		filepath.Join(appsFolderPath, "xpui", "index.html"):             htmlMod,
 		filepath.Join(appsFolderPath, "xpui", "xpui.js"):                insertCustomApp,
 		filepath.Join(appsFolderPath, "xpui", "vendor~xpui.js"):         insertExpFeatures,
-		filepath.Join(appsFolderPath, "xpui", "xpui-routes-home.js"):    insertHomeConfig,
+		filepath.Join(appsFolderPath, "xpui", "home-v2.js"):             insertHomeConfig,
 		filepath.Join(appsFolderPath, "xpui", "xpui-desktop-modals.js"): insertVersionInfo,
 	}
 
@@ -318,12 +318,8 @@ func insertHomeConfig(jsPath string, flags Flag) {
 	utils.ModifyFile(jsPath, func(content string) string {
 		utils.ReplaceOnce(
 			&content,
-			`(const \w+=null==\w+\?void 0\:)(\w+\.content\.items)`,
-			`${1}SpicetifyHomeConfig.arrange(${2})`)
-		utils.ReplaceOnce(
-			&content,
-			`;(\(0,\w+\.useEffect\))`,
-			`;${1}(()=>{SpicetifyHomeConfig.addToMenu();return SpicetifyHomeConfig.removeMenu;},[])${0}`)
+			`([\w$\.]+\.sections\.items)(\.map)`,
+			`SpicetifyHomeConfig.arrange(${1})${2}`)
 		return content
 	})
 }

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -318,7 +318,7 @@ func insertHomeConfig(jsPath string, flags Flag) {
 	utils.ModifyFile(jsPath, func(content string) string {
 		utils.ReplaceOnce(
 			&content,
-			`([\w$\.]+\.sections\.items)(\.map)`,
+			`([\w$_\.]+\.sections\.items)(\.map)`,
 			`SpicetifyHomeConfig.arrange(${1})${2}`)
 		return content
 	})


### PR DESCRIPTION
~~This thing has been broken for so long people forgot it existed lol~~
Works on `1.1.90` and higher, broken on `1.1.85` (as in the regex matched but they weren't using `home-v2`), have not tested in between.

`useEffect` implementation for menu item was removed because in some specific versions the `useEffect` hook was not present in the file.
![Spotify_wUfFkolFF6](https://user-images.githubusercontent.com/77577746/223393275-b1114972-1709-4a1f-ad2f-bf205a6d7f88.gif)
