### PR TITLE
feat: Add Marketplace version to "About Spotify" dialog

### DIFF
--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -362,6 +362,7 @@ func insertVersionInfo(jsPath string, flags Flag) {
 				${1}("li",{children: "Theme: " + Spicetify.Config.current_theme + (Spicetify.Config.color_scheme && " / ") + Spicetify.Config.color_scheme}),
 				${1}("li",{children: "Extensions: " + Spicetify.Config.extensions.join(", ")}),
 				${1}("li",{children: "Custom apps: " + Spicetify.Config.custom_apps.join(", ")}),
+				${1}("li",{children: "Marketplace: " + Marketplace ? Marketplace.version : "Not installed"}),
 				]}),`)
 		return content
 	})


### PR DESCRIPTION
This is up for discussion, if we want to intrgrate Marketplace into the CLI at all. I don't think this is super integrate-y in general, just makes more sense to have it as a part of the built-in about dialog instead of having to add an event listener or mutation observer or something (which we'd need to do if implemented via Marketplace itself) and adding extra overhead to Marketplace. 

As a note, I haven't tested this, as I don't know how to compile the project etc. Just looked at the code and modified how I figure it would work. Would be good to have someone actually test it before merging if that's what we decide to do. 

This would resolve https://github.com/spicetify/spicetify-marketplace/issues/457