### PR TITLE
perf(lyrics-plus): disable conversion by default

### DIFF
--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -48,7 +48,7 @@ const CONFIG = {
 		["font-size"]: localStorage.getItem("lyrics-plus:visual:font-size") || "32",
 		["translation-mode:japanese"]: localStorage.getItem("lyrics-plus:visual:translation-mode:japanese") || "furigana",
 		["translation-mode:chinese"]: localStorage.getItem("lyrics-plus:visual:translation-mode:chinese") || "cn",
-		["translate"]: getConfig("lyrics-plus:visual:translate"),
+		["translate"]: localStorage.getItem("lyrics-plus:visual:translate") || false,
 		["ja-detect-threshold"]: localStorage.getItem("lyrics-plus:visual:ja-detect-threshold") || "40",
 		["hans-detect-threshold"]: localStorage.getItem("lyrics-plus:visual:hans-detect-threshold") || "40",
 		["fade-blur"]: getConfig("lyrics-plus:visual:fade-blur"),

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -48,7 +48,7 @@ const CONFIG = {
 		["font-size"]: localStorage.getItem("lyrics-plus:visual:font-size") || "32",
 		["translation-mode:japanese"]: localStorage.getItem("lyrics-plus:visual:translation-mode:japanese") || "furigana",
 		["translation-mode:chinese"]: localStorage.getItem("lyrics-plus:visual:translation-mode:chinese") || "cn",
-		["translate"]: localStorage.getItem("lyrics-plus:visual:translate") || false,
+		["translate"]: getConfig("lyrics-plus:visual:translate", false),
 		["ja-detect-threshold"]: localStorage.getItem("lyrics-plus:visual:ja-detect-threshold") || "40",
 		["hans-detect-threshold"]: localStorage.getItem("lyrics-plus:visual:hans-detect-threshold") || "40",
 		["fade-blur"]: getConfig("lyrics-plus:visual:fade-blur"),


### PR DESCRIPTION
Lyrics have been severely slow to load since the Japanese & Chinese text conversion option patch. Of course, if you disable the conversion option, it loads quickly, but I think you'd better disable the default value of the conversion option for those who don't listen to that music.