### PR TITLE
fix(popupLyrics): providers change fix

### DIFF
--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -270,13 +270,13 @@ function PopupLyrics() {
 			musixmatch: {
 				on: boolLocalStorage("popup-lyrics:services:musixmatch:on"),
 				call: LyricProviders.fetchMusixmatch,
-				desc: `Fully compatible with Spotify. Requires a token that can be retrieved from the official Musixmatch app. Follow instructions on <a href="https://github.com/khanhas/spicetify-cli/wiki/Musixmatch-Token">spicetify Wiki</a>.`,
+				desc: `Fully compatible with Spotify. Requires a token that can be retrieved from the official Musixmatch app. Follow instructions on <a href="https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work">Spicetify Docs</a>.`,
 				token: LocalStorage.get("popup-lyrics:services:musixmatch:token") || "2005218b74f939209bda92cb633c7380612e14cb7fe92dcd6a780f"
 			},
 			spotify: {
 				on: boolLocalStorage("popup-lyrics:services:spotify:on"),
 				call: LyricProviders.fetchSpotify,
-				desc: `Lyrics officially provided by Spotify. Only available for some regions/countries' users (e.g., Japan, Vietnam, Thailand).`
+				desc: `Lyrics sourced from official Spotify API.`
 			}
 		},
 		servicesOrder: []

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -391,7 +391,7 @@ function PopupLyrics() {
 				const data = await service.call(info);
 				console.log(data);
 				sharedData = data;
-				if (sharedData.error == null) {
+				if (!sharedData.error) {
 					return;
 				}
 			} catch (err) {

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -382,24 +382,21 @@ function PopupLyrics() {
 			uri: Player.data.track.uri
 		};
 
-		sharedData = { lyrics: [] };
-		let error = null;
-
 		for (let name of userConfigs.servicesOrder) {
 			const service = userConfigs.services[name];
 			if (!service.on) continue;
+			sharedData = { lyrics: [] };
 
 			try {
 				const data = await service.call(info);
 				console.log(data);
 				sharedData = data;
-				return;
+				if (sharedData.error == null) {
+					return;
+				}
 			} catch (err) {
-				error = err;
+				sharedData = { error: "No lyrics" };
 			}
-		}
-		if (error || !sharedData.lyrics) {
-			sharedData = { error: "No lyrics" };
 		}
 	}
 


### PR DESCRIPTION
This is a bug that's been around for a long time. Providers in popupLyrics failed to switch normally. For example, if you get an error while looking for the lyrics for musixmatch, even if netase was enabled, the transition was not possible. Additionally, the desc of the providers has been modified to be the same as lyrics-plus.
![Desktop Screenshot 2023 03 27 - 02 11 55 17](https://user-images.githubusercontent.com/91320047/227792711-80dc6954-a4fc-4196-b25f-1682e5da5951.png)
![Desktop Screenshot 2023 03 27 - 02 14 28 69](https://user-images.githubusercontent.com/91320047/227792715-f701ff35-6af9-4f10-b6a4-e9040cefb8ea.png)
