### PR TITLE
feat: lyrics app improvement

### DIFF
--- a/CustomApps/lyrics-plus/ProviderMusixmatch.js
+++ b/CustomApps/lyrics-plus/ProviderMusixmatch.js
@@ -1,8 +1,4 @@
 const ProviderMusixmatch = (function () {
-	const headers = {
-		authority: "apic-desktop.musixmatch.com",
-		cookie: "x-mxm-token-guid="
-	};
 
 	async function findLyrics(info) {
 		const baseURL = `https://apic-desktop.musixmatch.com/ws/1.1/macro.subtitles.get?format=json&namespace=lyrics_richsynched&subtitle_format=mxm&app_id=web-desktop-app-v1.0&`;
@@ -28,7 +24,10 @@ const ProviderMusixmatch = (function () {
 				.map(key => key + "=" + encodeURIComponent(params[key]))
 				.join("&");
 
-		let body = await CosmosAsync.get(finalURL, null, headers);
+		let body = await CosmosAsync.get(finalURL, null, {
+			authority: "apic-desktop.musixmatch.com",
+			cookie: "x-mxm-token-guid="
+		});
 
 		body = body.message.body.macro_calls;
 

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -66,7 +66,7 @@ const CONFIG = {
 		musixmatch: {
 			on: getConfig("lyrics-plus:provider:musixmatch:on"),
 			desc: `Fully compatible with Spotify. Requires a token that can be retrieved from the official Musixmatch app. Follow instructions on <a href="https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work">Spicetify Docs</a>.`,
-			token: localStorage.getItem("lyrics-plus:provider:musixmatch:token") || "21051986b9886beabe1ce01c3ce94c96319411f8f2c122676365e3",
+			token: localStorage.getItem("lyrics-plus:provider:musixmatch:token") || "2005218b74f939209bda92cb633c7380612e14cb7fe92dcd6a780f|2211116e5392cee08db76d4ce398786a1f2d7ba5c12a6184f28d46",
 			modes: [SYNCED, UNSYNCED]
 		},
 		spotify: {
@@ -183,7 +183,7 @@ class LyricsContainer extends react.Component {
 			const colors = await CosmosAsync.get(`wg://colorextractor/v1/extract-presets?uri=${uri}&format=json`);
 			prominent = colors.entries[0].color_swatches[4].color;
 		} catch {
-			prominent = 0;
+			prominent = 8747370;
 		}
 
 		this.setState({

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -100,6 +100,8 @@ function PopupLyrics() {
 			const baseURL = `https://apic-desktop.musixmatch.com/ws/1.1/macro.subtitles.get?format=json&namespace=lyrics_synched&subtitle_format=mxm&app_id=web-desktop-app-v1.0&`;
 
 			const durr = info.duration / 1000;
+			const tokens = userConfigs.services.musixmatch.token.split("|");
+			const usertoken = tokens[Math.floor(Math.random() * tokens.length)];
 
 			const params = {
 				q_album: info.album,
@@ -109,7 +111,7 @@ function PopupLyrics() {
 				track_spotify_id: info.uri,
 				q_duration: durr,
 				f_subtitle_length: Math.floor(durr),
-				usertoken: userConfigs.services.musixmatch.token
+				usertoken
 			};
 
 			const finalURL =
@@ -271,7 +273,7 @@ function PopupLyrics() {
 				on: boolLocalStorage("popup-lyrics:services:musixmatch:on"),
 				call: LyricProviders.fetchMusixmatch,
 				desc: `Fully compatible with Spotify. Requires a token that can be retrieved from the official Musixmatch app. Follow instructions on <a href="https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work">Spicetify Docs</a>.`,
-				token: LocalStorage.get("popup-lyrics:services:musixmatch:token") || "2005218b74f939209bda92cb633c7380612e14cb7fe92dcd6a780f"
+				token: LocalStorage.get("popup-lyrics:services:musixmatch:token") || "2005218b74f939209bda92cb633c7380612e14cb7fe92dcd6a780f|2211116e5392cee08db76d4ce398786a1f2d7ba5c12a6184f28d46"
 			},
 			spotify: {
 				on: boolLocalStorage("popup-lyrics:services:spotify:on"),


### PR DESCRIPTION
first:
Modified the default musixmatch tokens for lyrics-plus and popupLyrics. The "popupLyrics" token `2005218b74f939209bda92cb633c7380612e14cb7fe92dcd6a780f` works, but the token lyrics-plus token `21051986b9886beabe1ce01c3ce94c96319411f8f2c122676365e3` does not seem to work properly.
This reduced the frequency of captcha error.

We applied two tokens, the existing token `2005218b74f939209bda92cb633c7380612e14cb7fe92dcd6a780f `and the newly issued token `22111116e5392ce08db76d4ce398786a1f2d7ba5c12a6184f28d46`

second:
Modified the default background color code for lyrics-plus to `8747370` If you turn on the colorful background option in "yrics-plus and look at the lyrics of the local music, it's too dark to see. If you have a better color, you can modify it.

before
![Desktop Screenshot 2023 03 27 - 15 13 26 33](https://user-images.githubusercontent.com/91320047/227872601-cdcbbb17-04fb-491a-a22b-af531d47d49f.png)

after
![Desktop Screenshot 2023 03 27 - 15 11 15 88](https://user-images.githubusercontent.com/91320047/227872640-dfd33655-6ce1-4c2e-a40d-ac986c107763.png)

