### PR TITLE
feat: add playbar button method

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1043,6 +1043,21 @@ declare namespace Spicetify {
     }
 
     /**
+     * Add button in player controls
+     */
+    namespace Playbar {
+        class Button {
+            constructor(label: string, icon: string, onClick: (self: Button) => void, disabled?: boolean, isEnabled?: boolean);
+            label: string;
+            icon: string;
+            onClick: (self: Button) => void;
+            disabled: boolean;
+            isEnabled: boolean;
+            element: HTMLButtonElement;
+        }
+    }
+
+    /**
      * SVG icons
      */
     namespace SVGIcons {

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1047,12 +1047,12 @@ declare namespace Spicetify {
      */
     namespace Playbar {
         class Button {
-            constructor(label: string, icon: string, onClick: (self: Button) => void, disabled?: boolean, isEnabled?: boolean);
+            constructor(label: string, icon: string, onClick: (self: Button) => void, disabled?: boolean, active?: boolean);
             label: string;
             icon: string;
             onClick: (self: Button) => void;
             disabled: boolean;
-            isEnabled: boolean;
+            active: boolean;
             element: HTMLButtonElement;
         }
     }

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -112,7 +112,8 @@ const Spicetify = {
             "Config",
             "expFeatureOverride",
             "createInternalMap",
-            "RemoteConfigResolver"
+            "RemoteConfigResolver",
+            "Playbar"
         ];
 
         const PLAYER_METHOD = [

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1279,6 +1279,89 @@ Spicetify.Topbar = (function() {
     return { Button };
 })();
 
+Spicetify.Playbar = (function() {
+    let rightContainer;
+    let sibling;
+    const buttonsStash = new Set();
+
+    class Button {
+        constructor(label, icon, onClick, disabled = false, isEnabled = false) {
+            this.element = document.createElement("button");
+            this.element.classList.add("main-genericButton-button");
+            this.label = label;
+            this.icon = icon;
+            this.onClick = onClick;
+            this.disabled = disabled;
+            this.isEnabled = isEnabled;
+            Array.from(sibling?.classList ?? []).forEach((className) => {
+                if (!className.startsWith("main-genericButton")) {
+                    this.element.classList.add(className);
+                }
+            });
+            buttonsStash.add(this.element);
+            rightContainer?.prepend(...buttonsStash);
+        }
+        get label() { return this._label; }
+        set label(text) {
+            this._label = text;
+            this.element.setAttribute("title", text);
+        }
+        get icon() { return this._icon; }
+        set icon(input) {
+            if (input && Spicetify.SVGIcons[input]) {
+                input = `<svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons[input]}</svg>`;
+            }
+            this._icon = input;
+            this.element.innerHTML = input;
+        }
+        get onClick() { return this._onClick; }
+        set onClick(func) {
+            this._onClick = func;
+            this.element.onclick = () => this._onClick(this);
+        }
+        get disabled() { return this._disabled; }
+        set disabled(bool) {
+            this._disabled = bool;
+            this.element.disabled = bool;
+            if (bool) {
+                this.element.classList.add("disabled");
+            } else {
+                this.element.classList.remove("disabled");
+            }
+        }
+        set isEnabled(bool) {
+            this._isEnabled = bool;
+            if (bool) {
+                this.element.classList.add("main-genericButton-buttonActive");
+            } else {
+                this.element.classList.remove("main-genericButton-buttonActive");
+            }
+        }
+        get isEnabled() { return this._isEnabled; }
+    }
+
+    (function waitForPlaybarMounted() {
+        sibling = document.querySelector(".main-nowPlayingBar-right .main-genericButton-button");
+        rightContainer = sibling?.parentElement;
+        if (!rightContainer) {
+            setTimeout(waitForPlaybarMounted, 300);
+            return;
+        }
+        Array.from(sibling?.classList ?? []).forEach((className) => {
+            if (!className.startsWith("main-genericButton")) {
+                buttonsStash.forEach((button) => {
+                    if (!button.classList.contains(className)) {
+                        button.classList.add(className);
+                    }
+                });
+            }
+        });
+        rightContainer.prepend(...buttonsStash);
+    })();
+
+    return { Button };
+})();
+
 (function waitForHistoryAPI() {
     const main = document.querySelector(".main-view-container__scroll-node-child");
     if (!main || !Spicetify.Platform?.History) {

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1350,9 +1350,7 @@ Spicetify.Playbar = (function() {
         Array.from(sibling?.classList ?? []).forEach((className) => {
             if (!className.startsWith("main-genericButton")) {
                 buttonsStash.forEach((button) => {
-                    if (!button.classList.contains(className)) {
-                        button.classList.add(className);
-                    }
+                    button.classList.add(className);
                 });
             }
         });

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1310,7 +1310,7 @@ Spicetify.Playbar = (function() {
         get icon() { return this._icon; }
         set icon(input) {
             if (input && Spicetify.SVGIcons[input]) {
-                input = `<svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons[input]}</svg>`;
+                input = `<svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor" stroke="currentColor">${Spicetify.SVGIcons[input]}</svg>`;
             }
             this._icon = input;
             this.element.innerHTML = input;

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1323,19 +1323,11 @@ Spicetify.Playbar = (function() {
         set disabled(bool) {
             this._disabled = bool;
             this.element.disabled = bool;
-            if (bool) {
-                this.element.classList.add("disabled");
-            } else {
-                this.element.classList.remove("disabled");
-            }
+            this.element.classList.toggle("disabled", bool);
         }
         set active(bool) {
             this._active = bool;
-            if (bool) {
-                this.element.classList.add("main-genericButton-buttonActive");
-            } else {
-                this.element.classList.remove("main-genericButton-buttonActive");
-            }
+            this.element.classList.toggle("main-genericButton-buttonActive", bool);
         }
         get active() { return this._active; }
     }

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1285,14 +1285,14 @@ Spicetify.Playbar = (function() {
     const buttonsStash = new Set();
 
     class Button {
-        constructor(label, icon, onClick, disabled = false, isEnabled = false) {
+        constructor(label, icon, onClick, disabled = false, active = false) {
             this.element = document.createElement("button");
             this.element.classList.add("main-genericButton-button");
             this.label = label;
             this.icon = icon;
             this.onClick = onClick;
             this.disabled = disabled;
-            this.isEnabled = isEnabled;
+            this.active = active;
             Array.from(sibling?.classList ?? []).forEach((className) => {
                 if (!className.startsWith("main-genericButton")) {
                     this.element.classList.add(className);
@@ -1329,15 +1329,15 @@ Spicetify.Playbar = (function() {
                 this.element.classList.remove("disabled");
             }
         }
-        set isEnabled(bool) {
-            this._isEnabled = bool;
+        set active(bool) {
+            this._active = bool;
             if (bool) {
                 this.element.classList.add("main-genericButton-buttonActive");
             } else {
                 this.element.classList.remove("main-genericButton-buttonActive");
             }
         }
-        get isEnabled() { return this._isEnabled; }
+        get active() { return this._active; }
     }
 
     (function waitForPlaybarMounted() {


### PR DESCRIPTION
A lot of extensions seem to rely on adding icons to player controls yet we don't have any conventional method of doing it (surprisingly after years) so here we are
![Spotify_RkGmp9Ffl3](https://user-images.githubusercontent.com/77577746/228444732-a384a885-5ca0-4419-9cf9-8a87e35fe764.gif)
![image](https://user-images.githubusercontent.com/77577746/228543522-84dd89e8-0f2b-4521-9482-39e6e8519f5d.png)
![Spotify_XW7oahmUyb](https://user-images.githubusercontent.com/77577746/228444758-19eeb16a-1867-40e8-b0ca-59315365eeec.png)
