### PR TITLE
feat: add check-update flag

### DIFF
--- a/spicetify.go
+++ b/spicetify.go
@@ -114,10 +114,10 @@ func init() {
 				}
 
 				cmd := exec.Command(ex, cmds...)
-				utils.Scanner(cmd)
+				utils.CmdScanner(cmd)
 
 				cmd = exec.Command(ex, strings.Join(commands[:], " "))
-				utils.Scanner(cmd)
+				utils.CmdScanner(cmd)
 
 				os.Exit(0)
 			}

--- a/spicetify.go
+++ b/spicetify.go
@@ -101,7 +101,7 @@ func init() {
 			liveUpdate = true
 		case "-u", "--update":
 			upgradeStatus := cmd.Upgrade(version)
-			if upgradeStatus != false {
+			if !upgradeStatus {
 				ex, err := os.Executable()
 				if err != nil {
 					ex = "spicetify"

--- a/spicetify.go
+++ b/spicetify.go
@@ -99,7 +99,7 @@ func init() {
 			appFocus = true
 			styleFocus = true
 			liveUpdate = true
-		case "-u", "--update":
+		case "--check-update":
 			upgradeStatus := cmd.Upgrade(version)
 			if upgradeStatus {
 				ex, err := os.Executable()

--- a/spicetify.go
+++ b/spicetify.go
@@ -5,11 +5,14 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/exec"
 	"runtime"
+	"strings"
 	"sync"
 
 	colorable "github.com/mattn/go-colorable"
 	"github.com/spicetify/spicetify-cli/src/cmd"
+	spotifystatus "github.com/spicetify/spicetify-cli/src/status/spotify"
 	"github.com/spicetify/spicetify-cli/src/utils"
 )
 
@@ -96,6 +99,28 @@ func init() {
 			appFocus = true
 			styleFocus = true
 			liveUpdate = true
+		case "-u", "--update":
+			upgradeStatus := cmd.Upgrade(version)
+			if upgradeStatus != false {
+				ex, err := os.Executable()
+				if err != nil {
+					ex = "spicetify"
+				}
+
+				spotStat := spotifystatus.Get(utils.FindAppPath())
+				cmds := []string{"backup", "apply"}
+				if !spotStat.IsBackupable() {
+					cmds = append([]string{"restore"}, cmds...)
+				}
+
+				cmd := exec.Command(ex, cmds...)
+				utils.Scanner(cmd)
+
+				cmd = exec.Command(ex, strings.Join(commands[:], " "))
+				utils.Scanner(cmd)
+
+				os.Exit(0)
+			}
 		}
 	}
 

--- a/spicetify.go
+++ b/spicetify.go
@@ -101,7 +101,7 @@ func init() {
 			liveUpdate = true
 		case "-u", "--update":
 			upgradeStatus := cmd.Upgrade(version)
-			if !upgradeStatus {
+			if upgradeStatus {
 				ex, err := os.Executable()
 				if err != nil {
 					ex = "spicetify"

--- a/src/cmd/upgrade.go
+++ b/src/cmd/upgrade.go
@@ -17,7 +17,7 @@ func Upgrade(currentVersion string) bool {
 	if err != nil {
 		utils.PrintError("Cannot fetch latest release info")
 		utils.PrintError(err.Error())
-		return true
+		return false
 	}
 	utils.PrintGreen("OK")
 

--- a/src/cmd/upgrade.go
+++ b/src/cmd/upgrade.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spicetify/spicetify-cli/src/utils"
 )
 
-func Upgrade(currentVersion string) (bool) {
+func Upgrade(currentVersion string) bool {
 	utils.PrintBold("Fetch latest release info:")
 	tagName, err := utils.FetchLatestTag()
 	if err != nil {

--- a/src/cmd/upgrade.go
+++ b/src/cmd/upgrade.go
@@ -11,13 +11,13 @@ import (
 	"github.com/spicetify/spicetify-cli/src/utils"
 )
 
-func Upgrade(currentVersion string) {
+func Upgrade(currentVersion string) (bool) {
 	utils.PrintBold("Fetch latest release info:")
 	tagName, err := utils.FetchLatestTag()
 	if err != nil {
 		utils.PrintError("Cannot fetch latest release info")
 		utils.PrintError(err.Error())
-		return
+		return true
 	}
 	utils.PrintGreen("OK")
 
@@ -25,7 +25,7 @@ func Upgrade(currentVersion string) {
 	utils.PrintInfo("Latest release: " + tagName)
 	if currentVersion == tagName {
 		utils.PrintSuccess("Already up-to-date.")
-		return
+		return false
 	}
 
 	var assetURL string = "https://github.com/spicetify/spicetify-cli/releases/download/v" + tagName + "/spicetify-" + tagName
@@ -105,6 +105,7 @@ func Upgrade(currentVersion string) {
 	utils.PrintGreen("OK")
 	utils.PrintSuccess("spicetify is up-to-date.")
 	utils.PrintInfo(`Please run "spicetify restore backup apply" to receive new features and bug fixes`)
+	return true
 }
 
 func permissionError(err error) {

--- a/src/utils/scanner.go
+++ b/src/utils/scanner.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+)
+
+func Scanner(cmd *exec.Cmd) {
+	stdout, _ := cmd.StdoutPipe()
+	cmd.Start()
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		m := scanner.Text()
+		fmt.Println(m)
+	}
+	cmd.Wait()
+}

--- a/src/utils/scanner.go
+++ b/src/utils/scanner.go
@@ -6,7 +6,8 @@ import (
 	"os/exec"
 )
 
-func Scanner(cmd *exec.Cmd) {
+// CmdScanner is a helper function to scan output from exec.Cmd
+func CmdScanner(cmd *exec.Cmd) {
 	stdout, _ := cmd.StdoutPipe()
 	cmd.Start()
 


### PR DESCRIPTION
Although this solution partially resolves #2071, we do not intend to implement a fully-fledged auto-update feature due to the potential risk of Spotify causing disruption to Spicetify's functionality at any point. As a result, our solution involves utilizing the `--check-update` flag, which can be added to any command. This allows users to create a shortcut that can update Spicetify prior to launching Spotify