### PR TITLE
feat: expose `Tippy.js` instance

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -2165,5 +2165,8 @@
     "eZnAGhYcXE4Bt0a7958z": "main-useDropTarget-playlistV2",
     "ratGUXdpLCkyXZNaJryg": "main-useDropTarget-show",
     "caTDfb6Oj7a5_8jBLUSo": "main-useDropTarget-track",
-    "aRyoyQFJkzhoSOnf2ERM": "main-useDropTarget-local"
+    "aRyoyQFJkzhoSOnf2ERM": "main-useDropTarget-local",
+    "X8yW2lJbFCQfV5GjoRwL": "main-contextMenu-tippy",
+    "mph1R_QkS44EPi4lrhxd": "main-contextMenu-tippyEnter",
+    "v5IUMJNPJgol0273zQXD": "main-contextMenu-tippyEnterActive"
 }

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1039,6 +1039,7 @@ declare namespace Spicetify {
             onClick: (self: Button) => void;
             disabled: boolean;
             element: HTMLButtonElement;
+            tippy: any;
         }
     }
 
@@ -1054,6 +1055,7 @@ declare namespace Spicetify {
             disabled: boolean;
             active: boolean;
             element: HTMLButtonElement;
+            tippy: any;
         }
     }
 
@@ -1081,4 +1083,14 @@ declare namespace Spicetify {
         const extensions: string[];
         const custom_apps: string[];
     }
+
+    /**
+     * Tippy.js instance used by Spotify
+     */
+    const Tippy: any;
+    /**
+     * Spicetify's predefined props for Tippy.js
+     * Used to mimic Spotify's tooltip behavior
+     */
+    const TippyProps: any;
 }

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -504,6 +504,11 @@ if (${1}.popper?.firstChild?.id === "context-menu") {
 		`(\w+ [\w$_]+)=[\w$_]+\([\w$_]+>>>0\)`,
 		`${1}=Spicetify._getStyledClassName(arguments,this)`)
 
+	utils.Replace(
+		&input,
+		`([\w$_]+)\.setDefaultProps=`,
+		`Spicetify.Tippy=${1};${0}`)
+
 	return input
 }
 


### PR DESCRIPTION
Works on Spotify `1.1.90` and later, have not tested below
Expose `Tippy.js` instance used by Spotify, useful for displaying tooltip on vanilla JS elements, namely `Topbar` and `Playbar`, making it more useful to implement `label` and help with accessibility.
![Spotify_D4OnggQe0E](https://user-images.githubusercontent.com/77577746/228787258-a65fe5e1-aaaf-4780-89cf-9a600bf02556.gif)
![Spotify_HzlxnQxg8R](https://user-images.githubusercontent.com/77577746/228787271-dfa00ca4-6518-4708-a903-c79a922a2d13.gif)
