### PR TITLE
feat(wrapper): add method to hide/show player button

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1048,7 +1048,7 @@ declare namespace Spicetify {
      */
     namespace Playbar {
         class Button {
-            constructor(label: string, icon: string, onClick: (self: Button) => void, disabled?: boolean, active?: boolean);
+            constructor(label: string, icon: string, onClick: (self: Button) => void, disabled?: boolean, active?: boolean, registerOnCreate?: boolean);
             label: string;
             icon: string;
             onClick: (self: Button) => void;
@@ -1056,6 +1056,8 @@ declare namespace Spicetify {
             active: boolean;
             element: HTMLButtonElement;
             tippy: any;
+            register: () => void;
+            deregister: () => void;
         }
     }
 

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1334,7 +1334,7 @@ Spicetify.Playbar = (function() {
     const buttonsStash = new Set();
 
     class Button {
-        constructor(label, icon, onClick, disabled = false, active = false) {
+        constructor(label, icon, onClick, disabled = false, active = false, registerOnCreate = true) {
             this.element = document.createElement("button");
             this.element.classList.add("main-genericButton-button");
             this.element.style.display = "block";
@@ -1352,8 +1352,7 @@ Spicetify.Playbar = (function() {
                 ...Spicetify.TippyProps,
             });
             this.label = label;
-            buttonsStash.add(this.element);
-            rightContainer?.prepend(...buttonsStash);
+            registerOnCreate && this.register();
         }
         get label() { return this._label; }
         set label(text) {
@@ -1385,6 +1384,14 @@ Spicetify.Playbar = (function() {
             this.element.classList.toggle("main-genericButton-buttonActive", bool);
         }
         get active() { return this._active; }
+        register() {
+            buttonsStash.add(this.element);
+            rightContainer?.prepend(...buttonsStash);
+        }
+        deregister() {
+            buttonsStash.delete(this.element);
+            this.element.remove();
+        }
     }
 
     (function waitForPlaybarMounted() {


### PR DESCRIPTION
In a very grim scenario this could happen
![image](https://user-images.githubusercontent.com/77577746/229279504-d7d714c0-29d2-44b3-965c-5251783a60b4.png)
In order to not discourage extension devs from registering an icon in cases like so, and since the player is a stateful component, it makes sense to add the ability to hide/show the button when needed.