### PR TITLE
feat(lyrics-plus): Add musixmatch word-by-word sync

### DIFF
--- a/CustomApps/lyrics-plus/ProviderMusixmatch.js
+++ b/CustomApps/lyrics-plus/ProviderMusixmatch.js
@@ -45,6 +45,63 @@ const ProviderMusixmatch = (function () {
 		return body;
 	}
 
+	async function getKaraoke(body) {
+		const meta = body?.["matcher.track.get"]?.message?.body;
+		if (!meta) {
+			return null;
+		}
+
+		if (!meta.track.has_richsync || meta.track.instrumental) {
+			return null;
+		}
+
+		const baseURL = `https://apic-desktop.musixmatch.com/ws/1.1/track.richsync.get?format=json&subtitle_format=mxm&app_id=web-desktop-app-v1.0&`;
+
+
+		const params = {
+			subtitle_length: meta.track.track_length,
+			commontrack_id: meta.track.commontrack_id,
+			usertoken: CONFIG.providers.musixmatch.token
+		};
+
+		const finalURL =
+			baseURL +
+			Object.keys(params)
+				.map(key => key + "=" + encodeURIComponent(params[key]))
+				.join("&");
+
+		let result = await CosmosAsync.get(finalURL, null, headers);
+
+		if (result.message.header.status_code != 200) {
+			return null;
+		}
+
+		result = result.message.body;
+
+		const parsedKaraoke = JSON.parse(result.richsync.richsync_body).map((e) => {
+			const words = e.l.map((f, i, a) => {
+				let time;
+				if (a[i + 1]?.o) {
+					time = a[i + 1]?.o - f.o;
+				} else {
+					time = e.te - (f.o + e.ts);
+				}
+				time = Math.floor(time * 1000);
+				return {
+					word: f.c,
+					time
+				};
+			});
+			return {
+				startTime: (e.ts * 1000),
+				text: words
+			};
+		});
+		console.log({parsedKaraoke});
+
+		return parsedKaraoke;
+	}
+
 	function getSynced(body) {
 		const meta = body?.["matcher.track.get"]?.message?.body;
 		if (!meta) {
@@ -95,5 +152,5 @@ const ProviderMusixmatch = (function () {
 		return null;
 	}
 
-	return { findLyrics, getSynced, getUnsynced };
+	return { findLyrics, getKaraoke, getSynced, getUnsynced };
 })();

--- a/CustomApps/lyrics-plus/Providers.js
+++ b/CustomApps/lyrics-plus/Providers.js
@@ -62,6 +62,11 @@ const Providers = {
 			return result;
 		}
 
+		const karaoke = await ProviderMusixmatch.getKaraoke(list);
+		if (karaoke) {
+			result.karaoke = karaoke;
+			result.copyright = list["track.lyrics.get"].message?.body?.lyrics?.lyrics_copyright?.trim();
+		}
 		const synced = ProviderMusixmatch.getSynced(list);
 		if (synced) {
 			result.synced = synced;

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -67,7 +67,7 @@ const CONFIG = {
 			on: getConfig("lyrics-plus:provider:musixmatch:on"),
 			desc: `Fully compatible with Spotify. Requires a token that can be retrieved from the official Musixmatch app. Follow instructions on <a href="https://spicetify.app/docs/faq#sometimes-popup-lyrics-andor-lyrics-plus-seem-to-not-work">Spicetify Docs</a>.`,
 			token: localStorage.getItem("lyrics-plus:provider:musixmatch:token") || "21051986b9886beabe1ce01c3ce94c96319411f8f2c122676365e3",
-			modes: [SYNCED, UNSYNCED]
+			modes: [KARAOKE, SYNCED, UNSYNCED]
 		},
 		spotify: {
 			on: getConfig("lyrics-plus:provider:spotify:on"),
@@ -696,12 +696,12 @@ class LyricsContainer extends react.Component {
 							onClick: () => {
 								const { synced, unsynced, karaoke } = this.state;
 								if (!synced && !unsynced && !karaoke) {
-									Spicetify.showNotification("No lyrics to cache", true);
+									Spicetify.showNotification("No lyrics to cache.", true);
 									return;
 								}
 
 								this.saveLocalLyrics(this.currentTrackUri, { synced, unsynced, karaoke });
-								Spicetify.showNotification("Lyrics cached");
+								Spicetify.showNotification("Lyrics cached.");
 							}
 						},
 						react.createElement("svg", {

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -696,12 +696,12 @@ class LyricsContainer extends react.Component {
 							onClick: () => {
 								const { synced, unsynced, karaoke } = this.state;
 								if (!synced && !unsynced && !karaoke) {
-									Spicetify.showNotification("No lyrics to cache.", true);
+									Spicetify.showNotification("No lyrics to cache", true);
 									return;
 								}
 
 								this.saveLocalLyrics(this.currentTrackUri, { synced, unsynced, karaoke });
-								Spicetify.showNotification("Lyrics cached.");
+								Spicetify.showNotification("Lyrics cached");
 							}
 						},
 						react.createElement("svg", {


### PR DESCRIPTION
This PR allows to get word-by-word sync data from musixmatch using the track.richsync.get endpoint.

## Syntax

```json
[
    {
        "ts": 7.748,
        "te": 11.283,
        "l": [
            {
                "c": "Don't",
                "o": 0
            },
            {
                "c": " ",
                "o": 0.115
            },
            {
                "c": "know",
                "o": 0.231
            },
            {
                "c": " ",
                "o": 0.338
            },
            {
                "c": "where",
                "o": 0.445
            },
            {
                "c": " ",
                "o": 0.538
            },
            {
                "c": "we",
                "o": 0.632
            },
            {
                "c": " ",
                "o": 0.832
            },
            {
                "c": "disconnected",
                "o": 1.033
            },
            {
                "c": " ",
                "o": 1.772
            },
            {
                "c": "each",
                "o": 2.074
            },
            {
                "c": " ",
                "o": 2.185
            },
            {
                "c": "of",
                "o": 2.297
            },
            {
                "c": " ",
                "o": 2.453
            },
            {
                "c": "our",
                "o": 2.609
            },
            {
                "c": " ",
                "o": 2.755
            },
            {
                "c": "stories",
                "o": 2.902
            }
        ],
        "x": "Don't know where we disconnected each of our stories"
    }
]
```

- `ts`: Start time
- `te`: End time
- `l`: Word divisions
- `l[].c`: Word text
- `l[].o`: Timing (relative to `ts`)
- `x`: Full line text