### PR TITLE
fix(player): listen to child on `appchange`

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1424,7 +1424,7 @@ Spicetify.Playbar = (function() {
 })();
 
 (function waitForHistoryAPI() {
-    const main = document.querySelector(".main-view-container__scroll-node-child");
+    const main = document.querySelector(".main-view-container__scroll-node-child > main");
     if (!main || !Spicetify.Platform?.History) {
         setTimeout(waitForHistoryAPI, 300);
         return;


### PR DESCRIPTION
This has been broken for a lot of versions now.

Basically the event never fired before because the element child was the one that had changing children.