### PR TITLE
fix(lyrics-plus): parse Musixmatch karaoke time

### DIFF
--- a/CustomApps/lyrics-plus/ProviderMusixmatch.js
+++ b/CustomApps/lyrics-plus/ProviderMusixmatch.js
@@ -85,9 +85,9 @@ const ProviderMusixmatch = (function () {
 			const text = words.map((word, index, words) => {
 				const wordText = word.c;
 				const wordStartTime = word.o * 1000;
-				const nextWordStartTime = words[index + 1]?.o || null;
+				const nextWordStartTime = words[index + 1]?.o * 1000;
 
-				const time = nextWordStartTime ? nextWordStartTime - wordStartTime : endTime - (wordStartTime + startTime);
+				const time = !isNaN(nextWordStartTime) ? nextWordStartTime - wordStartTime : endTime - (wordStartTime + startTime);
 
 				return {
 					word: wordText,


### PR DESCRIPTION
Dude prob didn't test it after refactoring.

Basically they multiplied every time variable by 1000 expect for this one, so most of them returned a negative value.
![image](https://user-images.githubusercontent.com/77577746/230757844-b7db7a64-b3f4-4e65-b16c-24ce706d6456.png)
