### PR TITLE
feat: add support for theme's script

### DIFF
--- a/spicetify.go
+++ b/spicetify.go
@@ -317,7 +317,7 @@ watch               Enter watch mode.
                     To update on change, use with any combination of the following flags:
 						  "-e" (for extensions),
 						  "-a" (for custom apps),
-						  "-s" (for the active theme; color.ini, user.js, user.css, and assets)
+						  "-s" (for the active theme; color.ini, theme.js, user.css, and assets)
 						  "-l" (for extensions, custom apps, and active theme)
 
 
@@ -332,15 +332,17 @@ path                Print path of color, css, extension file or
                     spicetify path color
                     3. Print theme's user.css path:
                     spicetify path css
-                    4. Print theme's assets path:
+					4. Print theme's theme.js path:
+					spicetify path js
+                    5. Print theme's assets path:
                     spicetify path assets
-                    5. Print all extensions path:
+                    6. Print all extensions path:
                     spicetify -e path
-                    6. Print extension <name> path:
+                    7. Print extension <name> path:
                     spicetify -e path <name>
-                    7. Print all custom apps path:
+                    8. Print all custom apps path:
                     spicetify -a path
-                    8. Print custom app <name> path:
+                    9. Print custom app <name> path:
                     spicetify -a path <name>
 
 config              1. Print all config fields and values:
@@ -396,7 +398,7 @@ upgrade             Upgrade spicetify latest version
                     like clear backup, restore will proceed without prompting
                     permission.
 
--s, --style         Use with "watch" command to auto-reload Spotify when changes are made to the active theme (color.ini, user.css, user.js, assets).
+-s, --style         Use with "watch" command to auto-reload Spotify when changes are made to the active theme (color.ini, user.css, theme.js, assets).
 
 -e, --extension     Use with "update", "watch" or "path" command to
                     focus on extensions. Use with "watch" command to auto-reload Spotify when changes are made to extensions.
@@ -439,7 +441,7 @@ inject_css <0 | 1>
     Whether custom css from user.css in theme folder is applied
 
 inject_theme_js <0 | 1>
-	Whether custom js from user.js in theme folder is applied
+	Whether custom js from theme.js in theme folder is applied
 
 replace_colors <0 | 1>
     Whether custom colors is applied

--- a/spicetify.go
+++ b/spicetify.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -173,7 +174,12 @@ func main() {
 	case "path":
 		commands = commands[1:]
 		path, err := (func() (string, error) {
-			if extensionFocus {
+			if styleFocus {
+				if len(commands) == 0 {
+					return cmd.ThemeAllAssetsPath()
+				}
+				return cmd.ThemeAssetPath(commands[0])
+			} else if extensionFocus {
 				if len(commands) == 0 {
 					return cmd.ExtensionAllPath()
 				}
@@ -184,10 +190,21 @@ func main() {
 				}
 				return cmd.AppPath(commands[0])
 			} else {
-				if len(commands) == 0 {
-					return cmd.ThemeAllAssetsPath()
+				if len(flags) != 0 && (flags[0] != "-e" ||
+					flags[0] != "-c" ||
+					flags[0] != "-a" ||
+					flags[0] != "-s") {
+					return "", errors.New("Invalid Flag\nAvailable Flags: -e, -c, -a, -s")
 				}
-				return cmd.ThemeAssetPath(commands[0])
+
+				if len(commands) == 0 && len(flags) == 0 {
+					return utils.GetExecutableDir(), nil
+				} else if commands[0] == "all" {
+					return cmd.AllPaths()
+				} else if commands[0] == "userdata" {
+					return utils.GetSpicetifyFolder(), nil
+				}
+				return "", errors.New("Invalid Option\nAvailable Options: all, userdata")
 			}
 		})()
 
@@ -324,26 +341,32 @@ watch               Enter watch mode.
 restart             Restart Spotify client.
 
 ` + utils.Bold("NON-CHAINABLE COMMANDS") + `
-path                Print path of color, css, extension file or
-                    custom app directory and quit.
-                    1. Print all theme's assets:
+path                Prints path of Spotify's executable, userdata, and more.
+                    1. Print executable path:
                     spicetify path
-                    2. Print theme's color.ini path:
-                    spicetify path color
-                    3. Print theme's user.css path:
-                    spicetify path css
-                    4. Print theme's theme.js path:
-                    spicetify path js
-                    5. Print theme's assets path:
-                    spicetify path assets
-                    6. Print all extensions path:
-                    spicetify -e path
-                    7. Print extension <name> path:
-                    spicetify -e path <name>
-                    8. Print all custom apps path:
-                    spicetify -a path
-                    9. Print custom app <name> path:
-                    spicetify -a path <name>
+
+                    2. Print userdata path:
+                    spicetify path userdata
+
+                    3. Print all paths:
+                    spicetify path all
+
+                    4. Toggle focus with flags:
+                    spicetify path <flag> <option>
+	
+                    Available Flags and Options:
+                    "-e" (for extensions),
+                    options: root, extension name, blank for all.
+					
+                    "-a" (for custom apps),
+                    options: root, app name, blank for all.
+					
+                    "-s" (for the active theme)
+                    options: root, folder, color, css, js, assets, blank for all.
+					
+                    "-c" (for config.ini)
+                    options: N/A.
+
 
 config              1. Print all config fields and values:
                     spicetify config

--- a/spicetify.go
+++ b/spicetify.go
@@ -317,7 +317,7 @@ watch               Enter watch mode.
                     To update on change, use with any combination of the following flags:
 						  "-e" (for extensions),
 						  "-a" (for custom apps),
-						  "-s" (for the active theme, color.ini and user.css)
+						  "-s" (for the active theme; color.ini, user.js, user.css, and assets)
 						  "-l" (for extensions, custom apps, and active theme)
 
 
@@ -396,7 +396,7 @@ upgrade             Upgrade spicetify latest version
                     like clear backup, restore will proceed without prompting
                     permission.
 
--s, --style         Use with "watch" command to auto-reload Spotify when changes are made to the active theme (color.ini, user.css).
+-s, --style         Use with "watch" command to auto-reload Spotify when changes are made to the active theme (color.ini, user.css, user.js, assets).
 
 -e, --extension     Use with "update", "watch" or "path" command to
                     focus on extensions. Use with "watch" command to auto-reload Spotify when changes are made to extensions.
@@ -437,6 +437,9 @@ color_scheme
 
 inject_css <0 | 1>
     Whether custom css from user.css in theme folder is applied
+
+inject_theme_js <0 | 1>
+	Whether custom js from user.js in theme folder is applied
 
 replace_colors <0 | 1>
     Whether custom colors is applied

--- a/spicetify.go
+++ b/spicetify.go
@@ -317,7 +317,7 @@ watch               Enter watch mode.
                     To update on change, use with any combination of the following flags:
 						  "-e" (for extensions),
 						  "-a" (for custom apps),
-						  "-s" (for the active theme; color.ini, theme.js, user.css, and assets)
+						  "-s" (for the active theme; color.ini, user.css, theme.js, and assets)
 						  "-l" (for extensions, custom apps, and active theme)
 
 
@@ -332,8 +332,8 @@ path                Print path of color, css, extension file or
                     spicetify path color
                     3. Print theme's user.css path:
                     spicetify path css
-					4. Print theme's theme.js path:
-					spicetify path js
+                    4. Print theme's theme.js path:
+                    spicetify path js
                     5. Print theme's assets path:
                     spicetify path assets
                     6. Print all extensions path:

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -15,6 +15,7 @@ import (
 type Flag struct {
 	CurrentTheme  string
 	ColorScheme   string
+	InjectThemeJS bool
 	Extension     []string
 	CustomApp     []string
 	SidebarConfig bool
@@ -94,6 +95,10 @@ func htmlMod(htmlPath string, flags Flag) {
 
 	extensionsHTML := "\n"
 	helperHTML := "\n"
+
+	if flags.InjectThemeJS {
+		extensionsHTML += `<script defer src="extensions/user.js"></script>` + "\n"
+	}
 
 	if flags.SidebarConfig {
 		helperHTML += `<script defer src="helper/sidebarConfig.js"></script>` + "\n"

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -97,7 +97,7 @@ func htmlMod(htmlPath string, flags Flag) {
 	helperHTML := "\n"
 
 	if flags.InjectThemeJS {
-		extensionsHTML += `<script defer src="extensions/user.js"></script>` + "\n"
+		extensionsHTML += `<script defer src="extensions/theme.js"></script>` + "\n"
 	}
 
 	if flags.SidebarConfig {

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -133,7 +133,7 @@ func UpdateTheme() {
 	utils.PrintSuccess("Custom CSS is updated")
 
 	if injectJS {
-		pushThemeExtension()
+		pushThemeJS()
 		utils.PrintSuccess("Theme's JS is updated")
 	}
 

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -56,7 +56,7 @@ func Apply(spicetifyVersion string) {
 
 	if injectJS {
 		utils.PrintBold(`Transferring theme.js:`)
-		pushThemeExtension()
+		pushThemeJS()
 		utils.PrintGreen("OK")
 	} else {
 		utils.CheckExistAndDelete(filepath.Join(appDestPath, "xpui", "extensions/theme.js"))

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -54,6 +54,14 @@ func Apply(spicetifyVersion string) {
 	updateCSS()
 	utils.PrintGreen("OK")
 
+	if injectJS {
+		utils.PrintBold(`Transferring user.js:`)
+		pushThemeExtension()
+		utils.PrintGreen("OK")
+	} else {
+		utils.CheckExistAndDelete(filepath.Join(appDestPath, "xpui", "extensions/user.js"))
+	}
+
 	if overwriteAssets {
 		utils.PrintBold(`Overwriting custom assets:`)
 		updateAssets()
@@ -73,6 +81,7 @@ func Apply(spicetifyVersion string) {
 	apply.AdditionalOptions(appDestPath, apply.Flag{
 		CurrentTheme:  settingSection.Key("current_theme").MustString(""),
 		ColorScheme:   settingSection.Key("color_scheme").MustString(""),
+		InjectThemeJS: injectJS,
 		Extension:     extensionList,
 		CustomApp:     customAppsList,
 		SidebarConfig: featureSection.Key("sidebar_config").MustBool(false),
@@ -110,7 +119,7 @@ func Apply(spicetifyVersion string) {
 	}
 }
 
-// UpdateTheme updates user.css and overwrites custom assets
+// UpdateTheme updates user.css + user.js and overwrites custom assets
 func UpdateTheme() {
 	checkStates()
 	InitSetting()
@@ -122,6 +131,11 @@ func UpdateTheme() {
 
 	updateCSS()
 	utils.PrintSuccess("Custom CSS is updated")
+
+	if injectJS {
+		pushThemeExtension()
+		utils.PrintSuccess("Custom JS is updated")
+	}
 
 	if overwriteAssets {
 		updateAssets()
@@ -224,6 +238,12 @@ func checkStates() {
 			os.Exit(1)
 		}
 	}
+}
+
+func pushThemeExtension() {
+	utils.CopyFile(
+		filepath.Join(themeFolder, "user.js"),
+		filepath.Join(appDestPath, "xpui", "extensions"))
 }
 
 func pushExtensions(destExt string, list ...string) {

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -55,11 +55,11 @@ func Apply(spicetifyVersion string) {
 	utils.PrintGreen("OK")
 
 	if injectJS {
-		utils.PrintBold(`Transferring user.js:`)
+		utils.PrintBold(`Transferring theme.js:`)
 		pushThemeExtension()
 		utils.PrintGreen("OK")
 	} else {
-		utils.CheckExistAndDelete(filepath.Join(appDestPath, "xpui", "extensions/user.js"))
+		utils.CheckExistAndDelete(filepath.Join(appDestPath, "xpui", "extensions/theme.js"))
 	}
 
 	if overwriteAssets {
@@ -119,7 +119,7 @@ func Apply(spicetifyVersion string) {
 	}
 }
 
-// UpdateTheme updates user.css + user.js and overwrites custom assets
+// UpdateTheme updates user.css + theme.js and overwrites custom assets
 func UpdateTheme() {
 	checkStates()
 	InitSetting()
@@ -242,7 +242,7 @@ func checkStates() {
 
 func pushThemeExtension() {
 	utils.CopyFile(
-		filepath.Join(themeFolder, "user.js"),
+		filepath.Join(themeFolder, "theme.js"),
 		filepath.Join(appDestPath, "xpui", "extensions"))
 }
 

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -134,7 +134,7 @@ func UpdateTheme() {
 
 	if injectJS {
 		pushThemeExtension()
-		utils.PrintSuccess("Custom JS is updated")
+		utils.PrintSuccess("Theme's JS is updated")
 	}
 
 	if overwriteAssets {

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -240,7 +240,7 @@ func checkStates() {
 	}
 }
 
-func pushThemeExtension() {
+func pushThemeJS() {
 	utils.CopyFile(
 		filepath.Join(themeFolder, "theme.js"),
 		filepath.Join(appDestPath, "xpui", "extensions"))

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -34,6 +34,7 @@ var (
 	colorCfg                *ini.File
 	colorSection            *ini.Section
 	injectCSS               bool
+	injectJS                bool
 	replaceColors           bool
 	overwriteAssets         bool
 )
@@ -136,12 +137,14 @@ func InitPaths() {
 func InitSetting() {
 	replaceColors = settingSection.Key("replace_colors").MustBool(false)
 	injectCSS = settingSection.Key("inject_css").MustBool(false)
+	injectJS = settingSection.Key("inject_theme_js").MustBool(false)
 	overwriteAssets = settingSection.Key("overwrite_assets").MustBool(false)
 
 	themeName := settingSection.Key("current_theme").String()
 
 	if len(themeName) == 0 {
 		injectCSS = false
+		injectJS = false
 		replaceColors = false
 		overwriteAssets = false
 		return
@@ -152,6 +155,7 @@ func InitSetting() {
 	colorPath := filepath.Join(themeFolder, "color.ini")
 	cssPath := filepath.Join(themeFolder, "user.css")
 	assetsPath := filepath.Join(themeFolder, "assets")
+	jsPath := filepath.Join(themeFolder, "user.js")
 
 	if replaceColors {
 		_, err := os.Stat(colorPath)
@@ -161,6 +165,14 @@ func InitSetting() {
 	if injectCSS {
 		_, err := os.Stat(cssPath)
 		injectCSS = err == nil
+	}
+
+	if injectJS {
+		_, err := os.Stat(jsPath)
+		injectJS = err == nil
+		if err != nil {
+			utils.CheckExistAndDelete(filepath.Join(appDestPath, "xpui", "extensions/user.js"))
+		}
 	}
 
 	if overwriteAssets {

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -134,7 +134,7 @@ func InitPaths() {
 }
 
 // InitSetting parses theme settings and gets color section.
-func InitSetting(silent ...bool) {
+func InitSetting() {
 	replaceColors = settingSection.Key("replace_colors").MustBool(false)
 	injectCSS = settingSection.Key("inject_css").MustBool(false)
 	injectJS = settingSection.Key("inject_theme_js").MustBool(false)
@@ -194,9 +194,7 @@ func InitSetting(silent ...bool) {
 	sections := colorCfg.Sections()
 
 	if len(sections) < 2 {
-		if silent == nil {
-			utils.PrintError("No section found in " + colorPath) 
-		}
+		utils.PrintError("No section found in " + colorPath) 
 		replaceColors = false
 		return
 	}

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -194,7 +194,7 @@ func InitSetting() {
 	sections := colorCfg.Sections()
 
 	if len(sections) < 2 {
-		utils.PrintError("No section found in " + colorPath) 
+		utils.PrintError("No section found in " + colorPath)
 		replaceColors = false
 		return
 	}

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -171,7 +171,7 @@ func InitSetting() {
 		_, err := os.Stat(jsPath)
 		injectJS = err == nil
 		if err != nil {
-			utils.CheckExistAndDelete(filepath.Join(appDestPath, "xpui", "extensions/user.js"))
+			utils.CheckExistAndDelete(filepath.Join(appDestPath, "xpui", "extensions/theme.js"))
 		}
 	}
 

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -134,7 +134,7 @@ func InitPaths() {
 }
 
 // InitSetting parses theme settings and gets color section.
-func InitSetting() {
+func InitSetting(silent ...bool) {
 	replaceColors = settingSection.Key("replace_colors").MustBool(false)
 	injectCSS = settingSection.Key("inject_css").MustBool(false)
 	injectJS = settingSection.Key("inject_theme_js").MustBool(false)
@@ -194,7 +194,9 @@ func InitSetting() {
 	sections := colorCfg.Sections()
 
 	if len(sections) < 2 {
-		utils.PrintError("No section found in " + colorPath)
+		if silent == nil {
+			utils.PrintError("No section found in " + colorPath) 
+		}
 		replaceColors = false
 		return
 	}

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -155,7 +155,7 @@ func InitSetting() {
 	colorPath := filepath.Join(themeFolder, "color.ini")
 	cssPath := filepath.Join(themeFolder, "user.css")
 	assetsPath := filepath.Join(themeFolder, "assets")
-	jsPath := filepath.Join(themeFolder, "user.js")
+	jsPath := filepath.Join(themeFolder, "theme.js")
 
 	if replaceColors {
 		_, err := os.Stat(colorPath)

--- a/src/cmd/path.go
+++ b/src/cmd/path.go
@@ -12,11 +12,15 @@ import (
 func ThemeAssetPath(kind string) (string, error) {
 	InitSetting()
 
-	if len(themeFolder) == 0 {
+	if kind == "root" {
+		return filepath.Join(utils.GetExecutableDir(), "Themes"), nil
+	} else if len(themeFolder) == 0 {
 		return "", errors.New(`Config "current_theme" is blank`)
 	}
 
-	if kind == "color" {
+	if kind == "folder" {
+		return themeFolder, nil
+	} else if kind == "color" {
 		color := filepath.Join(themeFolder, "color.ini")
 		return color, nil
 	} else if kind == "css" {
@@ -30,7 +34,7 @@ func ThemeAssetPath(kind string) (string, error) {
 		return assets, nil
 	}
 
-	return "", errors.New(`Unrecognized theme assets kind. Only "color", "css", "js" or "assets" is valid`)
+	return "", errors.New(`Unrecognized theme assets kind. Only "root", "folder", "color", "css", "js" or "assets" is valid`)
 }
 
 // ThemeAllAssetsPath returns paths of all theme's assets
@@ -42,6 +46,8 @@ func ThemeAllAssetsPath() (string, error) {
 	}
 
 	results := []string{
+		filepath.Join(utils.GetExecutableDir(), "Themes"),
+		themeFolder,
 		filepath.Join(themeFolder, "color.ini"),
 		filepath.Join(themeFolder, "user.css"),
 		filepath.Join(themeFolder, "theme.js"),
@@ -52,6 +58,9 @@ func ThemeAllAssetsPath() (string, error) {
 
 // ExtensionPath return path of extension file
 func ExtensionPath(name string) (string, error) {
+	if name == "root" {
+		return filepath.Join(utils.GetExecutableDir(), "Extensions"), nil
+	}
 	return utils.GetExtensionPath(name)
 }
 
@@ -72,6 +81,9 @@ func ExtensionAllPath() (string, error) {
 
 // AppPath return path of app directory
 func AppPath(name string) (string, error) {
+	if name == "root" {
+		return filepath.Join(utils.GetExecutableDir(), "CustomApps"), nil
+	}
 	return utils.GetCustomAppPath(name)
 }
 
@@ -88,4 +100,12 @@ func AppAllPath() (string, error) {
 	}
 
 	return strings.Join(results, "\n"), nil
+}
+
+func AllPaths() (string, error) {
+	theme, _ := ThemeAllAssetsPath()
+	ext, _ := ExtensionAllPath()
+	app, _ := AppAllPath()
+
+	return strings.Join([]string{theme, ext, app}, "\n"), nil
 }

--- a/src/cmd/path.go
+++ b/src/cmd/path.go
@@ -46,6 +46,7 @@ func ThemeAllAssetsPath() (string, error) {
 	}
 
 	results := []string{
+		themeFolder,
 		filepath.Join(themeFolder, "color.ini"),
 		filepath.Join(themeFolder, "user.css"),
 		filepath.Join(themeFolder, "theme.js"),

--- a/src/cmd/path.go
+++ b/src/cmd/path.go
@@ -22,12 +22,15 @@ func ThemeAssetPath(kind string) (string, error) {
 	} else if kind == "css" {
 		css := filepath.Join(themeFolder, "user.css")
 		return css, nil
+	} else if kind == "js" {
+		js := filepath.Join(themeFolder, "user.js")
+		return js, nil
 	} else if kind == "assets" {
 		assets := filepath.Join(themeFolder, "assets")
 		return assets, nil
 	}
 
-	return "", errors.New(`Unrecognized theme assets kind. Only "color", "css" or "assets" is valid`)
+	return "", errors.New(`Unrecognized theme assets kind. Only "color", "css", "js" or "assets" is valid`)
 }
 
 // ThemeAllAssetsPath returns paths of all theme's assets
@@ -41,6 +44,7 @@ func ThemeAllAssetsPath() (string, error) {
 	results := []string{
 		filepath.Join(themeFolder, "color.ini"),
 		filepath.Join(themeFolder, "user.css"),
+		filepath.Join(themeFolder, "user.js"),
 		filepath.Join(themeFolder, "assets")}
 
 	return strings.Join(results, "\n"), nil

--- a/src/cmd/path.go
+++ b/src/cmd/path.go
@@ -46,8 +46,6 @@ func ThemeAllAssetsPath() (string, error) {
 	}
 
 	results := []string{
-		filepath.Join(utils.GetExecutableDir(), "Themes"),
-		themeFolder,
 		filepath.Join(themeFolder, "color.ini"),
 		filepath.Join(themeFolder, "user.css"),
 		filepath.Join(themeFolder, "theme.js"),

--- a/src/cmd/path.go
+++ b/src/cmd/path.go
@@ -10,7 +10,7 @@ import (
 
 // ThemeAssetPath returns path of theme; assets, color.ini, theme.js and user.css
 func ThemeAssetPath(kind string) (string, error) {
-	InitSetting()
+	InitSetting(true)
 
 	if kind == "root" {
 		return filepath.Join(utils.GetExecutableDir(), "Themes"), nil

--- a/src/cmd/path.go
+++ b/src/cmd/path.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spicetify/spicetify-cli/src/utils"
 )
 
-// ThemeAssetPath returns path of theme assets color.ini and user.css
+// ThemeAssetPath returns path of theme; assets, color.ini, theme.js and user.css
 func ThemeAssetPath(kind string) (string, error) {
 	InitSetting()
 
@@ -23,7 +23,7 @@ func ThemeAssetPath(kind string) (string, error) {
 		css := filepath.Join(themeFolder, "user.css")
 		return css, nil
 	} else if kind == "js" {
-		js := filepath.Join(themeFolder, "user.js")
+		js := filepath.Join(themeFolder, "theme.js")
 		return js, nil
 	} else if kind == "assets" {
 		assets := filepath.Join(themeFolder, "assets")
@@ -44,7 +44,7 @@ func ThemeAllAssetsPath() (string, error) {
 	results := []string{
 		filepath.Join(themeFolder, "color.ini"),
 		filepath.Join(themeFolder, "user.css"),
-		filepath.Join(themeFolder, "user.js"),
+		filepath.Join(themeFolder, "theme.js"),
 		filepath.Join(themeFolder, "assets")}
 
 	return strings.Join(results, "\n"), nil

--- a/src/cmd/path.go
+++ b/src/cmd/path.go
@@ -10,7 +10,7 @@ import (
 
 // ThemeAssetPath returns path of theme; assets, color.ini, theme.js and user.css
 func ThemeAssetPath(kind string) (string, error) {
-	InitSetting(true)
+	InitSetting()
 
 	if kind == "root" {
 		return filepath.Join(utils.GetExecutableDir(), "Themes"), nil

--- a/src/cmd/watch.go
+++ b/src/cmd/watch.go
@@ -44,6 +44,22 @@ func Watch(liveUpdate bool) {
 		fileList = append(fileList, cssPath)
 	}
 
+	if injectJS {
+		jsPath := filepath.Join(themeFolder, "user.js")
+		pathArr := []string{jsPath}
+
+		if _, err := os.Stat(jsPath); err == nil {
+			go utils.Watch(pathArr, func(_ string, err error) {
+				if err != nil {
+					utils.Fatal(err)
+				}
+
+				pushThemeExtension()
+				utils.PrintSuccess(utils.PrependTime("Custom JS is updated"))
+			}, autoReloadFunc)
+		}
+	}
+
 	if overwriteAssets {
 		assetPath := filepath.Join(themeFolder, "assets")
 

--- a/src/cmd/watch.go
+++ b/src/cmd/watch.go
@@ -45,7 +45,7 @@ func Watch(liveUpdate bool) {
 	}
 
 	if injectJS {
-		jsPath := filepath.Join(themeFolder, "user.js")
+		jsPath := filepath.Join(themeFolder, "theme.js")
 		pathArr := []string{jsPath}
 
 		if _, err := os.Stat(jsPath); err == nil {

--- a/src/cmd/watch.go
+++ b/src/cmd/watch.go
@@ -54,7 +54,7 @@ func Watch(liveUpdate bool) {
 					utils.Fatal(err)
 				}
 
-				pushThemeExtension()
+				pushThemeJS()
 				utils.PrintSuccess(utils.PrependTime("Custom JS is updated"))
 			}, autoReloadFunc)
 		}

--- a/src/cmd/watch.go
+++ b/src/cmd/watch.go
@@ -55,7 +55,7 @@ func Watch(liveUpdate bool) {
 				}
 
 				pushThemeJS()
-				utils.PrintSuccess(utils.PrependTime("Custom JS is updated"))
+				utils.PrintSuccess(utils.PrependTime("Theme's JS is updated"))
 			}, autoReloadFunc)
 		}
 	}

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -17,6 +17,7 @@ var (
 			"prefs_path":              "",
 			"current_theme":           "",
 			"color_scheme":            "",
+			"inject_theme_js":         "1",
 			"inject_css":              "1",
 			"replace_colors":          "1",
 			"overwrite_assets":        "0",


### PR DESCRIPTION
## This PR allows theme creators to implement extensions for their theme within the themes folder. 

This removes the need for every theme to have its own install script in which it needs to move js files and modify the config, this PR will not affect older themes that do not have a theme.js.

As a side improvement i have modified the `spicetify path` command to be more consistent with additional missing options such as root paths for; themes, extensions, and customapps. 

##
![image](https://user-images.githubusercontent.com/22730962/230813985-b17acc94-6dbc-490d-a307-927de1f0616b.png)


![image](https://user-images.githubusercontent.com/22730962/230813912-7787b345-fc50-4767-94e9-0b7f8a4aac2c.png)

![image](https://user-images.githubusercontent.com/22730962/230813801-ce9460e4-d819-4dea-b4bf-38036c2c7359.png)

![image](https://user-images.githubusercontent.com/22730962/230813890-6278d8f3-eb83-47f9-8ada-2f1be4c74ba6.png)
