### PR TITLE
feat: help on no commands

### DIFF
--- a/spicetify.go
+++ b/spicetify.go
@@ -134,7 +134,7 @@ func init() {
 	cmd.InitConfig(quiet)
 
 	if len(commands) < 1 {
-		utils.PrintInfo(`Run "spicetify -h" for commands list.`)
+		help()
 		os.Exit(0)
 	}
 }


### PR DESCRIPTION
Spicetify v2.17.1 prints the following with no commands:

```
$ spicetify
info Run "spicetify -h" for commands list.
```

It might as well just print the help text that it suggests to the user.