### PR TITLE
feat: notify update in-app

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1481,9 +1481,8 @@ Spicetify.Playbar = (function() {
                     #spicetify-update pre {
                         cursor: pointer;
                         font-size: 1rem;
-                        padding-top: 0.5rem;
-                        padding-bottom: 0.5rem;
-                        background-color: var(--spice-highlight);
+                        padding: 0.5rem;
+                        background-color: var(--spice-highlight-elevated);
                         border-radius: 0.25rem;
                     }
                     #spicetify-update hr {

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1489,6 +1489,14 @@ Spicetify.Playbar = (function() {
                         margin-top: 1rem;
                         margin-bottom: 1rem;
                     }
+                    #spicetify-update ul {
+                        padding-left: 1rem;
+                    }
+                    #spicetify-update li {
+                        margin-top: 0.5rem;
+                        margin-bottom: 0.5rem;
+                        list-style-type: disc;
+                    }
                 </style>
                 <p> Current version: ${version} </p>
                 <p> Latest version:
@@ -1498,13 +1506,16 @@ Spicetify.Playbar = (function() {
                 </p>
                 <hr>
                 <p> Update Spicetify to receive new features and bug fixes. </p>
-                <p> Run this command in the terminal to update: </p>
-                <pre>spicetify restore backup apply --check-update</pre>
-                <p> Or update manually by downloading the latest release from
-                    <a href="${html_url}" target="_blank" rel="noopener noreferrer">
-                        GitHub
-                    </a>
-                </p>
+                <ul>
+                    <li> First, update Spicetify CLI: </li>
+                    <ul>
+                        <li> Run this command in the terminal: </li>
+                        <pre>spicetify upgrade</pre>
+                        <li> If you installed Spicetify via a package manager, update using said package manager. </li>
+                    </ul>
+                    <li> Afterwards, apply the latest changes to Spotify: </li>
+                    <pre>spicetify restore backup apply</pre>
+                </ul>
             `;
 
             (function waitForTippy() {
@@ -1513,17 +1524,19 @@ Spicetify.Playbar = (function() {
                     return;
                 }
 
-                const tippyInstance = Spicetify.Tippy(content.querySelector("pre"), {
+                const tippy = Spicetify.Tippy(content.querySelectorAll("pre"), {
                     content: "Click to copy",
                     hideOnClick: false,
                     ...Spicetify.TippyProps,
                 });
 
-                content.querySelector("pre").onclick = () => {
-                    Spicetify.Platform.ClipboardAPI.copy("spicetify restore backup apply --check-update");
-                    tippyInstance.setContent("Copied!");
-                    setTimeout(() => tippyInstance.setContent("Click to copy"), 2000);
-                };
+                tippy.forEach((instance) => {
+                    instance.reference.addEventListener("click", () => {
+                        Spicetify.Platform.ClipboardAPI.copy(instance.reference.textContent);
+                        instance.setContent("Copied!");
+                        setTimeout(() => instance.setContent("Click to copy"), 1000);
+                    });
+                });
             })();
 
             const updateModal = {

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1490,7 +1490,7 @@ Spicetify.Playbar = (function() {
                         margin-bottom: 1rem;
                     }
                     #spicetify-update ul {
-                        padding-left: 1rem;
+                        padding-left: 1.5rem;
                     }
                     #spicetify-update li {
                         margin-top: 0.5rem;

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1461,7 +1461,7 @@ Spicetify.Playbar = (function() {
     }
     const { version } = Spicetify.Config;
     // Skip checking if version is Dev or version is not set
-    if (!version) {
+    if (!version || version === "Dev") {
         return;
     }
     // Fetch latest version from GitHub

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1489,13 +1489,17 @@ Spicetify.Playbar = (function() {
                         margin-top: 1rem;
                         margin-bottom: 1rem;
                     }
-                    #spicetify-update ul {
+                    #spicetify-update ul,
+                    #spicetify-update ol {
                         padding-left: 1.5rem;
                     }
                     #spicetify-update li {
                         margin-top: 0.5rem;
                         margin-bottom: 0.5rem;
                         list-style-type: disc;
+                    }
+                    #spicetify-update ol > li {
+                        list-style-type: decimal;
                     }
                 </style>
                 <p> Current version: ${version} </p>
@@ -1505,17 +1509,17 @@ Spicetify.Playbar = (function() {
                     </a>
                 </p>
                 <hr>
-                <p> Update Spicetify to receive new features and bug fixes. </p>
-                <ul>
-                    <li> First, update Spicetify CLI: </li>
+                <p>Update Spicetify to receive new features and bug fixes.</p>
+                <ol>
+                    <li>Update Spicetify CLI</li>
                     <ul>
-                        <li> Run this command in the terminal: </li>
+                        <li>Run this command in the terminal:</li>
                         <pre>spicetify upgrade</pre>
                         <li> If you installed Spicetify via a package manager, update using said package manager. </li>
                     </ul>
-                    <li> Afterwards, apply the latest changes to Spotify: </li>
+                    <li>Apply latest changes to Spotify</li>
                     <pre>spicetify restore backup apply</pre>
-                </ul>
+                </ol>
             `;
 
             (function waitForTippy() {

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -19,6 +19,14 @@ func Apply(spicetifyVersion string) {
 	checkStates()
 	InitSetting()
 
+	backupSpicetifyVersion := backupSection.Key("with").MustString("")
+	if spicetifyVersion != backupSpicetifyVersion {
+		utils.PrintInfo(`Preprocessed Spotify data is outdated. Please run "spicetify restore backup apply" to receive new features and bug fixes`)
+		if !ReadAnswer("Continue applying anyway? [y/N]: ", false, true) {
+			os.Exit(1)
+		}
+	}
+
 	// Copy raw assets to Spotify Apps folder if Spotify is never applied
 	// before.
 	// extractedStock is for preventing copy raw assets 2 times when
@@ -112,11 +120,6 @@ func Apply(spicetifyVersion string) {
 	}
 
 	utils.PrintSuccess("Spotify is spiced up!")
-
-	backupSpicetifyVersion := backupSection.Key("with").MustString("")
-	if spicetifyVersion != backupSpicetifyVersion {
-		utils.PrintInfo(`Preprocessed Spotify data is outdated. Please run "spicetify restore backup apply" to receive new features and bug fixes`)
-	}
 }
 
 // UpdateTheme updates user.css + theme.js and overwrites custom assets


### PR DESCRIPTION
This is aimed to prevent at much user error as possible created by using an outdated version of Spicetify ~~because I'm honestly really tired at the amount of thickets and spam issues lol~~.
- Creates an in-app update notification that appears on the Topbar
![Spotify_LYqnbUO7PZ](https://user-images.githubusercontent.com/77577746/232984318-054fae04-0808-4e06-be41-4229584d34de.png)
![image](https://user-images.githubusercontent.com/77577746/233075201-5654ac78-e5d8-44e0-bce8-3cd23a58645e.png)

- Discourage running `apply` on outdated preprocess data
![Code_zavZXpmzso](https://user-images.githubusercontent.com/77577746/232984635-efb95794-12d5-4bfb-9143-84ee10bec371.png)
