### PR TITLE
fix(reddit): ignore on invalid URI

### DIFF
--- a/CustomApps/reddit/index.js
+++ b/CustomApps/reddit/index.js
@@ -361,7 +361,7 @@ async function fetchTrack(post) {
 function postMapper(posts) {
 	var mappedPosts = [];
 	posts.forEach(post => {
-		var uri = URI.fromString(post.data.url);
+		var uri = URI.from(post.data.url);
 		if (uri && (uri.type == "playlist" || uri.type == "playlist-v2" || uri.type == "track" || uri.type == "album")) {
 			mappedPosts.push({
 				uri: uri.toURI(),


### PR DESCRIPTION
`URI.fromString` throws an error on invalid URI, while `URI.from` returns null. Might have been an oversight from my previous patch.