### PR TITLE
feat(lyrics-plus): global delay

### DIFF
--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -218,7 +218,6 @@ const AdjustmentsMenu = react.memo(({ mode }) => {
 					],
 					onChange: (name, value) => {
 						CONFIG.visual[name] = value;
-						console.log(CONFIG.visual, APP_NAME, name, value);
 						localStorage.setItem(`${APP_NAME}:visual:${name}`, value);
 						name === "delay" && localStorage.setItem(`lyrics-delay:${Spicetify.Player.data.track.uri}`, value);
 						lyricContainerUpdate && lyricContainerUpdate();

--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -195,8 +195,8 @@ const AdjustmentsMenu = react.memo(({ mode }) => {
 							step: fontSizeLimit.step
 						},
 						{
-							desc: "Delay",
-							key: "delay",
+							desc: "Track delay",
+							key: "track-delay",
 							type: ConfigAdjust,
 							min: -10000,
 							max: 10000,
@@ -218,8 +218,9 @@ const AdjustmentsMenu = react.memo(({ mode }) => {
 					],
 					onChange: (name, value) => {
 						CONFIG.visual[name] = value;
+						console.log(CONFIG.visual, APP_NAME, name, value);
 						localStorage.setItem(`${APP_NAME}:visual:${name}`, value);
-						name === "delay" && localStorage.setItem(`lyrics-delay:${Spicetify.Player.data.track.uri}`, value);
+						name === "track-delay" && localStorage.setItem(`lyrics-track-delay:${Spicetify.Player.data.track.uri}`, value);
 						lyricContainerUpdate && lyricContainerUpdate();
 					}
 				})

--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -196,7 +196,7 @@ const AdjustmentsMenu = react.memo(({ mode }) => {
 						},
 						{
 							desc: "Track delay",
-							key: "track-delay",
+							key: "delay",
 							type: ConfigAdjust,
 							min: -10000,
 							max: 10000,
@@ -220,7 +220,7 @@ const AdjustmentsMenu = react.memo(({ mode }) => {
 						CONFIG.visual[name] = value;
 						console.log(CONFIG.visual, APP_NAME, name, value);
 						localStorage.setItem(`${APP_NAME}:visual:${name}`, value);
-						name === "track-delay" && localStorage.setItem(`lyrics-track-delay:${Spicetify.Player.data.track.uri}`, value);
+						name === "delay" && localStorage.setItem(`lyrics-delay:${Spicetify.Player.data.track.uri}`, value);
 						lyricContainerUpdate && lyricContainerUpdate();
 					}
 				})

--- a/CustomApps/lyrics-plus/Pages.js
+++ b/CustomApps/lyrics-plus/Pages.js
@@ -84,7 +84,7 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
 
 	useTrackPosition(() => {
 		const newPos = Spicetify.Player.getProgress();
-		const delay = CONFIG.visual["global-delay"] + CONFIG.visual["track-delay"];
+		const delay = CONFIG.visual["global-delay"] + CONFIG.visual.delay;
 		if (newPos != position) {
 			setPosition(newPos + delay);
 		}
@@ -353,7 +353,7 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 
 	useTrackPosition(() => {
 		if (!Player.data.is_paused) {
-			setPosition(Spicetify.Player.getProgress() + CONFIG.visual["global-delay"] + CONFIG.visual["track-delay"]);
+			setPosition(Spicetify.Player.getProgress() + CONFIG.visual["global-delay"] + CONFIG.visual.delay);
 		}
 	});
 

--- a/CustomApps/lyrics-plus/Pages.js
+++ b/CustomApps/lyrics-plus/Pages.js
@@ -84,8 +84,9 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
 
 	useTrackPosition(() => {
 		const newPos = Spicetify.Player.getProgress();
+		const delay = CONFIG.visual["global-delay"] + CONFIG.visual["track-delay"];
 		if (newPos != position) {
-			setPosition(newPos + CONFIG.visual.delay);
+			setPosition(newPos + delay);
 		}
 	});
 
@@ -352,7 +353,7 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 
 	useTrackPosition(() => {
 		if (!Player.data.is_paused) {
-			setPosition(Spicetify.Player.getProgress() + CONFIG.visual.delay);
+			setPosition(Spicetify.Player.getProgress() + CONFIG.visual["global-delay"] + CONFIG.visual["track-delay"]);
 		}
 	});
 

--- a/CustomApps/lyrics-plus/Settings.js
+++ b/CustomApps/lyrics-plus/Settings.js
@@ -536,7 +536,6 @@ function openConfig() {
 			],
 			onChange: (name, value) => {
 				CONFIG.visual[name] = value;
-				console.log(CONFIG.visual, APP_NAME, name, value);
 				localStorage.setItem(`${APP_NAME}:visual:${name}`, value);
 				lyricContainerUpdate && lyricContainerUpdate();
 			}

--- a/CustomApps/lyrics-plus/Settings.js
+++ b/CustomApps/lyrics-plus/Settings.js
@@ -432,6 +432,15 @@ function openConfig() {
 		react.createElement(OptionList, {
 			items: [
 				{
+					desc: "Global delay",
+					info: "Offset (in ms) across all tracks, useful in accounting for wireless delay.",
+					key: "global-delay",
+					type: ConfigAdjust,
+					min: -10000,
+					max: 10000,
+					step: 250
+				},
+				{
 					desc: "Font size",
 					info: "(or Ctrl + Mouse scroll in main app)",
 					key: "font-size",

--- a/CustomApps/lyrics-plus/Settings.js
+++ b/CustomApps/lyrics-plus/Settings.js
@@ -433,7 +433,7 @@ function openConfig() {
 			items: [
 				{
 					desc: "Global delay",
-					info: "Offset (in ms) across all tracks, useful in accounting for wireless delay.",
+					info: "Offset (in ms) across all tracks.",
 					key: "global-delay",
 					type: ConfigAdjust,
 					min: -10000,

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -56,7 +56,7 @@ const CONFIG = {
 		["synced-compact"]: getConfig("lyrics-plus:visual:synced-compact"),
 		["dual-genius"]: getConfig("lyrics-plus:visual:dual-genius"),
 		["global-delay"]: Number(localStorage.getItem("lyrics-plus:visual:global-delay")) || 0,
-		["track-delay"]: 0
+		delay: 0
 	},
 	providers: {
 		netease: {
@@ -344,7 +344,7 @@ class LyricsContainer extends react.Component {
 	}
 
 	resetDelay() {
-		CONFIG.visual["track-delay"] = Number(localStorage.getItem(`lyrics-track-delay:${Spicetify.Player.data.track.uri}`)) || 0;
+		CONFIG.visual.delay = Number(localStorage.getItem(`lyrics-delay:${Spicetify.Player.data.track.uri}`)) || 0;
 	}
 
 	async onVersionChange(items, index) {

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -55,7 +55,8 @@ const CONFIG = {
 		["fullscreen-key"]: localStorage.getItem("lyrics-plus:visual:fullscreen-key") || "f12",
 		["synced-compact"]: getConfig("lyrics-plus:visual:synced-compact"),
 		["dual-genius"]: getConfig("lyrics-plus:visual:dual-genius"),
-		delay: 0
+		["global-delay"]: Number(localStorage.getItem("lyrics-plus:visual:global-delay")) || 0,
+		["track-delay"]: 0
 	},
 	providers: {
 		netease: {
@@ -343,7 +344,7 @@ class LyricsContainer extends react.Component {
 	}
 
 	resetDelay() {
-		CONFIG.visual.delay = Number(localStorage.getItem(`lyrics-delay:${Spicetify.Player.data.track.uri}`)) || 0;
+		CONFIG.visual["track-delay"] = Number(localStorage.getItem(`lyrics-track-delay:${Spicetify.Player.data.track.uri}`)) || 0;
 	}
 
 	async onVersionChange(items, index) {


### PR DESCRIPTION
This PR resolves #1765, adds a global delay option in lyrics-plus settings.
This global delay is added onto the track delay (previously named just 'delay').

![image](https://user-images.githubusercontent.com/22730962/233823851-d3129c0b-b91f-4545-849c-54bfe7b4f4de.png)

