### PR TITLE
feat(config): string type value remove flag

### DIFF
--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -163,7 +163,7 @@ func stringType(section *ini.Section, field, value string) {
 	if err != nil {
 		utils.Fatal(err)
 	}
-	if len(strings.TrimSpace(value)) == 0 {
+	if len(strings.TrimSpace(value)) == 0 || value[len(value)-1] == '-' {
 		value = ""
 	}
 	key.SetValue(value)


### PR DESCRIPTION
Currently the arraytype function that handles extensions and custom_apps lets you pass a flag like so to remove its entry from the config: `spicetify config extensions extension.js-`

This PR adds this functionality to stringtype function which includes: "prefs_path", "spotify_path", "current_theme",  and "color_scheme".

![image](https://user-images.githubusercontent.com/22730962/234502475-64603335-cebd-4a3c-a4bd-3ac98dfab4c8.png)
