### PR TITLE
feat(react-component): add `ConfirmDialog`

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -2170,8 +2170,5 @@
     "mph1R_QkS44EPi4lrhxd": "main-contextMenu-tippyEnter",
     "v5IUMJNPJgol0273zQXD": "main-contextMenu-tippyEnterActive",
     "RbsCNNM9a0WkFCM2UzBA": "main-addButton-button",
-    "SPC4uzYXJmknkCGKpxHw": "main-addButton-active",
-    "RVgHI2ejYct8LjT1AO7m": "main-confirmDialog-container",
-    "m0yIuS1Q6XRA5R4PNEhl": "main-confirmDialog-overlay",
-    "X05XDhpQJ7THPHfgbUk1": "main-confirmDialog-buttonContainer"
+    "SPC4uzYXJmknkCGKpxHw": "main-addButton-active"
 }

--- a/css-map.json
+++ b/css-map.json
@@ -2170,5 +2170,8 @@
     "mph1R_QkS44EPi4lrhxd": "main-contextMenu-tippyEnter",
     "v5IUMJNPJgol0273zQXD": "main-contextMenu-tippyEnterActive",
     "RbsCNNM9a0WkFCM2UzBA": "main-addButton-button",
-    "SPC4uzYXJmknkCGKpxHw": "main-addButton-active"
+    "SPC4uzYXJmknkCGKpxHw": "main-addButton-active",
+    "RVgHI2ejYct8LjT1AO7m": "main-confirmDialog-container",
+    "m0yIuS1Q6XRA5R4PNEhl": "main-confirmDialog-overlay",
+    "X05XDhpQJ7THPHfgbUk1": "main-confirmDialog-buttonContainer"
 }

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -962,7 +962,7 @@ declare namespace Spicetify {
              */
             weight?: "book" | "bold" | "black";
         }
-        type ConfimDialogProps = {
+        type ConfirmDialogProps = {
             /**
              * Boolean to determine if the dialog should be opened
              * @default true
@@ -1084,7 +1084,9 @@ declare namespace Spicetify {
          * Component to render Spotify-style confirm dialog
          *
          * Props:
-         * @see Spicetify.ReactComponent.ConfimDialogProps
+         * @see Spicetify.ReactComponent.ConfirmDialogProps
+         */
+        const ConfirmDialog: any;
     }
 
     /**

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -962,6 +962,59 @@ declare namespace Spicetify {
              */
             weight?: "book" | "bold" | "black";
         }
+        type ConfimDialogProps = {
+            /**
+             * Boolean to determine if the dialog should be opened
+             * @default true
+             */
+            isOpen?: boolean;
+            /**
+             * Whether to allow inline HTML in component text
+             * @default false
+             */
+            allowHTML?: boolean;
+            /**
+             * Dialog title. Can be inline HTML if `allowHTML` is true
+             */
+            titleText: string;
+            /**
+             * Dialog description. Can be inline HTML if `allowHTML` is true
+             */
+            descriptionText?: string;
+            /**
+             * Confirm button text
+             */
+            confirmText?: string;
+            /**
+             * Cancel button text
+             */
+            cancelText?: string;
+            /**
+             * Confirm button aria-label
+             */
+            confirmLabel?: string;
+            /**
+             * Function to run when confirm button is clicked
+             * The dialog does not close automatically, a handler must be included.
+             * @param {React.MouseEvent<HTMLButtonElement>} event
+             */
+            onConfirm?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+            /**
+             * Function to run when cancel button is clicked.
+             * The dialog does not close automatically, a handler must be included.
+             * @param {React.MouseEvent<HTMLButtonElement>} event
+             * @default () => {}
+             */
+            onClose?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+            /**
+             * Function to run when dialog is clicked outside of.
+             * By default, this will run `onClose`.
+             * A handler must be included to close the dialog.
+             * @param {React.MouseEvent<HTMLButtonElement>} event
+             * @default () => {}
+             */
+            onOutside?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+        }
         /**
          * Generic context menu provider
          *
@@ -1027,6 +1080,11 @@ declare namespace Spicetify {
          * @see Spicetify.ReactComponent.TextComponentProps
          */
         const TextComponent: any;
+        /**
+         * Component to render Spotify-style confirm dialog
+         *
+         * Props:
+         * @see Spicetify.ReactComponent.ConfimDialogProps
     }
 
     /**

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -167,7 +167,8 @@ const Spicetify = {
             "PlaylistMenu",
             "TooltipWrapper",
             "TextComponent",
-            "IconComponent"
+            "IconComponent",
+            "ConfirmDialog",
         ]
 
         let count = SPICETIFY_METHOD.length;

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -385,7 +385,7 @@ Spicetify.React.useEffect(() => {
 	// React Component: Confirm Dialog
 	utils.Replace(
 		&input,
-		`function ?([\w$_]+)\(\{(?:(?:onClose|isOpen|onOutside|titleText)[:!\w(){}=>]*,){3,}`,
+		`function ?([\w$_]+)\(\{(?:(?:onClose|isOpen|onOutside|titleText)[:!\w$_(){}=>]*,){3,}`,
 		`Spicetify.ReactComponent.ConfirmDialog=${1};${0}`)
 
 	// Locale

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -382,6 +382,12 @@ Spicetify.React.useEffect(() => {
 		`(\w+)(=(?:function\([\{\w\}:,]+\)|\()\{(?:[\w. =]*(?:label|children|renderInline|showDelay)[\w:]*,?){4})`,
 		`${1}=Spicetify.ReactComponent.TooltipWrapper${2}`)
 
+	// React Component: Confirm Dialog
+	utils.Replace(
+		&input,
+		`function ?([\w$_]+)\(\{(?:(?:onClose|isOpen|onOutside|titleText)[:!\w(){}=>]*,){3,}`,
+		`Spicetify.ReactComponent.ConfirmDialog=${1};${0}`)
+
 	// Locale
 	utils.Replace(
 		&input,


### PR DESCRIPTION
Hooks a new component to display a confirmation dialog as a popup modal. Works on `1.1.97` and above, have not tested below.
![image](https://user-images.githubusercontent.com/77577746/234900242-c4af8bbd-2aa0-4708-bc9a-2cd4b4e459c7.png)
![image](https://user-images.githubusercontent.com/77577746/234900360-b3e4c86a-e80c-4415-b1f3-d0aa4e2a559c.png)
