### PR TITLE
fix(lyrics-plus): handle Musixmatch ratelimit

### DIFF
--- a/CustomApps/lyrics-plus/ProviderMusixmatch.js
+++ b/CustomApps/lyrics-plus/ProviderMusixmatch.js
@@ -116,7 +116,7 @@ const ProviderMusixmatch = (function () {
 		if (isInstrumental) {
 			return [{ text: "♪ Instrumental ♪", startTime: "0000" }];
 		} else if (hasSynced) {
-			const subtitle = body["track.subtitles.get"]?.message?.body.subtitle_list?.[0]?.subtitle;
+			const subtitle = body["track.subtitles.get"]?.message?.body?.subtitle_list?.[0]?.subtitle;
 			if (!subtitle) {
 				return null;
 			}


### PR DESCRIPTION
Happens after a few reloads, would throw lyrics fetching for the whole session