### PR TITLE
feat: hook GraphQL wrapper

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1183,4 +1183,38 @@ declare namespace Spicetify {
          */
         function sub(callback: (title: string) => void): { clear: () => void };
     }
+
+    /**
+     * Spicetify's QraphQL wrapper for Spotify's GraphQL API endpoints
+     */
+    namespace GraphQL {
+        /**
+         * Possible types of entities
+         * This list is dynamic and may change in the future
+         */
+        type Query = "decorateItemsForEnhance" | "imageURLAndSize" | "imageSources" | "audioItems" | "creator" | "extractedColors" | "extractedColorsAndImageSources" | "fetchExtractedColorAndImageForAlbumEntity" | "fetchExtractedColorAndImageForArtistEntity" | "fetchExtractedColorAndImageForEpisodeEntity" | "fetchExtractedColorAndImageForPlaylistEntity" | "fetchExtractedColorAndImageForPodcastEntity" | "fetchExtractedColorAndImageForTrackEntity" | "fetchExtractedColorForAlbumEntity" | "fetchExtractedColorForArtistEntity" | "fetchExtractedColorForEpisodeEntity" | "fetchExtractedColorForPlaylistEntity" | "fetchExtractedColorForPodcastEntity" | "fetchExtractedColorForTrackEntity" | "getAlbumNameAndTracks" | "getEpisodeName" | "getTrackName" | "queryAlbumTrackUris" | "queryTrackArtists" | "decorateContextEpisodesOrChapters" | "decorateContextTracks" | "fetchTracksForRadioStation" | "decoratePlaylists" | "addToLibrary" | "removeFromLibrary" | "pinLibraryItem" | "unpinLibraryItem" | "fetchLibraryAlbums" | "areAlbumsInLibrary" | "fetchLibraryArtists" | "areArtistsInLibrary" | "fetchLibraryTracks" | "areTracksInLibrary" | "fetchLibraryShows" | "areShowsInLibrary" | "fetchLibraryAudiobooks" | "fetchLibraryEpisodes" | "areEpisodesInLibrary" | "libraryV2" | "playlistUser" | "FetchPlaylistMetadata" | "playlistContentsItemTrackArtist" | "playlistContentsItemTrackAlbum" | "playlistContentsItemTrack" | "playlistContentsItemLocalTrack" | "playlistContentsItemEpisodeShow" | "playlistContentsItemEpisode" | "playlistContentsItemResponse" | "playlistContentsItem" | "FetchPlaylistContents" | "fetchPlaylist" | "fetchPlaylistMetadata" | "fetchPlaylistContents" | "addToPlaylist" | "removeFromPlaylist" | "moveItemsInPlaylist" | "fetchEntitiesForRecentlyPlayed" | "queryShowAccessInfo" | "episodeTrailerUri" | "podcastEpisode" | "podcastMetadataV2" | "minimalAudiobook" | "audiobookChapter" | "audiobookMetadataV2" | "queryShowMetadataV2" | "queryBookChapters" | "getEpisodeOrChapter" | "queryPodcastEpisodes" | "fetchExtractedColors" | "queryFullscreenMode" | "queryNpvEpisode" | "queryNpvArtist" | "albumTrack" | "getAlbum" | "queryAlbumTracks" | "queryArtistOverview" | "queryArtistAppearsOn" | "discographyAlbum" | "albumMetadataReleases" | "albumMetadata" | "queryArtistDiscographyAlbums" | "queryArtistDiscographySingles" | "queryArtistDiscographyCompilations" | "queryArtistDiscographyAll" | "queryArtistDiscographyOverview" | "artistPlaylist" | "queryArtistPlaylists" | "queryArtistDiscoveredOn" | "queryArtistFeaturing" | "queryArtistRelated" | "queryArtistMinimal" | "searchModalResults" | "queryWhatsNewFeed" | "whatsNewFeedNewItems" | "SetItemsStateInWhatsNewFeed" | "browseImageURLAndSize" | "browseImageSources" | "browseAlbum" | "browseArtist" | "browseEpisode" | "browseChapter" | "browsePlaylist" | "browsePodcast" | "browseAudiobook" | "browseTrack" | "browseUser" | "browseMerch" | "browseArtistConcerts" | "browseContent" | "browseSectionContainer" | "browseClientFeature" | "browseItem" | "browseAll";
+        /**
+         * GraphQL query definitions.
+         */
+        const Definitions: Record<Query | string, any>;
+        /**
+         * Send a GraphQL query to Spotify.
+         * @description A preinitialized version of `Spicetify.GraphQL.Handler` using current context.
+         * @param query Query to send
+         * @param variables Variables to use
+         * @return Promise that resolves to the response
+         */
+        function Request(query: typeof Definitions[Query | string], variables?: Record<string, any>): Promise<any>;
+        /**
+         * Context for GraphQL queries.
+         * Use this to set context for the handler and initialze it
+         */
+        const Context: Record<string | any>;
+        /**
+         * Handler for GraphQL queries
+         * @param context Context to use
+         * @return Function to handle GraphQL queries
+         */
+        function Handler(context: Record<string | any>): (query: string, variables?: Record<string, any>) => Promise<any>;
+    }
 }

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1189,8 +1189,9 @@ declare namespace Spicetify {
      */
     namespace GraphQL {
         /**
-         * Possible types of entities
-         * This list is dynamic and may change in the future
+         * Possible types of entities.
+         *
+         * This list is dynamic and may change in the future.
          */
         type Query = "decorateItemsForEnhance" | "imageURLAndSize" | "imageSources" | "audioItems" | "creator" | "extractedColors" | "extractedColorsAndImageSources" | "fetchExtractedColorAndImageForAlbumEntity" | "fetchExtractedColorAndImageForArtistEntity" | "fetchExtractedColorAndImageForEpisodeEntity" | "fetchExtractedColorAndImageForPlaylistEntity" | "fetchExtractedColorAndImageForPodcastEntity" | "fetchExtractedColorAndImageForTrackEntity" | "fetchExtractedColorForAlbumEntity" | "fetchExtractedColorForArtistEntity" | "fetchExtractedColorForEpisodeEntity" | "fetchExtractedColorForPlaylistEntity" | "fetchExtractedColorForPodcastEntity" | "fetchExtractedColorForTrackEntity" | "getAlbumNameAndTracks" | "getEpisodeName" | "getTrackName" | "queryAlbumTrackUris" | "queryTrackArtists" | "decorateContextEpisodesOrChapters" | "decorateContextTracks" | "fetchTracksForRadioStation" | "decoratePlaylists" | "addToLibrary" | "removeFromLibrary" | "pinLibraryItem" | "unpinLibraryItem" | "fetchLibraryAlbums" | "areAlbumsInLibrary" | "fetchLibraryArtists" | "areArtistsInLibrary" | "fetchLibraryTracks" | "areTracksInLibrary" | "fetchLibraryShows" | "areShowsInLibrary" | "fetchLibraryAudiobooks" | "fetchLibraryEpisodes" | "areEpisodesInLibrary" | "libraryV2" | "playlistUser" | "FetchPlaylistMetadata" | "playlistContentsItemTrackArtist" | "playlistContentsItemTrackAlbum" | "playlistContentsItemTrack" | "playlistContentsItemLocalTrack" | "playlistContentsItemEpisodeShow" | "playlistContentsItemEpisode" | "playlistContentsItemResponse" | "playlistContentsItem" | "FetchPlaylistContents" | "fetchPlaylist" | "fetchPlaylistMetadata" | "fetchPlaylistContents" | "addToPlaylist" | "removeFromPlaylist" | "moveItemsInPlaylist" | "fetchEntitiesForRecentlyPlayed" | "queryShowAccessInfo" | "episodeTrailerUri" | "podcastEpisode" | "podcastMetadataV2" | "minimalAudiobook" | "audiobookChapter" | "audiobookMetadataV2" | "queryShowMetadataV2" | "queryBookChapters" | "getEpisodeOrChapter" | "queryPodcastEpisodes" | "fetchExtractedColors" | "queryFullscreenMode" | "queryNpvEpisode" | "queryNpvArtist" | "albumTrack" | "getAlbum" | "queryAlbumTracks" | "queryArtistOverview" | "queryArtistAppearsOn" | "discographyAlbum" | "albumMetadataReleases" | "albumMetadata" | "queryArtistDiscographyAlbums" | "queryArtistDiscographySingles" | "queryArtistDiscographyCompilations" | "queryArtistDiscographyAll" | "queryArtistDiscographyOverview" | "artistPlaylist" | "queryArtistPlaylists" | "queryArtistDiscoveredOn" | "queryArtistFeaturing" | "queryArtistRelated" | "queryArtistMinimal" | "searchModalResults" | "queryWhatsNewFeed" | "whatsNewFeedNewItems" | "SetItemsStateInWhatsNewFeed" | "browseImageURLAndSize" | "browseImageSources" | "browseAlbum" | "browseArtist" | "browseEpisode" | "browseChapter" | "browsePlaylist" | "browsePodcast" | "browseAudiobook" | "browseTrack" | "browseUser" | "browseMerch" | "browseArtistConcerts" | "browseContent" | "browseSectionContainer" | "browseClientFeature" | "browseItem" | "browseAll";
         /**
@@ -1198,7 +1199,7 @@ declare namespace Spicetify {
          */
         const Definitions: Record<Query | string, any>;
         /**
-         * Send a GraphQL query to Spotify.
+         * Sends a GraphQL query to Spotify.
          * @description A preinitialized version of `Spicetify.GraphQL.Handler` using current context.
          * @param query Query to send
          * @param variables Variables to use
@@ -1207,11 +1208,11 @@ declare namespace Spicetify {
         function Request(query: typeof Definitions[Query | string], variables?: Record<string, any>): Promise<any>;
         /**
          * Context for GraphQL queries.
-         * Use this to set context for the handler and initialze it
+         * @description Used to set context for the handler and initialze it.
          */
         const Context: Record<string | any>;
         /**
-         * Handler for GraphQL queries
+         * Handler for GraphQL queries.
          * @param context Context to use
          * @return Function to handle GraphQL queries
          */

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -215,6 +215,13 @@ const Spicetify = {
                 console.log(`Spicetify.ReactComponent method ${key} exists but is not in the method list. Consider adding it.`)
             }
         })
+    },
+    GraphQL: {
+        get Request() {
+            if (!Spicetify.GraphQL.Handler || !Spicetify.GraphQL.Context) return null;
+            return Spicetify.GraphQL.Handler(Spicetify.GraphQL.Context);
+        },
+        Definitions: {}
     }
 };
 

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -400,6 +400,18 @@ Spicetify.React.useEffect(() => {
 		`document.pictureInPictureElement&&\(\w+.current=[!\w]+,document\.exitPictureInPicture\(\)\),\w+\.current=null`,
 		``)
 
+	// GraphQL handler
+	utils.Replace(
+		&input,
+		`(function ([\w$]+)\(([\w$])\)\{)(return [\w$&.,={}()[\]?!=>:; ]+"subscription")`,
+		`Spicetify.GraphQL.Handler=${2};${1}Spicetify.GraphQL.Context??=${3};${4}`)
+
+	// GraphQL definitions
+	utils.Replace(
+		&input,
+		`((?:\w+ ?)?[\w$]+=)(\{kind:"Document",definitions:\[\{(?:\w+:[\w"]+,)+name:\{(?:\w+:[\w"]+,?)+value:("\w+"))`,
+		`${1}Spicetify.GraphQL.Definitions[${3}]=${2}`)
+
 	return input
 }
 


### PR DESCRIPTION
Hooks onto Spotify's GraphQL handler and definitions. This allows developers to make queries to Spotify GraphQL endpoints easily without having to use obscure hashes for persisted query validation.
Works on `1.1.90` and above, have not tested below.
![image](https://user-images.githubusercontent.com/77577746/235356005-846f7538-d9da-48da-9239-d7c813f63e70.png)
![image](https://user-images.githubusercontent.com/77577746/235356050-2f50a6ba-caaa-4371-b2cf-88b09a88dd42.png)

This also includes all possible definitions for accepted queries
![image](https://user-images.githubusercontent.com/77577746/235356134-e0ed48ec-923b-44c0-a29f-cfd27440b732.png)
![image](https://user-images.githubusercontent.com/77577746/235356143-6e8511ad-f224-431a-9e1e-34c69342d8ba.png)
These definitions can be passed to the `Request` method as the first parameter for each query you want to fetch.
Additionally, since these are GraphQL definitions, they also include parameter type definitions so developers can easily catch on and utilize it.
![image](https://user-images.githubusercontent.com/77577746/235356237-9a8cf61c-526a-46c8-8d2c-ee0090aa4505.png)
