### PR TITLE
feat(lyrics-plus): improve Netease lyrics algorithm

### DIFF
--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -121,7 +121,7 @@ const ProviderNetease = (function () {
 		const lyrics = lines
 			.map(line => {
 				const { time, text } = parseTimestamp(line);
-				if (text === "纯音乐, 请欣赏") nolyr = true;
+				if (text === "纯音乐, 请欣赏") noLyrics = true;
 				if (!time || !text) return null;
 
 				const [key, value] = time.split(":") || [];

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -111,7 +111,7 @@ const ProviderNetease = (function () {
 
 	function getSynced(list) {
 		const lyricStr = list?.lrc?.lyric;
-		let nolyr = false;
+		let noLyrics = false;
 
 		if (!lyricStr) {
 			return null;

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -175,7 +175,7 @@ const ProviderNetease = (function () {
 
 	function getUnsynced(list) {
 		const lyricStr = list?.lrc?.lyric;
-		let nolyr = false;
+		let noLyrics = false;
 
 		if (!lyricStr) {
 			return null;

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -185,7 +185,7 @@ const ProviderNetease = (function () {
 		const lyrics = lines
 			.map(line => {
 				const parsed = parseTimestamp(line);
-				if (parsed.text === "纯音乐, 请欣赏") nolyr = true;
+				if (parsed.text === "纯音乐, 请欣赏") noLyrics = true;
 				if (!parsed.text || containCredits(parsed.text)) return null;
 				return parsed;
 			})

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -18,7 +18,7 @@ const ProviderNetease = (function () {
 
 		const album = Utils.capitalize(info.album);
 		let itemId = items.findIndex(
-			val => Utils.capitalize(val.album.name) === album || (info.duration + 1000 > val.duration && info.duration - 1000 < val.duration)
+			val => Utils.capitalize(val.album.name) === album || Math.abs(info.duration - val.duration) < 1000
 		);
 		if (itemId === -1) throw "Cannot find track";
 

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -191,7 +191,7 @@ const ProviderNetease = (function () {
 			})
 			.filter(a => a);
 
-		if (!lyrics.length || nolyr) {
+		if (!lyrics.length || noLyrics) {
 			return null;
 		}
 		return lyrics;

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -17,9 +17,7 @@ const ProviderNetease = (function () {
 		}
 
 		const album = Utils.capitalize(info.album);
-		let itemId = items.findIndex(
-			val => Utils.capitalize(val.album.name) === album || Math.abs(info.duration - val.duration) < 1000
-		);
+		let itemId = items.findIndex(val => Utils.capitalize(val.album.name) === album || Math.abs(info.duration - val.duration) < 1000);
 		if (itemId === -1) throw "Cannot find track";
 
 		return await CosmosAsync.get(lyricURL + items[itemId].id, null, requestHeader);

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -17,7 +17,9 @@ const ProviderNetease = (function () {
 		}
 
 		const album = Utils.capitalize(info.album);
-		let itemId = items.findIndex(val => Utils.capitalize(val.album.name) === album || (info.duration+1000 > val.duration && info.duration-1000 < val.duration));
+		let itemId = items.findIndex(
+			val => Utils.capitalize(val.album.name) === album || (info.duration + 1000 > val.duration && info.duration - 1000 < val.duration)
+		);
 		if (itemId === -1) throw "Cannot find track";
 
 		return await CosmosAsync.get(lyricURL + items[itemId].id, null, requestHeader);

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -111,7 +111,7 @@ const ProviderNetease = (function () {
 
 	function getSynced(list) {
 		const lyricStr = list?.lrc?.lyric;
-		let nolyr;
+		let nolyr = false;
 
 		if (!lyricStr) {
 			return null;
@@ -175,7 +175,7 @@ const ProviderNetease = (function () {
 
 	function getUnsynced(list) {
 		const lyricStr = list?.lrc?.lyric;
-		let nolyr;
+		let nolyr = false;
 
 		if (!lyricStr) {
 			return null;

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -121,9 +121,7 @@ const ProviderNetease = (function () {
 		const lyrics = lines
 			.map(line => {
 				const { time, text } = parseTimestamp(line);
-				if (text === "纯音乐, 请欣赏") {
-					noLyrics = true;
-				}
+				if (text === "纯音乐, 请欣赏") noLyrics = true;
 				if (!time || !text) return null;
 
 				const [key, value] = time.split(":") || [];
@@ -187,9 +185,7 @@ const ProviderNetease = (function () {
 		const lyrics = lines
 			.map(line => {
 				const parsed = parseTimestamp(line);
-				if (parsed.text === "纯音乐, 请欣赏") {
-					noLyrics = true;
-				}
+				if (parsed.text === "纯音乐, 请欣赏") noLyrics = true;
 				if (!parsed.text || containCredits(parsed.text)) return null;
 				return parsed;
 			})

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -17,7 +17,7 @@ const ProviderNetease = (function () {
 		}
 
 		const album = Utils.capitalize(info.album);
-		let itemId = items.findIndex(val => Utils.capitalize(val.album.name) === album || (info.duration+500 > val.duration && info.duration-500 < val.duration));
+		let itemId = items.findIndex(val => Utils.capitalize(val.album.name) === album || (info.duration+1000 > val.duration && info.duration-1000 < val.duration));
 		if (itemId === -1) throw "Cannot find track";
 
 		return await CosmosAsync.get(lyricURL + items[itemId].id, null, requestHeader);

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -136,7 +136,7 @@ const ProviderNetease = (function () {
 			})
 			.filter(a => a);
 
-		if (!lyrics.length || nolyr) {
+		if (!lyrics.length || noLyrics) {
 			return null;
 		}
 		return lyrics;

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -121,7 +121,9 @@ const ProviderNetease = (function () {
 		const lyrics = lines
 			.map(line => {
 				const { time, text } = parseTimestamp(line);
-				if (text === "纯音乐, 请欣赏") noLyrics = true;
+				if (text === "纯音乐, 请欣赏") {
+					noLyrics = true;
+				}
 				if (!time || !text) return null;
 
 				const [key, value] = time.split(":") || [];
@@ -185,7 +187,9 @@ const ProviderNetease = (function () {
 		const lyrics = lines
 			.map(line => {
 				const parsed = parseTimestamp(line);
-				if (parsed.text === "纯音乐, 请欣赏") noLyrics = true;
+				if (parsed.text === "纯音乐, 请欣赏") {
+					noLyrics = true;
+				}
 				if (!parsed.text || containCredits(parsed.text)) return null;
 				return parsed;
 			})

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -176,7 +176,7 @@ function PopupLyrics() {
 
 			const album = LyricUtils.capitalize(info.album);
 			let itemId = items.findIndex(
-				val => LyricUtils.capitalize(val.album.name) === album || (info.duration + 1000 > val.duration && info.duration - 1000 < val.duration)
+				val => LyricUtils.capitalize(val.album.name) === album || Math.abs(info.duration - val.duration) < 1000
 			);
 			if (itemId === -1) return { error: "Cannot find track" };
 

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -175,9 +175,7 @@ function PopupLyrics() {
 			}
 
 			const album = LyricUtils.capitalize(info.album);
-			let itemId = items.findIndex(
-				val => LyricUtils.capitalize(val.album.name) === album || Math.abs(info.duration - val.duration) < 1000
-			);
+			let itemId = items.findIndex(val => LyricUtils.capitalize(val.album.name) === album || Math.abs(info.duration - val.duration) < 1000);
 			if (itemId === -1) return { error: "Cannot find track" };
 
 			const meta = await CosmosAsync.get(lyricURL + items[itemId].id, null, requestHeader);

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -213,7 +213,9 @@ function PopupLyrics() {
 						text = matchResult.splice(textIndex, 1)[0];
 						text = LyricUtils.capitalize(LyricUtils.normalize(text, false));
 					}
-					if (text === "纯音乐, 请欣赏") noLyrics = true;
+					if (text === "纯音乐, 请欣赏") {
+						noLyrics = true;
+					}
 					return matchResult.map(slice => {
 						const result = {};
 						const matchResult = slice.match(/[^\[\]]+/g);

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -238,7 +238,7 @@ function PopupLyrics() {
 				})
 				.filter(a => a);
 				
-			if (nolyr) {
+			if (noLyrics) {
 				return { error: "No lyrics" };
 			}
 			if (!lyrics.length) {

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -213,9 +213,7 @@ function PopupLyrics() {
 						text = matchResult.splice(textIndex, 1)[0];
 						text = LyricUtils.capitalize(LyricUtils.normalize(text, false));
 					}
-					if (text === "纯音乐, 请欣赏") {
-						noLyrics = true;
-					}
+					if (text === "纯音乐, 请欣赏") noLyrics = true;
 					return matchResult.map(slice => {
 						const result = {};
 						const matchResult = slice.match(/[^\[\]]+/g);

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -195,7 +195,7 @@ function PopupLyrics() {
 			const otherInfoRegexp = new RegExp(`^(${otherInfoKeys.join("|")}).*(:|：)`, "i");
 
 			const lines = lyricStr.split(/\r?\n/).map(line => line.trim());
-			let nolyr = false;
+			let noLyrics = false;
 			const lyrics = lines
 				.map(line => {
 					// ["[ar:Beyond]"]

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -175,7 +175,9 @@ function PopupLyrics() {
 			}
 
 			const album = LyricUtils.capitalize(info.album);
-			let itemId = items.findIndex(val => LyricUtils.capitalize(val.album.name) === album || (info.duration+1000 > val.duration && info.duration-1000 < val.duration));
+			let itemId = items.findIndex(
+				val => LyricUtils.capitalize(val.album.name) === album || (info.duration + 1000 > val.duration && info.duration - 1000 < val.duration)
+			);
 			if (itemId === -1) return { error: "Cannot find track" };
 
 			const meta = await CosmosAsync.get(lyricURL + items[itemId].id, null, requestHeader);
@@ -237,7 +239,7 @@ function PopupLyrics() {
 					return a.startTime - b.startTime;
 				})
 				.filter(a => a);
-				
+
 			if (noLyrics) {
 				return { error: "No lyrics" };
 			}

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -213,7 +213,7 @@ function PopupLyrics() {
 						text = matchResult.splice(textIndex, 1)[0];
 						text = LyricUtils.capitalize(LyricUtils.normalize(text, false));
 					}
-					if (text === "纯音乐, 请欣赏") nolyr = true;
+					if (text === "纯音乐, 请欣赏") noLyrics = true;
 					return matchResult.map(slice => {
 						const result = {};
 						const matchResult = slice.match(/[^\[\]]+/g);

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -195,7 +195,7 @@ function PopupLyrics() {
 			const otherInfoRegexp = new RegExp(`^(${otherInfoKeys.join("|")}).*(:|：)`, "i");
 
 			const lines = lyricStr.split(/\r?\n/).map(line => line.trim());
-			let nolyr;
+			let nolyr = false;
 			const lyrics = lines
 				.map(line => {
 					// ["[ar:Beyond]"]

--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -175,7 +175,7 @@ function PopupLyrics() {
 			}
 
 			const album = LyricUtils.capitalize(info.album);
-			let itemId = items.findIndex(val => LyricUtils.capitalize(val.album.name) === album || (info.duration+500 > val.duration && info.duration-500 < val.duration));
+			let itemId = items.findIndex(val => LyricUtils.capitalize(val.album.name) === album || (info.duration+1000 > val.duration && info.duration-1000 < val.duration));
 			if (itemId === -1) return { error: "Cannot find track" };
 
 			const meta = await CosmosAsync.get(lyricURL + items[itemId].id, null, requestHeader);


### PR DESCRIPTION
1. The existing Netease lyrics were too inaccurate. In addition to comparing album names, this commit adds a method of comparing the length of the song in milliseconds (milliseconds are specified as ±500 milliseconds because there is a slight error), if either of these conditions is not met, it returns no lyrics (because otherwise useless lyrics will be returned)
2. The return value "纯音乐, 请欣赏" for lyrics Netease doesn't seem to be the track Instrumental. Sometimes when listening to local music or songs by indie artists, Instrumental is displayed. Therefore, it was modified to be displayed as no lyrics.
3. Fixed an issue where, when viewing the lyrics of Netease" in popupLyrics, the song would be displayed as prelude if there was a blank during the lyrics. the problem did not exist in lyrics-plus, so please leave an answer if this feature is intended.