### PR TITLE
fix(lyrics-plus): lyrics not fetched on queue change

### DIFF
--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -487,32 +487,11 @@ class LyricsContainer extends react.Component {
 	}
 
 	componentDidMount() {
-		this.onQueueChange = async queue => {
-			queue = queue.data;
+		this.onQueueChange = queue => {
 			this.state.explicitMode = this.state.lockMode;
-			this.currentTrackUri = queue.current.uri;
-
-			let nextTrack;
-			if (queue.queued.length) {
-				nextTrack = queue.queued[0];
-			} else {
-				nextTrack = queue.nextUp[0];
-			}
-
-			const nextInfo = this.infoFromTrack(nextTrack);
-			if (!nextInfo) {
-				this.fetchLyrics(queue.current, this.state.explicitMode);
-				return;
-			}
-			// Debounce queue change emitter
-			if (nextInfo.uri === this.nextTrackUri) {
-				return;
-			}
-			this.nextTrackUri = nextInfo.uri;
-			this.fetchLyrics(queue.current, this.state.explicitMode);
+			this.currentTrackUri = queue.data.current.uri;
+			this.fetchLyrics(queue.data.current, this.state.explicitMode);
 			this.viewPort.scrollTo(0, 0);
-			// Fetch next track
-			this.tryServices(nextInfo, this.state.explicitMode);
 		};
 
 		if (Spicetify.Player?.data?.track) {


### PR DESCRIPTION
I dont want to remove the functionality of fetching the next song and its lyrics, however it seems very buggy and messes with the queueing of multiple types of contexts. E.G songs from multiple different playlists, albums, or folders.

I'm happy to look into this further and re-implement it in a working fashion, however im not seeing any of the issues that fetching the next songs lyrics was supposed to solve anymore.