### PR TITLE
feat(new-releases): dismissible cards

### DIFF
--- a/CustomApps/new-releases/Card.js
+++ b/CustomApps/new-releases/Card.js
@@ -21,6 +21,7 @@ class Card extends react.Component {
 
 	closeButtonClicked(event) {
 		removeCards(this.props.uri);
+		Spicetify.showNotification(`Dismissed <b>${this.title}</b> from <b>${this.artist.name}</b>`);
 		event.stopPropagation();
 	}
 
@@ -112,7 +113,7 @@ class Card extends react.Component {
 						),
 						react.createElement(
 							Spicetify.ReactComponent.TooltipWrapper,
-							{ label: "Close" },
+							{ label: "Dismiss" },
 							react.createElement(
 								"button",
 								{

--- a/CustomApps/new-releases/Card.js
+++ b/CustomApps/new-releases/Card.js
@@ -19,6 +19,11 @@ class Card extends react.Component {
 		event.stopPropagation();
 	}
 
+	closeButtonClicked(event) {
+		removeCards(this.props.uri);
+		event.stopPropagation();
+	}
+
 	render() {
 		let detail = [];
 		this.visual.type && detail.push(this.type);
@@ -44,7 +49,7 @@ class Card extends react.Component {
 					"div",
 					{
 						className: "main-card-draggable",
-						draggable: "true"
+						draggable: "false"
 					},
 					react.createElement(
 						"div",
@@ -103,6 +108,34 @@ class Card extends react.Component {
 										)
 									)
 								)
+							)
+						),
+						react.createElement(
+							"button",
+							{
+								className: "main-card-closeButton",
+								onClick: this.closeButtonClicked.bind(this),
+								style: {
+									position: "absolute",
+									top: "10px",
+									right: "10px"
+								}
+							},
+							react.createElement(
+								"svg",
+								{
+									width: "18",
+									height: "18",
+									viewBox: "0 0 32 32",
+									xmlns: "http://www.w3.org/2000/svg",
+									className: "main-card-closeButton-svg"
+								},
+								react.createElement("title", null, "Close"),
+								react.createElement("path", {
+									d: "M31.098 29.794L16.955 15.65 31.097 1.51 29.683.093 15.54 14.237 1.4.094-.016 1.508 14.126 15.65-.016 29.795l1.414 1.414L15.54 17.065l14.144 14.143",
+									fill: "var(--spice-text)",
+									fillRule: "evenodd"
+								})
 							)
 						)
 					),

--- a/CustomApps/new-releases/Card.js
+++ b/CustomApps/new-releases/Card.js
@@ -111,31 +111,29 @@ class Card extends react.Component {
 							)
 						),
 						react.createElement(
-							"button",
-							{
-								className: "main-card-closeButton",
-								onClick: this.closeButtonClicked.bind(this),
-								style: {
-									position: "absolute",
-									top: "10px",
-									right: "10px"
-								}
-							},
+							Spicetify.ReactComponent.TooltipWrapper,
+							{ label: "Close" },
 							react.createElement(
-								"svg",
+								"button",
 								{
-									width: "18",
-									height: "18",
-									viewBox: "0 0 32 32",
-									xmlns: "http://www.w3.org/2000/svg",
-									className: "main-card-closeButton-svg"
+									className: "main-card-closeButton",
+									onClick: this.closeButtonClicked.bind(this)
 								},
-								react.createElement("title", null, "Close"),
-								react.createElement("path", {
-									d: "M31.098 29.794L16.955 15.65 31.097 1.51 29.683.093 15.54 14.237 1.4.094-.016 1.508 14.126 15.65-.016 29.795l1.414 1.414L15.54 17.065l14.144 14.143",
-									fill: "var(--spice-text)",
-									fillRule: "evenodd"
-								})
+								react.createElement(
+									"svg",
+									{
+										width: "18",
+										height: "18",
+										viewBox: "0 0 32 32",
+										xmlns: "http://www.w3.org/2000/svg",
+										className: "main-card-closeButton-svg"
+									},
+									react.createElement("path", {
+										d: "M31.098 29.794L16.955 15.65 31.097 1.51 29.683.093 15.54 14.237 1.4.094-.016 1.508 14.126 15.65-.016 29.795l1.414 1.414L15.54 17.065l14.144 14.143",
+										fill: "var(--spice-text)",
+										fillRule: "evenodd"
+									})
+								)
 							)
 						)
 					),

--- a/CustomApps/new-releases/Settings.js
+++ b/CustomApps/new-releases/Settings.js
@@ -269,7 +269,30 @@ function openConfig() {
 				}
 				localStorage.setItem(`${APP_NAME}:${name}`, value);
 			}
-		})
+		}),
+		react.createElement(
+			"div",
+			{
+				className: "setting-row"
+			},
+			react.createElement(
+				"label",
+				{
+					className: "col description"
+				},
+				"Dismissed releases"
+			),
+			react.createElement(
+				"div",
+				{
+					className: "col action"
+				},
+				react.createElement(ButtonText, {
+					text: Spicetify.Locale.get("equalizer.reset"),
+					onClick: removeCards.bind(this, null, "reset")
+				})
+			)
+		)
 	);
 
 	Spicetify.PopupModal.display({

--- a/CustomApps/new-releases/index.js
+++ b/CustomApps/new-releases/index.js
@@ -83,6 +83,8 @@ class Grid extends react.Component {
 	updatePostsVisual() {
 		gridList = [];
 		for (const date of dateList) {
+			if (separatedByDate[date].every(card => dismissed.includes(card.props.uri))) continue;
+
 			gridList.push(
 				react.createElement(
 					"div",
@@ -174,6 +176,8 @@ class Grid extends react.Component {
 		}
 
 		for (const date of dateList) {
+			if (separatedByDate[date].every(card => dismissed.includes(card.props.uri))) continue;
+
 			gridList.push(
 				react.createElement(
 					"div",

--- a/CustomApps/new-releases/index.js
+++ b/CustomApps/new-releases/index.js
@@ -193,7 +193,7 @@ class Grid extends react.Component {
 							"--grid-gap": "24px"
 						}
 					},
-					separatedByDate[date]
+					separatedByDate[date].filter(card => !dismissed.includes(card.props.uri))
 				)
 			);
 		}

--- a/CustomApps/new-releases/index.js
+++ b/CustomApps/new-releases/index.js
@@ -40,7 +40,14 @@ const CONFIG = {
 	relative: getConfig("new-releases:relative", false)
 };
 
-let dismissed = [JSON.parse(Spicetify.LocalStorage.get("new-releases:dismissed")) || null].flat();
+let dismissed;
+try {
+	dismissed = JSON.parse(Spicetify.LocalStorage.get("new-releases:dismissed"));
+	if (!Array.isArray(dismissed)) throw "";
+} catch {
+	dismissed = [];
+}
+
 let gridList = [];
 let lastScroll = 0;
 
@@ -103,7 +110,7 @@ class Grid extends react.Component {
 	}
 
 	removeCards(id) {
-		dismissed = dismissed[0] === null ? [id] : dismissed.concat(id);
+		dismissed.push(id);
 		Spicetify.LocalStorage.set("new-releases:dismissed", JSON.stringify(dismissed));
 		this.reload(true);
 	}
@@ -138,9 +145,7 @@ class Grid extends react.Component {
 		}
 
 		for (const track of items) {
-			if (dismissed.includes(track.uri)) {
-				continue;
-			}
+			if (dismissed.includes(track.uri)) continue;
 
 			track.visual = CONFIG.visual;
 			let dateStr;
@@ -315,9 +320,7 @@ var count = (function () {
 
 async function fetchTracks(silent) {
 	let artistList = await getArtistList();
-	if (!silent) {
-		Spicetify.showNotification(`Fetching releases from ${artistList.length} artists`);
-	}
+	if (!silent) Spicetify.showNotification(`Fetching releases from ${artistList.length} artists`);
 
 	const requests = artistList.map(async obj => {
 		const artist = obj.artistMetadata;

--- a/CustomApps/new-releases/index.js
+++ b/CustomApps/new-releases/index.js
@@ -109,8 +109,18 @@ class Grid extends react.Component {
 		this.setState({ cards: [...gridList] });
 	}
 
-	removeCards(id) {
-		dismissed.push(id);
+	removeCards(id, type) {
+		switch (type) {
+			case "reset":
+				dismissed = [];
+				break;
+			case "undo":
+				dismissed.pop();
+				break;
+			default:
+				dismissed.push(id);
+				break;
+		}
 		Spicetify.LocalStorage.set("new-releases:dismissed", JSON.stringify(dismissed));
 		this.reload(true);
 	}
@@ -241,6 +251,10 @@ class Grid extends react.Component {
 					react.createElement(ButtonText, {
 						text: Spicetify.Locale.get("playlist.extender.refresh"),
 						onClick: this.reload.bind(this)
+					}),
+					react.createElement(ButtonText, {
+						text: "undo", // no locale for this
+						onClick: this.removeCards.bind(this, null, "undo")
 					})
 				)
 			),

--- a/CustomApps/new-releases/style.css
+++ b/CustomApps/new-releases/style.css
@@ -137,6 +137,9 @@ option {
 	inline-size: 32px;
 	block-size: 32px;
 	border-radius: calc(var(--card-container-border-radius) + 2px);
+	position: absolute !important;
+	top: 10px;
+	right: 10px;
 }
 
 .main-card-closeButton {

--- a/CustomApps/new-releases/style.css
+++ b/CustomApps/new-releases/style.css
@@ -125,3 +125,36 @@ option {
 .new-releases-header + .main-gridContainer-gridContainer .main-card-card .main-playButton-PlayButton span:hover {
 	transform: scale(1.04);
 }
+
+.main-card-closeButton {
+	border: none;
+	-webkit-tap-highlight-color: transparent;
+	background-color: rgba(var(--spice-rgb-shadow), 0.7);
+	color: var(--spice-sidebar);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	inline-size: 32px;
+	block-size: 32px;
+	border-radius: calc(var(--card-container-border-radius) + 2px);
+}
+
+.main-card-closeButton {
+	visibility: hidden;
+	opacity: 0;
+	transition: visibility 0s, opacity 0.3s ease;
+}
+
+.main-card-closeButton:active {
+	transform: scale(0.96);
+}
+.main-card-closeButton:hover {
+	background-color: rgba(var(--spice-rgb-shadow), 1);
+	transition: background-color 0s, opacity 1s ease;
+}
+
+.main-card-card:hover .main-card-closeButton {
+	visibility: visible;
+	opacity: 1;
+	transition: visibility 0s, opacity 0.3s ease;
+}


### PR DESCRIPTION
Adds a close button to the top right of cards, once clicked a function is ran that adds the releases uri to an array which is then used by refresh() to refresh the grid whilst skipping those specific uris, aims to resolve #2317.

![image](https://user-images.githubusercontent.com/22730962/236650734-46e55549-7cc2-4968-9000-2c0f937bbf4c.png)

example video:
https://cdn.discordapp.com/attachments/842219447716151310/1104487178702180423/screen-capture.webm