### PR TITLE
feat(fullAppDisplay): show always the exact releaseDate

### DIFF
--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -365,9 +365,11 @@ body.video-full-screen.video-full-screen--hide-ui {
 			const albumInfo = await Spicetify.CosmosAsync.get(`https://api.spotify.com/v1/albums/${id}`);
 
 			const albumDate = new Date(albumInfo.release_date);
-			const recentDate = new Date();
-			recentDate.setMonth(recentDate.getMonth() - 6);
-			return albumDate.toLocaleString("default", albumDate > recentDate ? { year: "numeric", month: "short", day: "numeric" } : { year: "numeric" });
+			return albumDate.toLocaleString("default", {
+				year: "numeric",
+				month: "short",
+				day: "numeric"
+			});
 		}
 
 		async fetchInfo() {


### PR DESCRIPTION
Previously, only albums released in recent 6 months show the exact day, now all albums show their exact release day regardless the album is new or not.