### PR TITLE
style(new-releases): match spotify card styling

### DIFF
--- a/CustomApps/new-releases/Card.js
+++ b/CustomApps/new-releases/Card.js
@@ -123,14 +123,14 @@ class Card extends react.Component {
 								react.createElement(
 									"svg",
 									{
-										width: "18",
-										height: "18",
-										viewBox: "0 0 32 32",
+										width: "16",
+										height: "16",
+										viewBox: "0 0 16 16",
 										xmlns: "http://www.w3.org/2000/svg",
 										className: "main-card-closeButton-svg"
 									},
 									react.createElement("path", {
-										d: "M31.098 29.794L16.955 15.65 31.097 1.51 29.683.093 15.54 14.237 1.4.094-.016 1.508 14.126 15.65-.016 29.795l1.414 1.414L15.54 17.065l14.144 14.143",
+										d: "M1.47 1.47a.75.75 0 0 1 1.06 0L8 6.94l5.47-5.47a.75.75 0 1 1 1.06 1.06L9.06 8l5.47 5.47a.75.75 0 1 1-1.06 1.06L8 9.06l-5.47 5.47a.75.75 0 0 1-1.06-1.06L6.94 8 1.47 2.53a.75.75 0 0 1 0-1.06z",
 										fill: "var(--spice-text)",
 										fillRule: "evenodd"
 									})

--- a/CustomApps/new-releases/index.js
+++ b/CustomApps/new-releases/index.js
@@ -96,12 +96,11 @@ class Grid extends react.Component {
 				react.createElement(
 					"div",
 					{
-						className: "main-gridContainer-gridContainer main-gridContainer-fixedWidth",
+						className: "main-gridContainer-gridContainer ",
 						style: {
-							"--minimumColumnWidth": "180px",
-							"--column-width": "minmax(var(--minimumColumnWidth),1fr)",
+							"--min-container-width": "180px",
 							"--column-count": "auto-fill",
-							"--grid-gap": "24px"
+							"--grid-gap": "18px"
 						}
 					},
 					separatedByDate[date].map(card => !dismissed.includes(card.props.uri) && react.createElement(Card, card.props))
@@ -189,12 +188,11 @@ class Grid extends react.Component {
 				react.createElement(
 					"div",
 					{
-						className: "main-gridContainer-gridContainer main-gridContainer-fixedWidth",
+						className: "main-gridContainer-gridContainer",
 						style: {
-							"--minimumColumnWidth": "180px",
-							"--column-width": "minmax(var(--minimumColumnWidth),1fr)",
+							"--min-container-width": "180px",
 							"--column-count": "auto-fill",
-							"--grid-gap": "24px"
+							"--grid-gap": "18px"
 						}
 					},
 					separatedByDate[date].filter(card => !dismissed.includes(card.props.uri))

--- a/CustomApps/new-releases/style.css
+++ b/CustomApps/new-releases/style.css
@@ -127,37 +127,46 @@ option {
 }
 
 .main-card-closeButton {
-	border: none;
-	-webkit-tap-highlight-color: transparent;
-	background-color: rgba(var(--spice-rgb-shadow), 0.7);
-	color: var(--spice-sidebar);
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	inline-size: 32px;
-	block-size: 32px;
-	border-radius: calc(var(--card-container-border-radius) + 2px);
 	position: absolute !important;
-	top: 10px;
-	right: 10px;
-}
-
-.main-card-closeButton {
+	top: 8px;
+	right: 8px;
+	-webkit-box-align: center;
+	-ms-flex-align: center;
+	-webkit-box-pack: center;
+	-ms-flex-pack: center;
+	align-items: center;
+	background-color: rgba(var(--spice-rgb-shadow), 0.7);
+	border: 0;
+	border-radius: 500px;
+	color: var(--spice-sidebar);
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	height: 28px;
+	justify-content: center;
+	-webkit-transform: scale(1);
+	transform: scale(1);
+	-webkit-transform-origin: center;
+	transform-origin: center;
+	width: 28px;
 	visibility: hidden;
 	opacity: 0;
 	transition: visibility 0s, opacity 0.3s ease;
 }
 
 .main-card-closeButton:active {
-	transform: scale(0.96);
+	transform: scale(1) !important;
 }
 .main-card-closeButton:hover {
-	background-color: rgba(var(--spice-rgb-shadow), 1);
-	transition: background-color 0s, opacity 1s ease;
+	transform: scale(1.1);
 }
 
 .main-card-card:hover .main-card-closeButton {
 	visibility: visible;
 	opacity: 1;
 	transition: visibility 0s, opacity 0.3s ease;
+}
+
+.new-releases-header + .main-gridContainer-gridContainer {
+	grid-template-columns: repeat(var(--column-count), minmax(var(--min-container-width), 1fr)) !important;
 }


### PR DESCRIPTION
Comparison of the new border radius of new-releases card (blue), and default spotify card (red).
![Untitled-1](https://github.com/spicetify/spicetify-cli/assets/22730962/94d76cc5-46f5-485e-a70c-7cc31a22c975)

Since we are unable to receive any of the crucial variables that the radius relies on, i have taken advantage of the fact clamp will default to 0px when --column width isnt present, and since this variable isnt relied on anywhere else there is no need for it and will default to 0px in the clamp as spotify intends.
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/8f155c47-27c8-4adc-81cd-f9f66e9a86eb)

This is a pretty janky solution to come to, but it was either that or modify the --card-container-border-radius mentioned above for a multitude of classes.

this leaves us looking like this:
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/e4fe2b88-e0e3-4e0f-a5b8-6743a2127ae6)
