### PR TITLE
feat(react-hook): add method & `DragHandler`

### DIFF
--- a/CustomApps/new-releases/Card.js
+++ b/CustomApps/new-releases/Card.js
@@ -139,16 +139,16 @@ class Card extends react.Component {
 										"svg",
 										{
 											width: "16",
-										height: "16",
-										viewBox: "0 0 16 16",
-										xmlns: "http://www.w3.org/2000/svg",
-										className: "main-card-closeButton-svg"
-									},
-									react.createElement("path", {
-										d: "M1.47 1.47a.75.75 0 0 1 1.06 0L8 6.94l5.47-5.47a.75.75 0 1 1 1.06 1.06L9.06 8l5.47 5.47a.75.75 0 1 1-1.06 1.06L8 9.06l-5.47 5.47a.75.75 0 0 1-1.06-1.06L6.94 8 1.47 2.53a.75.75 0 0 1 0-1.06z",
-										fill: "var(--spice-text)",
-										fillRule: "evenodd"
-									})
+											height: "16",
+											viewBox: "0 0 16 16",
+											xmlns: "http://www.w3.org/2000/svg",
+											className: "main-card-closeButton-svg"
+										},
+										react.createElement("path", {
+											d: "M1.47 1.47a.75.75 0 0 1 1.06 0L8 6.94l5.47-5.47a.75.75 0 1 1 1.06 1.06L9.06 8l5.47 5.47a.75.75 0 1 1-1.06 1.06L8 9.06l-5.47 5.47a.75.75 0 0 1-1.06-1.06L6.94 8 1.47 2.53a.75.75 0 0 1 0-1.06z",
+											fill: "var(--spice-text)",
+											fillRule: "evenodd"
+										})
 									)
 								)
 							)

--- a/CustomApps/new-releases/Card.js
+++ b/CustomApps/new-releases/Card.js
@@ -1,3 +1,13 @@
+function DraggableComponent({ uri, title, children }) {
+	const dragHandler = Spicetify.ReactHook.DragHandler?.([uri], title);
+	return dragHandler
+		? react.cloneElement(children, {
+				onDragStart: dragHandler,
+				draggable: "true"
+		  })
+		: children;
+}
+
 class Card extends react.Component {
 	constructor(props) {
 		super(props);
@@ -47,146 +57,157 @@ class Card extends react.Component {
 					}
 				},
 				react.createElement(
-					"div",
+					DraggableComponent,
 					{
-						className: "main-card-draggable",
-						draggable: "false"
+						uri: this.uri,
+						title: this.title
 					},
 					react.createElement(
 						"div",
 						{
-							className: "main-card-imageContainer"
+							className: "main-card-draggable"
 						},
 						react.createElement(
 							"div",
 							{
-								className: "main-cardImage-imageWrapper"
-							},
-							react.createElement(
-								"div",
-								{},
-								react.createElement("img", {
-									"aria-hidden": "false",
-									draggable: "false",
-									loading: "lazy",
-									src: this.imageURL,
-									className: "main-image-image main-cardImage-image"
-								})
-							)
-						),
-						react.createElement(
-							"div",
-							{
-								className: "main-card-PlayButtonContainer"
+								className: "main-card-imageContainer"
 							},
 							react.createElement(
 								"div",
 								{
-									className: "main-playButton-PlayButton main-playButton-primary",
-									"aria-label": Spicetify.Locale.get("play"),
-									style: { "--size": "40px" },
-									onClick: this.play.bind(this)
+									className: "main-cardImage-imageWrapper"
 								},
 								react.createElement(
-									"button",
-									null,
+									"div",
+									{},
+									react.createElement("img", {
+										"aria-hidden": "false",
+										draggable: "false",
+										loading: "lazy",
+										src: this.imageURL,
+										className: "main-image-image main-cardImage-image"
+									})
+								)
+							),
+							react.createElement(
+								"div",
+								{
+									className: "main-card-PlayButtonContainer"
+								},
+								react.createElement(
+									"div",
+									{
+										className: "main-playButton-PlayButton main-playButton-primary",
+										"aria-label": Spicetify.Locale.get("play"),
+										style: { "--size": "40px" },
+										onClick: this.play.bind(this)
+									},
 									react.createElement(
-										"span",
+										"button",
 										null,
 										react.createElement(
-											"svg",
-											{
-												height: "24",
-												role: "img",
-												width: "24",
-												viewBox: "0 0 24 24",
-												"aria-hidden": "true"
-											},
-											react.createElement("polygon", {
-												points: "21.57 12 5.98 3 5.98 21 21.57 12",
-												fill: "currentColor"
-											})
+											"span",
+											null,
+											react.createElement(
+												"svg",
+												{
+													height: "24",
+													role: "img",
+													width: "24",
+													viewBox: "0 0 24 24",
+													"aria-hidden": "true"
+												},
+												react.createElement("polygon", {
+													points: "21.57 12 5.98 3 5.98 21 21.57 12",
+													fill: "currentColor"
+												})
+											)
 										)
+									)
+								)
+							),
+							react.createElement(
+								Spicetify.ReactComponent.TooltipWrapper,
+								{ label: "Dismiss" },
+								react.createElement(
+									"button",
+									{
+										className: "main-card-closeButton",
+										onClick: this.closeButtonClicked.bind(this)
+									},
+									react.createElement(
+										"svg",
+										{
+											width: "18",
+											height: "18",
+											viewBox: "0 0 32 32",
+											xmlns: "http://www.w3.org/2000/svg",
+											className: "main-card-closeButton-svg"
+										},
+										react.createElement("path", {
+											d: "M31.098 29.794L16.955 15.65 31.097 1.51 29.683.093 15.54 14.237 1.4.094-.016 1.508 14.126 15.65-.016 29.795l1.414 1.414L15.54 17.065l14.144 14.143",
+											fill: "var(--spice-text)",
+											fillRule: "evenodd"
+										})
 									)
 								)
 							)
 						),
 						react.createElement(
-							Spicetify.ReactComponent.TooltipWrapper,
-							{ label: "Dismiss" },
+							"div",
+							{
+								className: "main-card-cardMetadata"
+							},
 							react.createElement(
-								"button",
+								"a",
 								{
-									className: "main-card-closeButton",
-									onClick: this.closeButtonClicked.bind(this)
+									draggable: "false",
+									title: this.title,
+									className: "main-cardHeader-link",
+									dir: "auto",
+									href: this.href
 								},
 								react.createElement(
-									"svg",
+									"div",
 									{
-										width: "18",
-										height: "18",
-										viewBox: "0 0 32 32",
-										xmlns: "http://www.w3.org/2000/svg",
-										className: "main-card-closeButton-svg"
+										className: "main-cardHeader-text main-type-balladBold"
 									},
-									react.createElement("path", {
-										d: "M31.098 29.794L16.955 15.65 31.097 1.51 29.683.093 15.54 14.237 1.4.094-.016 1.508 14.126 15.65-.016 29.795l1.414 1.414L15.54 17.065l14.144 14.143",
-										fill: "var(--spice-text)",
-										fillRule: "evenodd"
-									})
+									this.title
+								)
+							),
+							detail.length > 0 &&
+								react.createElement(
+									"div",
+									{
+										className: "main-cardSubHeader-root main-type-mestoBold new-releases-cardSubHeader"
+									},
+									react.createElement("span", null, detail.join(" • "))
+								),
+							react.createElement(
+								DraggableComponent,
+								{
+									uri: this.artist.uri,
+									title: this.artist.name
+								},
+								react.createElement(
+									"a",
+									{
+										className: `main-cardSubHeader-root main-type-mesto new-releases-cardSubHeader`,
+										href: this.artistHref,
+										onClick: event => {
+											History.push(this.artistHref);
+											event.stopPropagation();
+											event.preventDefault();
+										}
+									},
+									react.createElement("span", null, this.artist.name)
 								)
 							)
-						)
-					),
-					react.createElement(
-						"div",
-						{
-							className: "main-card-cardMetadata"
-						},
-						react.createElement(
-							"a",
-							{
-								draggable: "false",
-								title: this.title,
-								className: "main-cardHeader-link",
-								dir: "auto",
-								href: this.href
-							},
-							react.createElement(
-								"div",
-								{
-									className: "main-cardHeader-text main-type-balladBold",
-									as: "div"
-								},
-								this.title
-							)
 						),
-						detail.length > 0 &&
-							react.createElement(
-								"div",
-								{
-									className: "main-cardSubHeader-root main-type-mestoBold new-releases-cardSubHeader",
-									as: "div"
-								},
-								react.createElement("span", null, detail.join(" • "))
-							),
-						react.createElement(
-							"a",
-							{
-								className: `main-cardSubHeader-root main-type-mesto new-releases-cardSubHeader`,
-								href: this.artistHref,
-								onClick: event => {
-									History.push(this.artistHref);
-									event.stopPropagation();
-									event.preventDefault();
-								}
-							},
-							react.createElement("span", null, this.artist.name)
-						)
-					),
-					react.createElement("div", {
-						className: "main-card-cardLink"
-					})
+						react.createElement("div", {
+							className: "main-card-cardLink"
+						})
+					)
 				)
 			)
 		);

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1228,9 +1228,21 @@ declare namespace Spicetify {
          * @param contextUri Context URI of the element from which the drag originated (e.g. Playlist URI)
          * @param sectionIndex Index of the section in which the drag originated
          * @param dropOriginUri URI of the desired drop target. Leave empty to allow drop anywhere
-         * @return Function to handle drag event. Should be passed to `onDragStart` prop of the element
+         * @return Function to handle drag event. Should be passed to `onDragStart` prop of the element. All parameters passed onto the hook will be passed onto the handler unless declared otherwise.
          *
          */
-        function DragHandler(uris?: string[], label?: string, contextUri?: string, sectionIndex?: number, dropOriginUri?: string): (event: React.DragEvent) => void;
+        function DragHandler(
+            uris?: string[],
+            label?: string,
+            contextUri?: string,
+            sectionIndex?: number,
+            dropOriginUri?: string
+        ): (
+            event: React.DragEvent,
+            uris?: string[],
+            label?: string,
+            contextUri?: string,
+            sectionIndex?: number
+        ) => void;
     }
 }

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1222,7 +1222,7 @@ declare namespace Spicetify {
     namespace ReactHook {
         /**
          * React Hook to create interactive drag-and-drop element
-         * @description Used if you want to create a draggable element that can be dropped into Spotify's components (e.g. Playlist, Folder, Sidebar, Queue)
+         * @description Used to create a draggable element that can be dropped into Spotify's components (e.g. Playlist, Folder, Sidebar, Queue)
          * @param uris List of URIs to be dragged
          * @param label Label to be displayed when dragging
          * @param contextUri Context URI of the element from which the drag originated (e.g. Playlist URI)
@@ -1237,12 +1237,6 @@ declare namespace Spicetify {
             contextUri?: string,
             sectionIndex?: number,
             dropOriginUri?: string
-        ): (
-            event: React.DragEvent,
-            uris?: string[],
-            label?: string,
-            contextUri?: string,
-            sectionIndex?: number
-        ) => void;
+        ): (event: React.DragEvent, uris?: string[], label?: string, contextUri?: string, sectionIndex?: number) => void;
     }
 }

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1225,9 +1225,9 @@ declare namespace Spicetify {
          * @description Used if you want to create a draggable element that can be dropped into Spotify's components (e.g. Playlist, Folder, Sidebar, Queue)
          * @param uris List of URIs to be dragged
          * @param label Label to be displayed when dragging
-         * @param contextUri Context URI of the element from which the drag originated
+         * @param contextUri Context URI of the element from which the drag originated (e.g. Playlist URI)
          * @param sectionIndex Index of the section in which the drag originated
-         * @param dropOriginUri URI of the element from which the drag originated
+         * @param dropOriginUri URI of the desired drop element
          * @return Function to handle drag event. Should be passed to `onDragStart` prop of the element
          *
          */

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1227,7 +1227,7 @@ declare namespace Spicetify {
          * @param label Label to be displayed when dragging
          * @param contextUri Context URI of the element from which the drag originated (e.g. Playlist URI)
          * @param sectionIndex Index of the section in which the drag originated
-         * @param dropOriginUri URI of the desired drop element
+         * @param dropOriginUri URI of the desired drop target. Leave empty to allow drop anywhere
          * @return Function to handle drag event. Should be passed to `onDragStart` prop of the element
          *
          */

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1210,12 +1210,27 @@ declare namespace Spicetify {
          * Context for GraphQL queries.
          * @description Used to set context for the handler and initialze it.
          */
-        const Context: Record<string | any>;
+        const Context: Record<string, any>;
         /**
          * Handler for GraphQL queries.
          * @param context Context to use
          * @return Function to handle GraphQL queries
          */
-        function Handler(context: Record<string | any>): (query: string, variables?: Record<string, any>) => Promise<any>;
+        function Handler(context: Record<string, any>): (query: string, variables?: Record<string, any>) => Promise<any>;
+    }
+
+    namespace ReactHook {
+        /**
+         * React Hook to create interactive drag-and-drop element
+         * @description Used if you want to create a draggable element that can be dropped into Spotify's components (e.g. Playlist, Folder, Sidebar, Queue)
+         * @param uris List of URIs to be dragged
+         * @param label Label to be displayed when dragging
+         * @param contextUri Context URI of the element from which the drag originated
+         * @param sectionIndex Index of the section in which the drag originated
+         * @param dropOriginUri URI of the element from which the drag originated
+         * @return Function to handle drag event. Should be passed to `onDragStart` prop of the element
+         *
+         */
+        function DragHandler(uris?: string[], label?: string, contextUri?: string, sectionIndex?: number, dropOriginUri?: string): (event: React.DragEvent) => void;
     }
 }

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -241,8 +241,7 @@ const Spicetify = {
     },
     GraphQL: {
         get Request() {
-            if (!Spicetify.GraphQL.Handler || !Spicetify.GraphQL.Context) return null;
-            return Spicetify.GraphQL.Handler(Spicetify.GraphQL.Context);
+            return Spicetify.Platform?.GraphQLLoader || Spicetify.GraphQL.Handler?.(Spicetify.GraphQL.Context);
         },
         Definitions: {}
     },

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -115,7 +115,11 @@ const Spicetify = {
             "RemoteConfigResolver",
             "Playbar",
             "Tippy",
-            "_getStyledClassName"
+            "_getStyledClassName",
+            "GraphQL",
+            "ReactHook",
+            "_sidebarItemXToClone",
+            "AppTitle"
         ];
 
         const PLAYER_METHOD = [
@@ -171,6 +175,10 @@ const Spicetify = {
             "ConfirmDialog",
         ]
 
+        const REACT_HOOK = [
+            "DragHandler"
+        ]
+
         let count = SPICETIFY_METHOD.length;
         SPICETIFY_METHOD.forEach((method) => {
             if (Spicetify[method] === undefined || Spicetify[method] === null) {
@@ -198,6 +206,15 @@ const Spicetify = {
         })
         console.log(`${count}/${REACT_COMPONENT.length} Spicetify.ReactComponent methods and objects are OK.`)
 
+        count = REACT_HOOK.length;
+        REACT_HOOK.forEach((method) => {
+            if (Spicetify.ReactHook[method] === undefined || Spicetify.ReactHook[method] === null) {
+                console.error(`Spicetify.ReactHook.${method} is not available. Please open an issue in the Spicetify repository to inform us about it.`)
+                count--;
+            }
+        })
+        console.log(`${count}/${REACT_HOOK.length} Spicetify.ReactHook methods and objects are OK.`)
+
         Object.keys(Spicetify).forEach(key => {
             if(!SPICETIFY_METHOD.includes(key)) {
                 console.log(`Spicetify method ${key} exists but is not in the method list. Consider adding it.`)
@@ -215,6 +232,12 @@ const Spicetify = {
                 console.log(`Spicetify.ReactComponent method ${key} exists but is not in the method list. Consider adding it.`)
             }
         })
+
+        Object.keys(Spicetify.ReactHook).forEach(key => {
+            if(!REACT_HOOK.includes(key)) {
+                console.log(`Spicetify.ReactHook method ${key} exists but is not in the method list. Consider adding it.`)
+            }
+        })
     },
     GraphQL: {
         get Request() {
@@ -222,7 +245,10 @@ const Spicetify = {
             return Spicetify.GraphQL.Handler(Spicetify.GraphQL.Context);
         },
         Definitions: {}
-    }
+    },
+    ReactComponent: {},
+    ReactHook: {},
+    URI: {},
 };
 
 // Wait for Spicetify.Player.origin._state before adding following APIs
@@ -275,7 +301,6 @@ Spicetify.getAudioData = async (uri) => {
     return await Spicetify.CosmosAsync.get(`wg://audio-attributes/v1/audio-analysis/${uriObj.getBase62Id?.() ?? uriObj.id}?format=json`);
 }
 
-if (!Spicetify.URI) Spicetify.URI = {};
 (function appendValidationFunc() {
     if (!Spicetify.URI.Type) {
         setTimeout(appendValidationFunc, 10);
@@ -1262,8 +1287,6 @@ class _HTMLGenericModal extends HTMLElement {
 }
 customElements.define("generic-modal", _HTMLGenericModal);
 Spicetify.PopupModal = new _HTMLGenericModal();
-
-Spicetify.ReactComponent = {};
 
 Object.defineProperty(Spicetify, "TippyProps", {
     value: {

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -388,6 +388,12 @@ Spicetify.React.useEffect(() => {
 		`function ?([\w$_]+)\(\{(?:(?:onClose|isOpen|onOutside|titleText)[:!\w$_(){}=>]*,){3,}`,
 		`Spicetify.ReactComponent.ConfirmDialog=${1};${0}`)
 
+	// React Hook: Drag Handler
+	utils.Replace(
+		&input,
+		`([\w$]+=)((?:function)?\((?:[\w$](?:=[\[\]"\w]+)?,?)+\)(?:=>)?[\w:,=".,{}|()=>;]+"data-dragging-type")`,
+		`${1}Spicetify.ReactHook.DragHandler=${2}`)
+
 	// Locale
 	utils.Replace(
 		&input,


### PR DESCRIPTION
Introduce the `ReactHook` method and `DragHandler` hook, helps integrates Spotify components created by extensions and custom apps.
Works on `1.2.6` and later, breaks on `1.1.96`, have not tested in between.

https://github.com/spicetify/spicetify-cli/assets/77577746/dab0633a-6d27-4208-a836-d92070c1a2f8

https://github.com/spicetify/spicetify-cli/assets/77577746/c3e462e2-0639-48c9-951b-fddb2cf0823d

This will hopefully lay a foundation if we were ever to expose React hooks