### PR TITLE
chore(types): update URI class definition

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -474,6 +474,7 @@ declare namespace Spicetify {
         public args?: any;
         public category?: string;
         public username?: string;
+        public track?: string;
         public artist?: string;
         public album?: string;
         public query?: string;


### PR DESCRIPTION
URIs can have a track property for local tracks. For example,
```js
Spicetify.URI.from("spotify:local:Andrew+Hale+%26+Simon+Hale:L.A.+Noire:Global+Chase+Full:129")
```

returns 
```js
{
    "type": "local",
    "artist": "Andrew Hale & Simon Hale",
    "album": "L.A. Noire",
    "track": "Global Chase Full",
    "duration": 129
}
```