### PR TITLE
chore(types): update local URI properties

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -474,8 +474,10 @@ declare namespace Spicetify {
         public args?: any;
         public category?: string;
         public username?: string;
+        public track?: string;
         public artist?: string;
         public album?: string;
+        public duration?: number;
         public query?: string;
         public country?: string;
         public global?: boolean;


### PR DESCRIPTION
URIs can have track and duration properties for local tracks, which are undocumented. For example,
```js
Spicetify.URI.from("spotify:local:Andrew+Hale+%26+Simon+Hale:L.A.+Noire:Global+Chase+Full:129")
```

returns 
```js
{
    "type": "local",
    "artist": "Andrew Hale & Simon Hale",
    "album": "L.A. Noire",
    "track": "Global Chase Full",
    "duration": 129
}
```