### PR TITLE
fix(panel): render `NowPlayingView` on `1.2.9`

### DIFF
--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -427,8 +427,8 @@ Spicetify.React.useEffect(() => {
 	// Panel component patch
 	utils.Replace(
 		&input,
-		`(case [\w$.]+BuddyFeed:return ?[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;(?:case [\w$.]+:return ?[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;)*)default:return ?([ \w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;?)`,
-		`${1}default:return Spicetify.Panel?.render()??${2}`)
+		`(case [\w$.]+BuddyFeed:return ?[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;(?:case [\w$.]+:return ?[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;)*)default:return ?`,
+		`${1}default:return Spicetify.Panel?.render()??`)
 
 	// Reserved panels
 	utils.Replace(

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -427,8 +427,8 @@ Spicetify.React.useEffect(() => {
 	// Panel component patch
 	utils.Replace(
 		&input,
-		`(case [\w$.]+BuddyFeed:return ?[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;(?:case [\w$.]+:return ?[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;)*)default:`,
-		`${1}default:return Spicetify.Panel?.render()??null;`)
+		`(case [\w$.]+BuddyFeed:return ?[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;(?:case [\w$.]+:return ?[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;)*)default:return ?([ \w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;?)`,
+		`${1}default:return Spicetify.Panel?.render()??${2}`)
 
 	// Reserved panels
 	utils.Replace(

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -427,7 +427,7 @@ Spicetify.React.useEffect(() => {
 	// Panel component patch
 	utils.Replace(
 		&input,
-		`(case [\w$.]+BuddyFeed:return ?[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;(?:case [\w$.]+:return ?[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;)*)default:return ?`,
+		`(case [\w$.]+BuddyFeed:return ?[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;(?:case [\w$.]+:return ?[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;)*)default:return`,
 		`${1}default:return Spicetify.Panel?.render()??`)
 
 	// Reserved panels


### PR DESCRIPTION
For some reason on this specific version, Spotify decided to be lazy and not write an additional case for `NowPlayingView` like they have done for every other panel like before.
![image](https://github.com/spicetify/spicetify-cli/assets/77577746/32be12b2-a903-4db7-a153-ed2dddd1fce9)

Since React Components cannot return `undefined` we can be sure there will always be something on the other end of the null coalescer.