### PR TITLE
fix(tippyProps): allow innerHTML property

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1318,7 +1318,7 @@ Object.defineProperty(Spicetify, "TippyProps", {
             popper.appendChild(box);
 
             box.className = "main-contextMenu-tippy"
-            box.textContent = instance.props.content;
+            box[instance.props.allowHTML ? 'innerHTML' : 'textContent'] = instance.props.content;
 
             function onUpdate(prevProps, nextProps) {
               if (prevProps.content !== nextProps.content) {

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1318,7 +1318,7 @@ Object.defineProperty(Spicetify, "TippyProps", {
             popper.appendChild(box);
 
             box.className = "main-contextMenu-tippy"
-            box[instance.props.allowHTML ? 'innerHTML' : 'textContent'] = instance.props.content;
+            box[instance.props.allowHTML ? "innerHTML" : "textContent"] = instance.props.content;
 
             function onUpdate(prevProps, nextProps) {
               if (prevProps.content !== nextProps.content) {


### PR DESCRIPTION
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/fe90cd94-ced4-4962-8904-44a6270a8f1b)

The code below didnt used to work, this will fix it.
```js
const element = document.querySelector("#Custom-Image-URL > div.col.action > input")
const tooltip = Spicetify.Tippy(element, {
  ...Spicetify.TippyProps,
  content: `
    <div>
    <img src='https://placeimg.com/244/184/people'>
    <h6>People</h6>
    <ul>
    <li>People Feature 1</li>
    <li>People Feature 2</li>
    <li>People Feature 3</li>
    </ul>
    </div>`,
  allowHTML: true
}
```