### PR TITLE
feat(trashbin): fix code & handle player state upon enable

### DIFF
--- a/Extensions/trashbin.js
+++ b/Extensions/trashbin.js
@@ -242,7 +242,8 @@
 		const data = Spicetify.Player.data || Spicetify.Queue;
 		if (!data) return;
 
-		setWidgetState(trashSongList[data.track.uri], Spicetify.URI.fromString(data.track.uri).type !== Spicetify.URI.Type.TRACK);
+		const isBanned = trashSongList[data.track.uri];
+		setWidgetState(isBanned, Spicetify.URI.fromString(data.track.uri).type !== Spicetify.URI.Type.TRACK);
 
 		if (userHitBack) {
 			userHitBack = false;

--- a/Extensions/trashbin.js
+++ b/Extensions/trashbin.js
@@ -225,6 +225,7 @@
 			skipBackBtn.addEventListener("click", eventListener);
 			Spicetify.Player.addEventListener("songchange", watchChange);
 			enableWidget && widget.register();
+			watchChange();
 		} else {
 			skipBackBtn.removeEventListener("click", eventListener);
 			Spicetify.Player.removeEventListener("songchange", watchChange);


### PR DESCRIPTION
The trashbin extension is currently broken, since `isBanned` isn't defined, which is the variable which determines whether the current track should be skipped.

This PR additionally invokes `watchChange` when the event listeners are activated. By doing so, we can handle tracks that are already playing upon the initial loading of the extension, as well as tracks that are playing when the extension has just been enabled through the settings page.
