### PR TITLE
feat(trashbin): handle current track upon enable.

### DIFF
--- a/Extensions/trashbin.js
+++ b/Extensions/trashbin.js
@@ -225,6 +225,7 @@
 			skipBackBtn.addEventListener("click", eventListener);
 			Spicetify.Player.addEventListener("songchange", watchChange);
 			enableWidget && widget.register();
+			watchChange();
 		} else {
 			skipBackBtn.removeEventListener("click", eventListener);
 			Spicetify.Player.removeEventListener("songchange", watchChange);


### PR DESCRIPTION
By invoking watchChange when the event listeners are activated, we can handle tracks that are already playing upon the initial loading of the extension, as well as tracks that are playing when the extension has just been enabled through the settings page.