### PR TITLE
feat(custom-apps): allow adding assets/resources

### DIFF
--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -344,6 +344,36 @@ func pushApps(list ...string) {
 				}
 				pushExtensions(app, subfilePath)
 			}
+			for _, assetFile := range manifestJson.Assets {
+				assetsList, err := filepath.Glob(filepath.Join(customAppPath, assetFile))
+				if err != nil {
+					utils.PrintError(err.Error())
+					continue
+				}
+				for _, assetPath := range assetsList {
+					assetName, err := filepath.Rel(customAppPath, assetPath)
+					if err != nil {
+						utils.PrintError(err.Error())
+						continue
+					}
+					stat, err := os.Stat(assetPath)
+					if err != nil {
+						utils.PrintError(err.Error())
+						continue
+					}
+					if stat.IsDir() {
+						dest := filepath.Join(appDestPath, "xpui", "assets", app, assetName)
+						err = utils.Copy(assetPath, dest, true, []string{})
+					} else {
+						dest := filepath.Join(appDestPath, "xpui", "assets", app, filepath.Dir(assetName))
+						err = utils.CopyFile(assetPath, dest)
+					}
+					if err != nil {
+						utils.PrintError(err.Error())
+						continue
+					}
+				}
+			}
 		}
 
 		jsTemplate := fmt.Sprintf(

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -293,6 +293,7 @@ func SeekToCloseParen(content string, regexpTerm string, leftChar, rightChar byt
 type AppManifest struct {
 	Files          []string `json:"subfiles"`
 	ExtensionFiles []string `json:"subfiles_extension"`
+	Assets         []string `json:"assets"`
 }
 
 func GetAppManifest(app string) (AppManifest, string, error) {


### PR DESCRIPTION
#2394 

Example usage (manifest.json):
```json
{
  "name": "...",
  "subfiles": ["..."],
  "assets": [
    "manifest.json",
    "beatsaber.*.js",
    "css/*.css",
    "levelpacks",
    "levels/Ost*.png"
  ]
}
```

Glob expressions are supported as well (`css/*.css`). Directories can also be specified by just their name/path (`levelpacks`).

File/dir structure is resembled in the output directory.

I can add this to docs with a separate PR if requested.