### PR TITLE
fix(wrapper/app-title): use override values

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -674,16 +674,14 @@ Spicetify.SVGIcons = {
     }
 
     let subRequest;
-    const initialValue = await Spicetify.Platform.UserAPI._product_state.getValues();
-    const initialName = initialValue.pairs.name;
 
     Spicetify.AppTitle = {
         set: async (name) => {
             if (subRequest) subRequest.cancel();
-            await Spicetify.Platform.UserAPI._product_state.putValues({ pairs: { name }});
+            await Spicetify.Platform.UserAPI._product_state.putOverridesValues({ pairs: {name} });
             subRequest = Spicetify.Platform.UserAPI._product_state.subValues({ keys: ["name"] }, ({ pairs }) => {
                 if (pairs.name !== name) {
-                    Spicetify.Platform.UserAPI._product_state.putValues({ pairs: { name }}); // Restore name
+                    Spicetify.Platform.UserAPI._product_state.putOverridesValues({ pairs: { name }}); // Restore name
                 }
             });
             return subRequest;
@@ -694,7 +692,7 @@ Spicetify.SVGIcons = {
         },
         reset: async () => {
             if (subRequest) subRequest.cancel();
-            await Spicetify.Platform.UserAPI._product_state.putValues({ pairs: { name: initialName }});
+            await Spicetify.Platform.UserAPI._product_state.delOverridesValues({ keys: ["name"] })
         },
         sub: (callback) => {
             return Spicetify.Platform.UserAPI._product_state.subValues({ keys: ["name"] }, ({ pairs }) => {


### PR DESCRIPTION
Using override values allows us to more accurately "reset" the product state values since we are not having to rely on a variable declared once at startup.

Example where this is needed:
- await Spicetify.AppTitle.set("test")
- restart Spotify
- await Spicetify.AppTitle.reset()
- await Spicetify.AppTitle.get()
> returns "test"

Provided you havent hit the re-occurring time limit for Spotify to reset the name, the temporary variable is assigned to the previously set value at startup, this makes it difficult for developers to predict the true value of the title.

Using override values completely separates our changes from the true values of the product state.