### PR TITLE
feat(watch): enable devtools

### DIFF
--- a/src/cmd/watch.go
+++ b/src/cmd/watch.go
@@ -221,6 +221,7 @@ func startDebugger() {
 	if len(utils.GetDebuggerPath()) == 0 {
 		EvalSpotifyRestart(true, "--remote-debugging-port=9222", "--remote-allow-origins=*")
 		utils.PrintInfo("Spotify is restarted with debugger on. Waiting...")
+		SetDevTools();
 		for len(utils.GetDebuggerPath()) == 0 {
 			// Wait until debugger is up
 		}

--- a/src/cmd/watch.go
+++ b/src/cmd/watch.go
@@ -219,9 +219,9 @@ func isValidForWatching() bool {
 
 func startDebugger() {
 	if len(utils.GetDebuggerPath()) == 0 {
+		SetDevTools()
 		EvalSpotifyRestart(true, "--remote-debugging-port=9222", "--remote-allow-origins=*")
 		utils.PrintInfo("Spotify is restarted with debugger on. Waiting...")
-		SetDevTools()
 		for len(utils.GetDebuggerPath()) == 0 {
 			// Wait until debugger is up
 		}

--- a/src/cmd/watch.go
+++ b/src/cmd/watch.go
@@ -221,7 +221,7 @@ func startDebugger() {
 	if len(utils.GetDebuggerPath()) == 0 {
 		EvalSpotifyRestart(true, "--remote-debugging-port=9222", "--remote-allow-origins=*")
 		utils.PrintInfo("Spotify is restarted with debugger on. Waiting...")
-		SetDevTools();
+		SetDevTools()
 		for len(utils.GetDebuggerPath()) == 0 {
 			// Wait until debugger is up
 		}


### PR DESCRIPTION
For example `spicetify watch -[insert optional flag(s) here]` will watch for changes and restart as expected but with the devtools enabled so a separate command is not needed to enable devtools. This is useful for debugging and development.

Works just fine, though as far as I can tell this is certainly not the most efficient way to do this, so someone with a better understanding of the codebase should probably take a look at this.