### PR TITLE
fix(panel): catch error & prevent crashing client

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1642,7 +1642,8 @@ Spicetify.Playbar = (function() {
 
         render() {
           if (this.state.hasError) {
-            return null;
+            // `false` not `null`, so it won’t render beyond the null coalescing operator.
+            return false;
           }
 
           return this.props.children;

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1147,7 +1147,7 @@ Spicetify._cloneSidebarItem = function (list, isLibX = false) {
 	const React = Spicetify.React;
 	const reactObjs = [];
 	const sidebarIsCollapsed = Spicetify.Platform?.LocalStorageAPI?.getItem?.("ylx-sidebar-state") === 1;
-	
+
 	for (const app of list) {
 		let manifest;
 		try {
@@ -1621,6 +1621,34 @@ Spicetify.Playbar = (function() {
         Object.entries(Spicetify._reservedPanelIds).map(([key, value]) => !isNaN(parseInt(key)) && [parseInt(key), value]).filter(Boolean)
     )
 
+    // https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
+    class ErrorBoundary extends Spicetify.React.Component {
+        constructor(props) {
+          super(props);
+          this.state = { hasError: false };
+        }
+
+        static getDerivedStateFromError(error) {
+          // Update state so the next render will show the fallback UI.
+          return { hasError: true };
+        }
+
+        componentDidCatch(error, info) {
+          Spicetify.showNotification(`Something went wrong in panel ID "${this.props.id}", check Console for error log`, true);
+          console.error(error);
+          console.error(`Error stack in panel ID "${this.props.id}": ${info.componentStack}`);
+          Spicetify.Panel.setPanel(Spicetify.Panel.reservedPanelIds.Disabled);
+        }
+
+        render() {
+          if (this.state.hasError) {
+            return null;
+          }
+
+          return this.props.children;
+        }
+    }
+
     Spicetify.Panel = {
         reservedPanelIds: Spicetify._reservedPanelIds,
         Components: {
@@ -1675,7 +1703,7 @@ Spicetify.Playbar = (function() {
                     )
                 )
 
-            contentMap.set(id, content);
+            contentMap.set(id, Spicetify.React.createElement(ErrorBoundary, { id }, content))
 
             let isActive = Spicetify.Panel.currentPanel === id;
 

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1704,7 +1704,7 @@ Spicetify.Playbar = (function() {
                     )
                 )
 
-            contentMap.set(id, Spicetify.React.createElement(ErrorBoundary, { id }, content))
+            contentMap.set(id, Spicetify.React.createElement(ErrorBoundary, { id }, content));
 
             let isActive = Spicetify.Panel.currentPanel === id;
 


### PR DESCRIPTION
Spotify does not have error boundaries for their right sidebar, so when the Panel component throws an error, the whole client crashes, and will continue to crash in subsequent reloads if the panel ID is cached into state as the client attempts to open last closed panel.
This is made to prevent the client crashing and logs an error stack in addition to React's usual error code.
![image](https://github.com/spicetify/spicetify-cli/assets/77577746/265df53d-6b1a-4f9a-b6b5-aa6143a88bdd)
![image](https://github.com/spicetify/spicetify-cli/assets/77577746/25ed304c-5c89-4efc-a0f1-4ea542c9063a)
