### PR TITLE
feat(panel): pass panel ID as props

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1389,6 +1389,7 @@ declare namespace Spicetify {
             /**
              * Children to render inside the Panel.
              * Must be a React Component.
+             * Will be passed a `panel` prop with the Panel ID.
              */
             children: React.ReactNode;
             /**

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1713,7 +1713,7 @@ Spicetify.Playbar = (function() {
                     )
                 )
 
-            contentMap.set(id, Spicetify.React.createElement(ErrorBoundary, { id }, Content));
+            contentMap.set(id, Spicetify.React.createElement(ErrorBoundary, { id }, content));
 
             let isActive = Spicetify.Panel.currentPanel === id;
 

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1682,7 +1682,7 @@ Spicetify.Playbar = (function() {
         subPanelState: (callback) => Spicetify.Platform.PanelAPI.subscribeToPanelState(callback),
         registerPanel: ({ label, children, isCustom = false, style, wrapperClassname, headerClassname, headerVariant, headerSemanticColor, headerLink, headerActions, headerOnClose, headerPreventDefaultClose, headerOnBack }) => {
             const id = [...contentMap.keys()].sort((a, b) => a - b).pop() + 1;
-            const Content = isCustom
+            const content = isCustom
                 ? children
                 : Spicetify.React.createElement(
                     Spicetify.ReactComponent.PanelSkeleton,

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1654,7 +1654,8 @@ Spicetify.Playbar = (function() {
             return false;
           }
 
-          return this.props.children;
+          // Pass the `panel` prop with the current panel ID to the children
+          return Spicetify.React.cloneElement(this.props.children, { panel: this.props.id });
         }
     }
 
@@ -1681,10 +1682,10 @@ Spicetify.Playbar = (function() {
         subPanelState: (callback) => Spicetify.Platform.PanelAPI.subscribeToPanelState(callback),
         registerPanel: ({ label, children, isCustom = false, style, wrapperClassname, headerClassname, headerVariant, headerSemanticColor, headerLink, headerActions, headerOnClose, headerPreventDefaultClose, headerOnBack }) => {
             const id = [...contentMap.keys()].sort((a, b) => a - b).pop() + 1;
-            const content = isCustom
+            const Content = isCustom
                 ? children
                 : Spicetify.React.createElement(
-                    Spicetify.ReactComponent.PanelSkeleton ?? "aside",
+                    Spicetify.ReactComponent.PanelSkeleton,
                     {
                         label,
                         // Backwards compatibility, no longer needed in Spotify 1.2.12
@@ -1692,11 +1693,11 @@ Spicetify.Playbar = (function() {
                         style,
                     },
                     Spicetify.React.createElement(
-                        Spicetify.ReactComponent.PanelContent ?? "div",
+                        Spicetify.ReactComponent.PanelContent,
                         {
                             className: wrapperClassname,
                         },
-                        Spicetify.React.createElement(Spicetify.ReactComponent.PanelHeader ?? "div", {
+                        Spicetify.React.createElement(Spicetify.ReactComponent.PanelHeader, {
                             title: label,
                             panel: id,
                             link: headerLink,
@@ -1708,11 +1709,11 @@ Spicetify.Playbar = (function() {
                             titleVariant: headerVariant,
                             titleSemanticColor: headerSemanticColor,
                         }),
-                        children
+                        Spicetify.React.cloneElement(children, { panel: id })
                     )
                 )
 
-            contentMap.set(id, Spicetify.React.createElement(ErrorBoundary, { id }, content));
+            contentMap.set(id, Spicetify.React.createElement(ErrorBoundary, { id }, Content));
 
             let isActive = Spicetify.Panel.currentPanel === id;
 


### PR DESCRIPTION
Pass panel ID as props since the Panel header requires the panel ID to be passed (doesn't seem to be optional internally, but still works fine without?), plus for more usage inside the panel component as the ID is not accessible until after the panel is registered.
Works fine with both types of children.
![image](https://github.com/spicetify/spicetify-cli/assets/77577746/4944c79a-2c39-4e6a-b1a9-d855c859e4b7)
![image](https://github.com/spicetify/spicetify-cli/assets/77577746/1ff65560-09c1-480b-a8da-4407a960161e)
