### PR TITLE
feat: expose `ReactFlipToolkit` & `classnames`

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1556,7 +1556,7 @@ declare namespace Spicetify {
     namespace ReactFlipToolkit {
         const Flipper: any;
         const Flipped: any;
-        const Spring: any;
+        const spring: any;
     }
 
     /**

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1555,4 +1555,8 @@ declare namespace Spicetify {
         const Flipped: any;
         const Spring: any;
     }
+
+    // classnames
+    // https://github.com/JedWatson/classnames
+    function classnames(...args: any[]): string;
 }

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1547,4 +1547,12 @@ declare namespace Spicetify {
          */
         const currentPanel: number;
     }
+
+    // React Flip Toolkit used by Spotify
+    // https://github.com/aholachek/react-flip-toolkit
+    namespace ReactFlipToolkit {
+        const Flipper: any;
+        const Flipped: any;
+        const Spring: any;
+    }
 }

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1548,15 +1548,21 @@ declare namespace Spicetify {
         const currentPanel: number;
     }
 
-    // React Flip Toolkit used by Spotify
-    // https://github.com/aholachek/react-flip-toolkit
+    /**
+     * react-flip-toolkit
+     * @description A lightweight magic-move library for configurable layout transitions.
+     * @link https://github.com/aholachek/react-flip-toolkit
+     */
     namespace ReactFlipToolkit {
         const Flipper: any;
         const Flipped: any;
         const Spring: any;
     }
 
-    // classnames
-    // https://github.com/JedWatson/classnames
+    /**
+     * classnames
+     * @description A simple JavaScript utility for conditionally joining classNames together.
+     * @link https://github.com/JedWatson/classnames
+     */
     function classnames(...args: any[]): string;
 }

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1,16 +1,3 @@
-(function hotloadWebpackModules() {
-    if (!window?.webpackChunkopen) {
-        setTimeout(hotloadWebpackModules, 10);
-        return;
-    }
-    // Force all webpack modules to load
-    const require = webpackChunkopen.push([[Symbol()], {}, re => re]);
-    const modules = Object.keys(require.m).map(id => require(id));
-
-    // classnames
-    // https://github.com/JedWatson/classnames/
-    Spicetify.classnames = modules.filter(module => typeof module === "function").find(module => module.toString().includes('"string"') && module.toString().includes("[native code]"));
-})();
 
 const Spicetify = {
     get CosmosAsync() {return Spicetify.Player.origin?._cosmos},
@@ -279,6 +266,20 @@ const Spicetify = {
     ReactFlipToolkit: {},
     URI: {},
 };
+
+(function hotloadWebpackModules() {
+    if (!window?.webpackChunkopen) {
+        setTimeout(hotloadWebpackModules, 50);
+        return;
+    }
+    // Force all webpack modules to load
+    const require = webpackChunkopen.push([[Symbol()], {}, re => re]);
+    const modules = Object.keys(require.m).map(id => require(id));
+
+    // classnames
+    // https://github.com/JedWatson/classnames/
+    Spicetify.classnames = modules.filter(module => typeof module === "function").find(module => module.toString().includes('"string"') && module.toString().includes("[native code]"));
+})();
 
 // Wait for Spicetify.Player.origin._state before adding following APIs
 (function waitOrigins() {

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -261,6 +261,7 @@ const Spicetify = {
     },
     ReactComponent: {},
     ReactHook: {},
+    ReactFlipToolkit: {},
     URI: {},
 };
 

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1,3 +1,13 @@
+(function hotloadWebpackModules() {
+    if (!window?.webpackChunkopen) {
+        setTimeout(hotloadWebpackModules, 10);
+        return;
+    }
+    // Force all webpack modules to load
+    const require = webpackChunkopen.push([[Symbol()], {}, re => re]);
+    Object.keys(require.m).map(id => require(id));
+})();
+
 const Spicetify = {
     get CosmosAsync() {return Spicetify.Player.origin?._cosmos},
     get Queue() {return Spicetify.Player.origin?._queue?._state ?? Spicetify.Player.origin?._queue?._queue},

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -121,7 +121,8 @@ const Spicetify = {
             "_sidebarXItemToClone",
             "AppTitle",
             "_reservedPanelIds",
-            "Panel"
+            "Panel",
+            "ReactFlipToolkit",
         ];
 
         const PLAYER_METHOD = [

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -5,7 +5,11 @@
     }
     // Force all webpack modules to load
     const require = webpackChunkopen.push([[Symbol()], {}, re => re]);
-    Object.keys(require.m).map(id => require(id));
+    const modules = Object.keys(require.m).map(id => require(id));
+
+    // classnames
+    // https://github.com/JedWatson/classnames/
+    Spicetify.classnames = modules.filter(module => typeof module === "function").filter(module => module.toString().includes('"string"')).find(module => module.toString().includes("[native code]"));
 })();
 
 const Spicetify = {

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -124,6 +124,7 @@ const Spicetify = {
             "_reservedPanelIds",
             "Panel",
             "ReactFlipToolkit",
+            "classnames",
         ];
 
         const PLAYER_METHOD = [

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -9,7 +9,7 @@
 
     // classnames
     // https://github.com/JedWatson/classnames/
-    Spicetify.classnames = modules.filter(module => typeof module === "function").filter(module => module.toString().includes('"string"')).find(module => module.toString().includes("[native code]"));
+    Spicetify.classnames = modules.filter(module => typeof module === "function").find(module => module.toString().includes('"string"') && module.toString().includes("[native code]"));
 })();
 
 const Spicetify = {

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -571,10 +571,27 @@ if (${1}.popper?.firstChild?.id === "context-menu") {
 		`(\w+ [\w$_]+)=[\w$_]+\([\w$_]+>>>0\)`,
 		`${1}=Spicetify._getStyledClassName(arguments,this)`)
 
+	// Tippy
 	utils.Replace(
 		&input,
 		`([\w$_]+)\.setDefaultProps=`,
 		`Spicetify.Tippy=${1};${0}`)
+
+	// Flipper components
+	utils.Replace(
+		&input,
+		`(\w+ [\w$]+)=([\w$=(){}[\].,;!" ]+"Each Flipped component must wrap a single child")`,
+		`${1}=Spicetify.ReactFlipToolkit.Flipped=${2}`)
+
+	utils.Replace(
+		&input,
+		`([\w$]+)\.getSnapshotBeforeUpdate=`,
+		`Spicetify.ReactFlipToolkit.Flipper=${1},${0}`)
+
+	utils.Replace(
+		&input,
+		`([\w$]+)=((?:function|\()([\w$.,{}()= ]+(?:springConfig|overshootClamping)){2})`,
+		`${1}=Spicetify.ReactFlipToolkit.Spring=${2}`)
 
 	return input
 }

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -585,8 +585,8 @@ if (${1}.popper?.firstChild?.id === "context-menu") {
 
 	utils.Replace(
 		&input,
-		`([\w$]+)\.getSnapshotBeforeUpdate=`,
-		`Spicetify.ReactFlipToolkit.Flipper=${1},${0}`)
+		`([\w$]+=([\w$]+)\.prototype;)(return ?[\w$]+\.getSnapshotBeforeUpdate)`,
+		`${1}Spicetify.ReactFlipToolkit.Flipper=${2};${3}`)
 
 	utils.Replace(
 		&input,

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -591,7 +591,7 @@ if (${1}.popper?.firstChild?.id === "context-menu") {
 	utils.Replace(
 		&input,
 		`([\w$]+)=((?:function|\()([\w$.,{}()= ]+(?:springConfig|overshootClamping)){2})`,
-		`${1}=Spicetify.ReactFlipToolkit.Spring=${2}`)
+		`${1}=Spicetify.ReactFlipToolkit.spring=${2}`)
 
 	return input
 }


### PR DESCRIPTION
Expose the `ReactFlipToolkit` module used by Spotify.
https://github.com/aholachek/react-flip-toolkit

tl;dr: This method works on as far back as `1.2.2`, have not tested below:
![image](https://github.com/spicetify/spicetify-cli/assets/77577746/899262e9-4aae-4ab9-99d7-b8407573e28c)

Because the module isn't imported until required (in this case the Buddy Feed panel uses it), the module won't be initialized. To circumvent this, we need a function that will force load all available Webpack modules. Note that this **will not** load modules outisde of imported Webpack chunk, meaning modules in `xpui` and `vendor~xpui` will always be loaded and there will be no significant performance impact.

The naming convention for the method also doesn't change between versions as this method was discovered in April. This will also help in hooking components in the future, and we could also leverage this for Webpack injection instead of native injection.
![Spotify_9DSXsfbbqf](https://github.com/spicetify/spicetify-cli/assets/77577746/63958851-e95f-45dc-a3ae-86e061166322)

This PR also features hooking onto the [`classnames`](https://github.com/JedWatson/classnames) module via Webpack chunk instead of native injection as it proves to be difficult to maintain if we were to use a regex (and the syntax doesn't make sense either)
![image](https://github.com/spicetify/spicetify-cli/assets/77577746/02c556b0-e117-4fd3-8d93-0a3cc558d444)
![image](https://github.com/spicetify/spicetify-cli/assets/77577746/f0a8cbbc-65a8-417e-acea-271b76032d37)
