### PR TITLE
chore(github): Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @spicetify/cli


### PR DESCRIPTION
This damn thing forces me to subscribe to EVERY single PR posted to the repo. I do not want to be requested to review every single PR. I will review PRs if I want. Forcing every CLI member to receive notifications about every PR in the entire repo is super spammy.