### PR TITLE
fix(new-releases): use GraphQL query

### DIFF
--- a/CustomApps/new-releases/Settings.js
+++ b/CustomApps/new-releases/Settings.js
@@ -244,13 +244,13 @@ function openConfig() {
 					type: ConfigSlider,
 					when: () => CONFIG["music"]
 				},
-				{
+				/* {
 					desc: Spicetify.Locale.get("artist.appears-on"),
 					key: "appears-on",
 					defaultValue: CONFIG["appears-on"],
 					type: ConfigSlider,
 					when: () => CONFIG["music"]
-				},
+				}, */
 				{
 					desc: Spicetify.Locale.get("artist.compilations"),
 					key: "compilations",


### PR DESCRIPTION
Resolves #2422 
![image](https://github.com/spicetify/spicetify-cli/assets/77577746/6cd12ed6-fb4c-4c30-82ad-1a6c0ae6252b)

Seems like Spotify deprecated this endpoint, it can no longer be found inside xpui files.
![image](https://github.com/spicetify/spicetify-cli/assets/77577746/d1773462-8d2e-41a4-9dec-ebff5a1eb590)

Their Discography page is also seems to be using the GraphQL endpoint.
![image](https://github.com/spicetify/spicetify-cli/assets/77577746/92ddabc9-c3c6-4ce6-a0f4-72107a0ca143)
