### PR TITLE
feat(wrapper): expose `ReactQuery` & `usePanelState`

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -2498,5 +2498,6 @@
     "YUyFyiI58gL8VuLdbOD6": "main-devicePicker-troubleshooting",
     "AN2rvWrkrs7UsnY12hL8": "main-devicePicker-troubleshootingList",
     "QClIatTm05fvjVzODr8X": "main-devicePicker-troubleshootingItemIcon",
-    "OTuSSciCS3NJqFG8OKX2": "main-devicePicker-troubleshootingItemSubtitle"
+    "OTuSSciCS3NJqFG8OKX2": "main-devicePicker-troubleshootingItemSubtitle",
+    "SFgYidQmrqrFEVh65Zrg": "main-userWidget-boxCondensed"
 }

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1372,6 +1372,13 @@ declare namespace Spicetify {
             sectionIndex?: number,
             dropOriginUri?: string
         ): (event: React.DragEvent, uris?: string[], label?: string, contextUri?: string, sectionIndex?: number) => void;
+
+        /**
+         * React Hook to use panel state
+         * @param id ID of the panel to use
+         * @return Object with methods of the panel
+         */
+        function usePanelState(id: number): { toggle: () => void, isActive: boolean };
     }
 
     /**
@@ -1565,4 +1572,11 @@ declare namespace Spicetify {
      * @link https://github.com/JedWatson/classnames
      */
     function classnames(...args: any[]): string;
+
+    /**
+     * React Query v3
+     * @description A hook for fetching, caching and updating asynchronous data in React.
+     * @link https://github.com/TanStack/query/tree/v3
+     */
+    const ReactQuery: any;
 }

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -276,10 +276,21 @@ const Spicetify = {
     // Force all webpack modules to load
     const require = webpackChunkopen.push([[Symbol()], {}, re => re]);
     const modules = Object.keys(require.m).map(id => require(id));
+    const functionModules = modules.filter(module => typeof module === "object").map(module => Object.values(module)).flat().filter(module => typeof module === "function");
 
     // classnames
     // https://github.com/JedWatson/classnames/
     Spicetify.classnames = modules.filter(module => typeof module === "function").find(module => module.toString().includes('"string"') && module.toString().includes("[native code]"));
+
+    // React Query v3
+    // https://github.com/TanStack/query/tree/v3
+    Spicetify.ReactQuery = modules.find(module => module.useQuery);
+
+    // React Hook - Drag Handler
+    Spicetify.ReactHook.DragHandler = functionModules.find(m => m.toString().includes("data-dragging-uri"));
+
+    // React Hook - usePanelState
+    Spicetify.ReactHook.usePanelState = functionModules.find(m => m.toString().includes("setPanelState"));
 })();
 
 // Wait for Spicetify.Player.origin._state before adding following APIs

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -389,18 +389,6 @@ Spicetify.React.useEffect(() => {
 		`function ?([\w$_]+)(?:\(|\([\w$,]+\))\{[\w$., =(){}?:]*(?:[\w$. =]*(?:onClose|isOpen|onOutside|titleText)[?:|!\w$_(){}=> ]*,){2,}`,
 		`Spicetify.ReactComponent.ConfirmDialog=${1};${0}`)
 
-	// React Hook: Drag Handler
-	utils.Replace(
-		&input,
-		`([\w$]+=)((?:function)?\((?:[\w$](?:=[\[\]"\w]+)?,?)+\)(?:=>)?[\w:,=".,{}|()=>;]+"data-dragging-type")`,
-		`${1}Spicetify.ReactHook.DragHandler=${2}`)
-
-	// React Hook: Drag Handler - Fallback case
-	utils.Replace(
-		&input,
-		`([\w$]+=)((?:function)?\(\)(?:=>)?\{(?:[\w$= ]+arguments)[\w:,=".,{}!?|[\]()=>&; ]+"data-dragging-type")`,
-		`${1}Spicetify.ReactHook.DragHandler=${2}`)
-
 	// Locale
 	utils.Replace(
 		&input,


### PR DESCRIPTION
Not much to say except moving to Webpack hooking for `DragHandler` instead of maintaining 2 dreadful hooks
Cool stuff also
![image](https://github.com/spicetify/spicetify-cli/assets/77577746/f137bfd3-dc3e-4fad-80ba-9261c30c6432)
