### PR TITLE
feat(upgrade): verify backup status

### DIFF
--- a/src/cmd/upgrade.go
+++ b/src/cmd/upgrade.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/spicetify/spicetify-cli/src/utils"
 	backupstatus "github.com/spicetify/spicetify-cli/src/status/backup"
+	"github.com/spicetify/spicetify-cli/src/utils"
 )
 
 func Upgrade(currentVersion string) bool {

--- a/src/cmd/upgrade.go
+++ b/src/cmd/upgrade.go
@@ -112,7 +112,6 @@ func Upgrade(currentVersion string) bool {
 	if !backStat.IsOutdated() {
 		cmd = append(cmd[:1], append([]string{"restore"}, cmd[1:]...)...)
 	}
-	
 	utils.PrintInfo(`Please run "` + strings.Join(cmd, " ") + `" to receive new features and bug fixes`)
 	return true
 }

--- a/src/cmd/upgrade.go
+++ b/src/cmd/upgrade.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	backupstatus "github.com/spicetify/spicetify-cli/src/status/backup"
 	"github.com/spicetify/spicetify-cli/src/utils"
@@ -107,11 +108,12 @@ func Upgrade(currentVersion string) bool {
 	utils.PrintSuccess("spicetify is up-to-date.")
 	backupVersion := backupSection.Key("version").MustString("")
 	backStat := backupstatus.Get(prefsPath, backupFolder, backupVersion)
-	if backStat.IsOutdated() {
-		utils.PrintInfo(`Please run "spicetify backup apply" to receive new features and bug fixes`)
-	} else {
-		utils.PrintInfo(`Please run "spicetify restore backup apply" to receive new features and bug fixes`)
+	cmd := []string{"spicetify", "backup", "apply"}
+	if !backStat.IsOutdated() {
+		cmd = append(cmd[:1], append([]string{"restore"}, cmd[1:]...)...)
 	}
+	
+	utils.PrintInfo(`Please run "` + strings.Join(cmd, " ") + `" to receive new features and bug fixes`)
 	return true
 }
 

--- a/src/cmd/upgrade.go
+++ b/src/cmd/upgrade.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 
 	"github.com/spicetify/spicetify-cli/src/utils"
+	backupstatus "github.com/spicetify/spicetify-cli/src/status/backup"
 )
 
 func Upgrade(currentVersion string) bool {
@@ -104,7 +105,13 @@ func Upgrade(currentVersion string) bool {
 	utils.CheckExistAndDelete(exeOld)
 	utils.PrintGreen("OK")
 	utils.PrintSuccess("spicetify is up-to-date.")
-	utils.PrintInfo(`Please run "spicetify restore backup apply" to receive new features and bug fixes`)
+	backupVersion := backupSection.Key("version").MustString("")
+	backStat := backupstatus.Get(prefsPath, backupFolder, backupVersion)
+	if backStat.IsOutdated() {
+		utils.PrintInfo(`Please run "spicetify backup apply" to receive new features and bug fixes`)
+	} else {
+		utils.PrintInfo(`Please run "spicetify restore backup apply" to receive new features and bug fixes`)
+	}
 	return true
 }
 


### PR DESCRIPTION
This PR will ensure the user is told the correct commands to run, the issue this solves is:

 whenever a users Spotify has updated BEFORE they then run `spicetify upgrade`, the backups are mismatched, they are then told to run `spicetify restore backup apply` which will plonk their old backup files into their new spotify installation causing issues. This PR checks for this and tells them to just run `spicetify backup apply`.