### PR TITLE
chore(config.go): remove `PrintSuccess` on config generate

### DIFF
--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -69,7 +69,6 @@ func ParseConfig(configPath string) Config {
 			content: getDefaultConfig(),
 		}
 		defaultConfig.Write()
-		PrintSuccess("Default config-xpui.ini generated.")
 		return defaultConfig
 	}
 


### PR DESCRIPTION
so that automated tools (such as scripts) can rely on the command output