### PR TITLE
feat(wrapper): expose `imageColorExtractor` and `Color`

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -363,6 +363,20 @@ declare namespace Spicetify {
      */
     function getAudioData(uri?: string): Promise<any>;
     /**
+     * Fetch extracted colors from an image. Can be a URL, or a URI string to an image. Works for both local and remote images.
+     * @param uri Either a Spotify URI to an image, or a URL that represents one.
+     */
+    function imageColorExtractor(imageURL: string): Promise<{
+        colorRaw: Color;
+        colorLight: Color;
+        colorDark: Color;
+    }>;
+    function imageColorExtractor(imageURL: string[]): Promise<{
+        colorRaw: Color;
+        colorLight: Color;
+        colorDark: Color;
+    }[]>;
+    /**
      * Set of APIs method to register, deregister hotkeys/shortcuts
      */
     namespace Keyboard {

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -74,6 +74,52 @@ declare namespace Spicetify {
         session_id: string;
         queue_revision: string;
     };
+    interface hsl {
+        h: number;
+        s: number;
+        l: number;
+    };
+    interface hsv {
+        h: number;
+        s: number;
+        v: number;
+    };
+    interface rgb {
+        r: number;
+        g: number;
+        b: number;
+    };
+    type CSSColors = "HEX" | "HEXA" | "HSL" | "HSLA" | "RGB" | "RGBA";
+    /**
+     * Spotify's internal color class
+     */
+    class Color {
+        constructor(rgb: rgb, hsl: hsl, hsv: hsv, alpha?: number);
+
+        static BLACK: Color;
+        static WHITE: Color;
+        static CSSColorFormat: Record<CSSColors, number> & Record<number, CSSColors>;
+
+        a: number;
+        hsl: hsl;
+        hsv: hsv;
+        rgb: rgb;
+
+        static fromCSS(cssColor: string, alpha?: number): Color;
+        static fromHSL(hsl: hsl, alpha?: number): Color;
+        static fromHSV(hsv: hsv, alpha?: number): Color;
+        static fromRGB(rgb: rgb, alpha?: number): Color;
+        static fromHEX(hex: rgb, alpha?: number): Color;
+
+        /**
+         * Change the contrast of the color against another so that
+         * the contrast between them is at least `strength`.
+         */
+        contrastAdjust(against: Color, strength?: number): Color;
+        stringify(): string;
+        toCSS(colorFormat: number): string;
+        toString(): string;
+    }
     namespace Player {
         /**
          * Register a listener `type` on Spicetify.Player.

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -127,6 +127,7 @@ const Spicetify = {
             "ReactFlipToolkit",
             "classnames",
             "ReactQuery",
+            "Color",
         ];
 
         const PLAYER_METHOD = [

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -128,6 +128,7 @@ const Spicetify = {
             "classnames",
             "ReactQuery",
             "Color",
+            "imageColorExtractor"
         ];
 
         const PLAYER_METHOD = [
@@ -299,6 +300,16 @@ const Spicetify = {
         usePanelState: functionModules.find(m => m.toString().includes("setPanelState")),
         useExtractedColor: functionModules.find(m => m.toString().includes("extracted-color")),
     };
+
+    // Image color extractor
+    const graphQLColorQueryFactory = functionModules.find(m => m.toString().includes("GraphQL subscriptions are not supported!"));
+    const imageColorExtractorFetcher = functionModules.find(m => m.toString().includes("extractColors"));
+
+    Spicetify.imageColorExtractor = graphQLColorQueryFactory && imageColorExtractorFetcher ? (imageURL) => {
+        return imageColorExtractorFetcher(graphQLColorQueryFactory(imageURL), imageURL).then(
+            (data) => Array.isArray(imageURL) ? data : data[0]
+        )
+    } : undefined;
 
     Spicetify.ReactComponent = {
         ...Spicetify.ReactComponent,

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -294,6 +294,12 @@ func exposeAPIs_main(input string) string {
 		`(\w+=\(\w+,(\w+)\.lazy\)\(?\((?:\(\)=>|function\(\)\{return )\w+\.\w+\((?:\d+)?\)\.then\(\w+\.bind\(\w+,\w+\)\)\}?\)\)?),`,
 		`${1};Spicetify.React=${2};var `)
 
+	// Color class
+	utils.Replace(
+		&input,
+		`(class (\w+)\{constructor\([\w$.,={}]+\)\{this\.rgb[\w !?:=.,>&(){}[\];]*?this\.hsl[\w !?:=.,>&(){}[\];]*?this\.hsv[\w !?:=.,>&(){}[\];]*?this\.a[\w !?:=.,>&(){}[\];]*?\})(.*?case ([\w\.]+)\.HEX:.*?static parse\([\w !?:=.,>&(){}[\];]*?\}\})`,
+		`${1}static CSSColorFormat=${4};${3};Spicetify.Color=${2};`)
+
 	utils.Replace(
 		&input,
 		`"data-testid":`,


### PR DESCRIPTION
Exposes `Spicetify.imageColorExtractor`, which uses Spotify's algorithms to extract the prominent colors from an image URL. Internally, it first attempts to fetch these colors through GraphQL. If it fails, it loads the image and processes it locally. This makes it work for any image, including local tracks:
![image](https://github.com/spicetify/spicetify-cli/assets/38393797/5b705b3d-3c90-453f-9133-209895d75257)
![image](https://github.com/spicetify/spicetify-cli/assets/38393797/7534b009-862f-4490-8d39-ad05a163bce8)
or furry art:
![image](https://github.com/spicetify/spicetify-cli/assets/38393797/42d4cf14-55a2-485f-bc20-61c17a160b97)
but not normal item URIs (they are not images):
![image](https://github.com/spicetify/spicetify-cli/assets/38393797/bd174394-90b0-445f-a622-d03b0e0aa410)
Spotify returns rgb(83,83,83) as fallback.

The colors are returned as Spotify's own internal `Color` class, which is also exposed through this PR.

`colorExtractor` should remain and keep it's original functionality (as it and `imageColorExtractor` expect different inputs, and return different outputs).