### PR TITLE
fix(sidebar-config): retain `id` on re-render

### DIFF
--- a/jsHelper/sidebarConfig.js
+++ b/jsHelper/sidebarConfig.js
@@ -293,6 +293,15 @@ color: var(--spice-button-disabled);
 			storage = buttons.map(el => [el.dataset.id, STICKY]);
 		}
 
+		const observer = new MutationObserver(mutations => {
+			for (const mutation of mutations) {
+				if (mutation.type === "childList" && mutation.addedNodes.length) {
+					mutation.addedNodes[0].id = "spicetify-hidden-list";
+				}
+			}
+		});
+		observer.observe(playlistList.parentElement, { childList: true });
+
 		arrangeItems(storage);
 		appendItems();
 


### PR DESCRIPTION
Retain ID when sidebar re-renders on changing mode, expanding.