### PR TITLE
fix(context-menu): catch error for items

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1376,7 +1376,10 @@ Spicetify.ContextMenu = (function () {
 			});
 
 			for (const child of currentItem._items) {
-				if (!child.shouldAdd(uris, uids, contextUri)) {
+				try {
+					if (!child.shouldAdd(uris, uids, contextUri)) continue;
+				} catch (e) {
+					console.error(e);
 					continue;
 				}
 
@@ -1438,7 +1441,10 @@ Spicetify.ContextMenu = (function () {
 
 		const elemList = [];
 		for (const item of itemList) {
-			if (!item.shouldAdd(uris, uids, contextUri)) {
+			try {
+				if (!item.shouldAdd(uris, uids, contextUri)) continue;
+			} catch (e) {
+				console.error(e);
 				continue;
 			}
 


### PR DESCRIPTION
Uncaught error caused by one item affects all other items as the loop gets broken and the function never reaches the part where all items are prepended at once. 
https://github.com/spicetify/spicetify-cli/blob/4393d2fb02d435f6e3ea4e0224553c95225d95c7/jsHelper/spicetifyWrapper.js#L1466