### PR TITLE
feat(panel): descriptive error message

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -2012,13 +2012,16 @@ Spicetify.Playbar = (function () {
 			this.state = { hasError: false };
 		}
 
-		static getDerivedStateFromError(error) {
+		static getDerivedStateFromError() {
 			// Update state so the next render will show the fallback UI.
 			return { hasError: true };
 		}
 
 		componentDidCatch(error, info) {
-			const extension = Spicetify.Config.extensions.find(ext => error.stack.includes(ext));
+			const extension =
+				Spicetify.Config.extensions.find(ext => error.stack.includes(ext)) ||
+				Spicetify.Config.custom_apps.find(app => error.stack.includes(`spicetify-routes-${app}`));
+
 			Spicetify.showNotification(
 				`Something went wrong in panel ID "${this.props.id}" ${extension ? `of "${extension}"` : ""}, check Console for error log`,
 				true

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -2018,7 +2018,11 @@ Spicetify.Playbar = (function () {
 		}
 
 		componentDidCatch(error, info) {
-			Spicetify.showNotification(`Something went wrong in panel ID "${this.props.id}", check Console for error log`, true);
+			const extension = Spicetify.Config.extensions.find(ext => error.stack.includes(ext));
+			Spicetify.showNotification(
+				`Something went wrong in panel ID "${this.props.id}" ${extension ? `of "${extension}"` : ""}, check Console for error log`,
+				true
+			);
 			console.error(error);
 			console.error(`Error stack in panel ID "${this.props.id}": ${info.componentStack}`);
 			Spicetify.Panel.setPanel(Spicetify.Panel.reservedPanelIds.Disabled);


### PR DESCRIPTION
Shows descriptive error message if possible, instead of having users second guessing where the stack is from.
![image](https://github.com/spicetify/spicetify-cli/assets/77577746/b92191ca-e17e-4f4e-bd04-57713844d8da)
