### PR TITLE
fix(css-map): remove outdated buddy feed header class

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1790,7 +1790,6 @@
     "tp8rO9vtqBGPLOhwcdYv": "main-avatar-avatar",
     "tojGvx6tcIBmKlICMJAZ": "main-rootlist-rootlistPlaylistsScrollNode",
     "oWQvtc5QZlmB60A9ejJx": "main-buddyFeed-friendsFeedContainer",
-    "PJt6DU4NhGjz7fVCZjS7": "main-buddyFeed-header",
     "BeABJha8PrxMcJmlBzcH": "main-buddyFeed-headerTitle",
     "GtLo0cn39YXPlR9kbbbo": "main-buddyFeed-findFriendsButton",
     "AWUxW13rbpNdQkvJJg13": "main-buddyFeed-scrollableArea",


### PR DESCRIPTION
This would fix misaligned buddy feed header

Before version 1.2.0 buddy feed header has class `PJt6DU4NhGjz7fVCZjS7` and its styles were stored in `xpui-routes-buddy-feed.css`, but starting with version 1.2.0 the class name has changed and its styles moved to `xpui.css`, so the styles in `xpui-routes-buddy-feed.css` became obsolete and weren't apply anymore. Spicetify changes both the actual class name in `xpui.css` and the obsolete ones in `xpui-routes-buddy-feed.css` to `main-buddyFeed-header`, resulting in incorrect styling and misalignment

stock:
![image](https://github.com/spicetify/spicetify-cli/assets/115353812/52ac53ef-e29c-4e0b-b074-bfa761194a39)

with spicetify applied:

![image](https://github.com/spicetify/spicetify-cli/assets/115353812/fbd743e2-e974-4638-9f75-018bd917ff53)

since versions below 1.2.0 aren't supported anymore and in 1.2.0 it is different class name, I think this class can be removed from the map

![image](https://github.com/spicetify/spicetify-cli/assets/115353812/7306c728-1331-4fb0-a08d-daa76c54e9b4)
