### PR TITLE
refactor(keyboardShortcut): cleanup & patch keybinds

### DIFF
--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -12,7 +12,6 @@
 
 	// Default keybinds
 	const vim = new VimBind();
-	vim.setCancelKey("ESCAPE");
 	const SCROLL_STEP = 25;
 	const binds = {
 		// Ctrl + Tab and Ctrl + Shift + Tab to switch sidebar items
@@ -77,6 +76,7 @@
 		f: {
 			callback: event => {
 				vim.activate(event);
+				vim.setCancelKey("ESCAPE");
 			}
 		}
 	};

--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -49,7 +49,6 @@
 		if (typeof staticCondition === "undefined" || staticCondition) {
 			Spicetify.Mousetrap.bind(key, event => {
 				if (!vim.isActive) {
-					console.log(callback)
 					callback(event);
 				}
 			});

--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -14,65 +14,14 @@
 	const vim = new VimBind();
 	const SCROLL_STEP = 25;
 	const binds = {
-		// Ctrl + Tab and Ctrl + Shift + Tab to switch sidebar items
-		"ctrl+tab": {
-			callback: () => {
-				rotateSidebar(1);
-			}
-		},
-		"ctrl+shift+tab": {
-			callback: () => {
-				rotateSidebar(-1);
-			}
-		},
-		// PageUp, PageDown to focus on iframe app before scrolling
-		"shift+pageup": {
-			callback: focusOnApp
-		},
-		"shift+pagedown": {
-			callback: focusOnApp
-		},
-		// J and K to vertically scroll app
-		j: {
-			callback: () => {
-				const app = focusOnApp();
-				if (app) {
-					const scrollInterval = setInterval(() => {
-						app.scrollTop += SCROLL_STEP;
-					}, 10);
-					document.addEventListener("keyup", () => {
-						clearInterval(scrollInterval);
-					});
-				}
-			}
-		},
-		k: {
-			callback: () => {
-				const app = focusOnApp();
-				if (app) {
-					const scrollInterval = setInterval(() => {
-						app.scrollTop -= SCROLL_STEP;
-					}, 10);
-					document.addEventListener("keyup", () => {
-						clearInterval(scrollInterval);
-					});
-				}
-			}
-		},
-		// G and Shift + G to scroll to top and to bottom
-		g: {
-			callback: () => {
-				const app = focusOnApp();
-				app.scroll(0, 0);
-			}
-		},
-		"shift+g": {
-			callback: () => {
-				const app = focusOnApp();
-				app.scroll(0, app.scrollHeight);
-			}
-		},
-		// F to activate Link Follow function
+		"ctrl+tab": { callback: rotateSidebar(1) },
+		"ctrl+shift+tab": { callback: rotateSidebar(-1) },
+		"shift+pageup": { callback: focusOnApp },
+		"shift+pagedown": { callback: focusOnApp },
+		j: createScrollCallback(SCROLL_STEP),
+		k: createScrollCallback(-SCROLL_STEP),
+		g: scrollToPosition(0),
+		"shift+g": scrollToPosition(1),
 		f: {
 			callback: event => {
 				vim.activate(event);
@@ -93,6 +42,27 @@
 	// Functions
 	function focusOnApp() {
 		return document.querySelector(".Root__main-view .os-viewport");
+	}
+
+	function createScrollCallback(step) {
+		return () => {
+			const app = focusOnApp();
+			if (app) {
+				const scrollInterval = setInterval(() => {
+					app.scrollTop += step;
+				}, 10);
+				document.addEventListener("keyup", () => {
+					clearInterval(scrollInterval);
+				});
+			}
+		};
+	}
+
+	function scrollToPosition(position) {
+		return () => {
+			const app = focusOnApp();
+			app.scroll(0, position === 0 ? 0 : app.scrollHeight);
+		};
 	}
 
 	/**

--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -25,17 +25,17 @@
 		"ctrl+tab": { callback: () => rotateSidebar(1) },
 		"ctrl+shift+tab": { callback: () => rotateSidebar(-1) },
 
-		// Focus on the app content using Shift+PageUp and Shift+PageDown
-		"shift+pageup": { callback: focusOnApp },
-		"shift+pagedown": { callback: focusOnApp },
+		// Focus on the app content before scrolling using Shift+PageUp and Shift+PageDown
+		"shift+pageup": { callback: () => focusOnApp() },
+		"shift+pagedown": { callback: () => focusOnApp() },
 
 		// Scroll actions using 'j' and 'k' keys
-		j: { callback: createScrollCallback(SCROLL_STEP) },
-		k: { callback: createScrollCallback(-SCROLL_STEP) },
+		j: { callback: () => createScrollCallback(SCROLL_STEP) },
+		k: { callback: () => createScrollCallback(-SCROLL_STEP) },
 
 		// Scroll to the top ('g') or bottom ('Shift+g') of the page
-		g: { callback: scrollToPosition(0) },
-		"shift+g": { callback: scrollToPosition(1) },
+		g: { callback: () => scrollToPosition(0) },
+		"shift+g": { callback: () => scrollToPosition(1) },
 
 		// Activate Vim mode and set cancel key to 'ESCAPE'
 		f: {
@@ -61,24 +61,20 @@
 	}
 
 	function createScrollCallback(step) {
-		return () => {
-			const app = focusOnApp();
-			if (app) {
-				const scrollInterval = setInterval(() => {
-					app.scrollTop += step;
-				}, 10);
-				document.addEventListener("keyup", () => {
-					clearInterval(scrollInterval);
-				});
-			}
-		};
+		const app = focusOnApp();
+		if (app) {
+			const scrollInterval = setInterval(() => {
+				app.scrollTop += step;
+			}, 10);
+			document.addEventListener("keyup", () => {
+				clearInterval(scrollInterval);
+			});
+		}
 	}
 
 	function scrollToPosition(position) {
-		return () => {
-			const app = focusOnApp();
-			app.scroll(0, position === 0 ? 0 : app.scrollHeight);
-		};
+		const app = focusOnApp();
+		app.scroll(0, position === 0 ? 0 : app.scrollHeight);
 	}
 
 	/**

--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -1,217 +1,97 @@
 // NAME: Keyboard Shortcut
-// AUTHOR: khanhas
+// AUTHOR: khanhas, OhItsTom
 // DESCRIPTION: Register a few more keybinds to support keyboard-driven navigation in Spotify client.
 
 /// <reference path="../globals.d.ts" />
 
 (function KeyboardShortcut() {
-	if (!Spicetify.Keyboard) {
+	if (!Spicetify.Mousetrap) {
 		setTimeout(KeyboardShortcut, 1000);
 		return;
 	}
 
-	const SCROLL_STEP = 25;
-
-	/**
-	 * Register your own keybind with function `registerBind`
-	 *
-	 * Syntax:
-	 *     registerBind(keyName, ctrl, shift, alt, callback)
-	 *
-	 * ctrl, shift and alt are boolean, true or false
-	 *
-	 * Valid keyName:
-	 * - BACKSPACE       - C               - Y               - F3
-	 * - TAB             - D               - Z               - F4
-	 * - ENTER           - E               - WINDOW_LEFT     - F5
-	 * - SHIFT           - F               - WINDOW_RIGHT    - F6
-	 * - CTRL            - G               - SELECT          - F7
-	 * - ALT             - H               - NUMPAD_0        - F8
-	 * - PAUSE/BREAK     - I               - NUMPAD_1        - F9
-	 * - CAPS            - J               - NUMPAD_2        - F10
-	 * - ESCAPE          - K               - NUMPAD_3        - F11
-	 * - SPACE           - L               - NUMPAD_4        - F12
-	 * - PAGE_UP         - M               - NUMPAD_5        - NUM_LOCK
-	 * - PAGE_DOWN       - N               - NUMPAD_6        - SCROLL_LOCK
-	 * - END             - O               - NUMPAD_7        - ;
-	 * - HOME            - P               - NUMPAD_8        - =
-	 * - ARROW_LEFT      - Q               - NUMPAD_9        - ,
-	 * - ARROW_UP        - R               - MULTIPLY        - -
-	 * - ARROW_RIGHT     - S               - ADD             - /
-	 * - ARROW_DOWN      - T               - SUBTRACT        - `
-	 * - INSERT          - U               - DECIMAL_POINT   - [
-	 * - DELETE          - V               - DIVIDE          - \
-	 * - A               - W               - F1              - ]
-	 * - B               - X               - F2              - "
-	 *
-	 * Use one of keyName as a string. If key that you want isn't in that list,
-	 * you can also put its keycode number in keyName as a number.
-	 *
-	 * callback is name of function you want your shortcut to bind to. It also
-	 * returns one KeyboardEvent parameter.
-	 *
-	 * Following are my default keybinds, use them as examples.
-	 */
-
-	// Ctrl + Tab and Ctrl + Shift + Tab to switch sidebar items
-	registerBind("TAB", true, false, false, rotateSidebarDown);
-	registerBind("TAB", true, true, false, rotateSidebarUp);
-
-	// Ctrl + Q to open Queue page
-	registerBind("Q", true, false, false, clickQueueButton);
-
-	// Shift + H and Shift + L to go back and forward page
-	registerBind("H", false, true, false, clickNavigatingBackButton);
-	registerBind("L", false, true, false, clickNavigatingForwardButton);
-
-	// PageUp, PageDown to focus on iframe app before scrolling
-	registerBind("PAGE_UP", false, true, false, focusOnApp);
-	registerBind("PAGE_DOWN", false, true, false, focusOnApp);
-
-	// J and K to vertically scroll app
-	registerBind("J", false, false, false, appScrollDown);
-	registerBind("K", false, false, false, appScrollUp);
-
-	// G and Shift + G to scroll to top and to bottom
-	registerBind("G", false, false, false, appScrollTop);
-	registerBind("G", false, true, false, appScrollBottom);
-
-	// M to Like/Unlike track
-	registerBind("M", false, false, false, Spicetify.Player.toggleHeart);
-
-	// Forward Slash to open search page
-	registerBind("/", false, false, false, openSearchPage);
-
-	if (window.navigator.userAgent.indexOf("Win") === -1) {
-		// CTRL + Arrow Left Next and CTRL + Arrow Right  Previous Song
-		registerBind("ARROW_RIGHT", true, false, false, nextSong);
-		registerBind("ARROW_LEFT", true, false, false, previousSong);
-
-		// CTRL + Arrow Up Increase Volume CTRL + Arrow Down Decrease Volume
-		registerBind("ARROW_UP", true, false, false, increaseVolume);
-		registerBind("ARROW_DOWN", true, false, false, decreaseVolume);
-	}
-
-	// F to activate Link Follow function
+	// Default keybinds
 	const vim = new VimBind();
-	registerBind("F", false, false, false, vim.activate.bind(vim));
-	// Esc to cancel Link Follow
 	vim.setCancelKey("ESCAPE");
-
-	function rotateSidebarDown() {
-		rotateSidebar(1);
-	}
-
-	function rotateSidebarUp() {
-		rotateSidebar(-1);
-	}
-
-	function clickQueueButton() {
-		document.querySelector(".main-nowPlayingBar-right .control-button-wrapper > button").click();
-	}
-
-	function clickNavigatingBackButton() {
-		document.querySelector(".main-topBar-historyButtons .main-topBar-back").click();
-	}
-
-	function clickNavigatingForwardButton() {
-		document.querySelector(".main-topBar-historyButtons .main-topBar-forward").click();
-	}
-
-	function appScrollDown() {
-		const app = focusOnApp();
-		if (app) {
-			const scrollInterval = setInterval(() => {
-				app.scrollTop += SCROLL_STEP;
-			}, 10);
-			document.addEventListener("keyup", () => {
-				clearInterval(scrollInterval);
-			});
-		}
-	}
-
-	function appScrollUp() {
-		const app = focusOnApp();
-		if (app) {
-			const scrollInterval = setInterval(() => {
-				app.scrollTop -= SCROLL_STEP;
-			}, 10);
-			document.addEventListener("keyup", () => {
-				clearInterval(scrollInterval);
-			});
-		}
-	}
-
-	function appScrollBottom() {
-		const app = focusOnApp();
-		app.scroll(0, app.scrollHeight);
-	}
-
-	function appScrollTop() {
-		const app = focusOnApp();
-		app.scroll(0, 0);
-	}
-
-	function nextSong() {
-		document.querySelector("button[aria-label='Next']").click();
-	}
-
-	function previousSong() {
-		document.querySelector("button[aria-label='Previous']").click();
-	}
-
-	function increaseVolume() {
-		Spicetify.Player.setVolume(Spicetify.Player.getVolume() + 0.05);
-	}
-
-	function decreaseVolume() {
-		Spicetify.Player.setVolume(Spicetify.Player.getVolume() - 0.05);
-	}
-
-	/**
-	 *
-	 * @param {KeyboardEvent} event
-	 */
-	function openSearchPage(event) {
-		const searchInput = document.querySelector(".main-topBar-container input");
-		if (searchInput) {
-			searchInput.focus();
-		} else {
-			const sidebarItem = document.querySelector(`.main-navBar-navBar a[href="/search"]`);
-			if (sidebarItem) {
-				sidebarItem.click();
+	const SCROLL_STEP = 25;
+	const binds = {
+		// Ctrl + Tab and Ctrl + Shift + Tab to switch sidebar items
+		"ctrl+tab": {
+			callback: () => {
+				rotateSidebar(1);
+			}
+		},
+		"ctrl+shift+tab": {
+			callback: () => {
+				rotateSidebar(-1);
+			}
+		},
+		// PageUp, PageDown to focus on iframe app before scrolling
+		"shift+pageup": {
+			callback: focusOnApp
+		},
+		"shift+pagedown": {
+			callback: focusOnApp
+		},
+		// J and K to vertically scroll app
+		j: {
+			callback: () => {
+				const app = focusOnApp();
+				if (app) {
+					const scrollInterval = setInterval(() => {
+						app.scrollTop += SCROLL_STEP;
+					}, 10);
+					document.addEventListener("keyup", () => {
+						clearInterval(scrollInterval);
+					});
+				}
+			}
+		},
+		k: {
+			callback: () => {
+				const app = focusOnApp();
+				if (app) {
+					const scrollInterval = setInterval(() => {
+						app.scrollTop -= SCROLL_STEP;
+					}, 10);
+					document.addEventListener("keyup", () => {
+						clearInterval(scrollInterval);
+					});
+				}
+			}
+		},
+		// G and Shift + G to scroll to top and to bottom
+		g: {
+			callback: () => {
+				console.log(vim.isActive);
+				const app = focusOnApp();
+				app.scroll(0, 0);
+			}
+		},
+		"shift+g": {
+			callback: () => {
+				const app = focusOnApp();
+				app.scroll(0, app.scrollHeight);
+			}
+		},
+		// F to activate Link Follow function
+		f: {
+			callback: event => {
+				vim.activate(event);
 			}
 		}
-
-		event.preventDefault();
-	}
-
-	/**
-	 *
-	 * @param {Spicetify.Keyboard.ValidKey} keyName
-	 * @param {boolean} ctrl
-	 * @param {boolean} shift
-	 * @param {boolean} alt
-	 * @param {(event: KeyboardEvent) => void} callback
-	 */
-	function registerBind(keyName, ctrl, shift, alt, callback) {
-		const key = Spicetify.Keyboard.KEYS[keyName];
-
-		Spicetify.Keyboard.registerShortcut(
-			{
-				key,
-				ctrl,
-				shift,
-				alt
-			},
-			event => {
+	};
+	Object.entries(binds).forEach(([key, { staticCondition, callback }]) => {
+		if (typeof staticCondition === "undefined" || staticCondition) {
+			Spicetify.Mousetrap.bind(key, event => {
 				if (!vim.isActive) {
 					callback(event);
 				}
-			}
-		);
-	}
+			});
+		}
+	});
 
+	// Functions
 	function focusOnApp() {
 		return document.querySelector(".Root__main-view .os-viewport");
 	}
@@ -221,16 +101,17 @@
 	 * @param {NodeListOf<Element>} allItems
 	 */
 	function findActiveIndex(allItems) {
-		const active = document.querySelector(
-			".main-navBar-navBarLinkActive, .main-collectionLinkButton-selected, .main-rootlist-rootlistItemLinkActive"
-		);
-		if (!active) {
+		const activeLink = document.querySelector(".main-yourLibraryX-navLinkActive");
+		const historyURI = Spicetify.Platform.History.location.pathname.replace(/^\//, "spotify:").replace(/\//g, ":");
+		const activePage = document.querySelector(`[aria-describedby="onClickHint${historyURI}"]`);
+
+		if (!activeLink && !activePage) {
 			return -1;
 		}
 
 		let index = 0;
 		for (const item of allItems) {
-			if (item === active) {
+			if (item === activeLink || item === activePage) {
 				return index;
 			}
 
@@ -244,20 +125,15 @@
 	 */
 	function rotateSidebar(direction) {
 		const allItems = document.querySelectorAll(
-			".main-navBar-navBarLink, .main-collectionLinkButton-collectionLinkButton, .main-rootlist-rootlistItemLink"
+			"#spicetify-sticky-list .main-yourLibraryX-navLink, .main-yourLibraryX-listItem > div > div:first-child"
 		);
 		const maxIndex = allItems.length - 1;
-		let index = findActiveIndex(allItems) + direction;
 
+		let index = findActiveIndex(allItems) + direction;
 		if (index < 0) index = maxIndex;
 		else if (index > maxIndex) index = 0;
 
-		let toClick = allItems[index];
-		if (!toClick.hasAttribute("href")) {
-			toClick = toClick.querySelector(".main-rootlist-rootlistItemLink");
-		}
-
-		toClick.click();
+		allItems[index].click();
 	}
 })();
 
@@ -423,17 +299,6 @@ function VimBind() {
 		}
 		alert("Let me know where you found this button, please. I can't click this for you without that information.");
 		return;
-		// TableCell case where play button is hidden
-		// Index number is in first column
-		const index = parseInt(element.firstChild.innerText) - 1;
-		const context = getContextUri();
-		if (index >= 0 && context) {
-			console.log(index);
-			console.log(context);
-
-			//Spicetify.PlaybackControl.playFromResolver(context, { index }, () => {});
-			return;
-		}
 	}
 
 	/**
@@ -450,20 +315,6 @@ function VimBind() {
 		div.style.left = left + "px";
 		div.target = target;
 		return div;
-	}
-
-	function getContextUri() {
-		const username = __spotify.username;
-		const activeApp = localStorage.getItem(username + ":activeApp");
-		if (activeApp) {
-			try {
-				return JSON.parse(activeApp).uri.replace("app:", "");
-			} catch {
-				return null;
-			}
-		}
-
-		return null;
 	}
 
 	/**

--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -63,7 +63,6 @@
 		// G and Shift + G to scroll to top and to bottom
 		g: {
 			callback: () => {
-				console.log(vim.isActive);
 				const app = focusOnApp();
 				app.scroll(0, 0);
 			}

--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -10,18 +10,34 @@
 		return;
 	}
 
-	// Default keybinds
+	// Variables / Conditions
 	const vim = new VimBind();
 	const SCROLL_STEP = 25;
+
+	/**
+	 * Binds a keyboard shortcut using Mousetrap.
+	 * @param {string} key - The Mousetrap keybind.
+	 * @param {boolean | undefined} staticCondition - A static condition.
+	 * @param {(event: KeyboardEvent) => void} callback - Callback function for the event.
+	 */
 	const binds = {
+		// Rotate through sidebar items using Ctrl+Tab and Ctrl+Shift+Tab
 		"ctrl+tab": { callback: rotateSidebar(1) },
 		"ctrl+shift+tab": { callback: rotateSidebar(-1) },
+
+		// Focus on the app content using Shift+PageUp and Shift+PageDown
 		"shift+pageup": { callback: focusOnApp },
 		"shift+pagedown": { callback: focusOnApp },
+
+		// Scroll actions using 'j' and 'k' keys
 		j: createScrollCallback(SCROLL_STEP),
 		k: createScrollCallback(-SCROLL_STEP),
+
+		// Scroll to the top ('g') or bottom ('Shift+g') of the page
 		g: scrollToPosition(0),
 		"shift+g": scrollToPosition(1),
+
+		// Activate Vim mode and set cancel key to 'ESCAPE'
 		f: {
 			callback: event => {
 				vim.activate(event);

--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -22,20 +22,20 @@
 	 */
 	const binds = {
 		// Rotate through sidebar items using Ctrl+Tab and Ctrl+Shift+Tab
-		"ctrl+tab": { callback: rotateSidebar(1) },
-		"ctrl+shift+tab": { callback: rotateSidebar(-1) },
+		"ctrl+tab": { callback: () => rotateSidebar(1) },
+		"ctrl+shift+tab": { callback: () => rotateSidebar(-1) },
 
 		// Focus on the app content using Shift+PageUp and Shift+PageDown
 		"shift+pageup": { callback: focusOnApp },
 		"shift+pagedown": { callback: focusOnApp },
 
 		// Scroll actions using 'j' and 'k' keys
-		j: createScrollCallback(SCROLL_STEP),
-		k: createScrollCallback(-SCROLL_STEP),
+		j: { callback: createScrollCallback(SCROLL_STEP) },
+		k: { callback: createScrollCallback(-SCROLL_STEP) },
 
 		// Scroll to the top ('g') or bottom ('Shift+g') of the page
-		g: scrollToPosition(0),
-		"shift+g": scrollToPosition(1),
+		g: { callback: scrollToPosition(0) },
+		"shift+g": { callback: scrollToPosition(1) },
 
 		// Activate Vim mode and set cancel key to 'ESCAPE'
 		f: {
@@ -49,6 +49,7 @@
 		if (typeof staticCondition === "undefined" || staticCondition) {
 			Spicetify.Mousetrap.bind(key, event => {
 				if (!vim.isActive) {
+					console.log(callback)
 					callback(event);
 				}
 			});


### PR DESCRIPTION
This PR removes redundant keybinds that Spotify have implemented into their own shortcut menu (ctrl + ?), whilst also fixing pre-existing ones (namely rotate navbar item which broke from libx).

The registering of these binds has also been moved to a json/object structure making it easier to expand upon both on the dev side and in a future settings menu if we were to add one.

Also moved from `Spicetify.Keyboard` to `Spicetify.Mousetrap`

(docs will need rewriting)