### PR TITLE
feat(wrapper): add webpack related definitions to own class

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -292,7 +292,8 @@ window.Spicetify = {
 	},
 	ReactComponent: {},
 	ReactHook: {},
-	ReactFlipToolkit: {}
+	ReactFlipToolkit: {},
+	Webpack: {}
 };
 
 (async function hotloadWebpackModules() {
@@ -334,6 +335,12 @@ window.Spicetify = {
 		.filter(Boolean);
 
 	Object.assign(Spicetify, {
+		Webpack: {
+			chunks: webpackChunkopen,
+			require,
+			modules,
+			functionModules
+		},
 		React: cache.find(m => m?.useMemo),
 		ReactDOM: cache.find(m => m?.createPortal),
 		ReactDOMServer: cache.find(m => m?.renderToString),


### PR DESCRIPTION
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/84867c41-1aff-444f-83cf-c1b1b0e58221)

This PR aims to make it easier for devs to interact with webpack related functions and object, without having to define 5 lines of variables in devtools every reload just to troubleshoot it.

This adds no performance disadvantage as we already define these functions.

If this is closed without proper discussion with the rest of the org i will be reporting whoever closes it to @afonsojramos, it is not a one person decision to deny a PR.