### PR TITLE
feat(wrapper): expose `Button` components

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -2,6 +2,34 @@ declare namespace Spicetify {
     type Icon = "album" | "artist" | "block" | "brightness" | "car" | "chart-down" | "chart-up" | "check" | "check-alt-fill" | "chevron-left" | "chevron-right" | "chromecast-disconnected" | "clock" | "collaborative" | "computer" | "copy" | "download" | "downloaded" | "edit" | "enhance" | "exclamation-circle" | "external-link" | "facebook" | "follow" | "fullscreen" | "gamepad" | "grid-view" | "heart" | "heart-active" | "instagram" | "laptop" | "library" | "list-view" | "location" | "locked" | "locked-active" | "lyrics" | "menu" | "minimize" | "minus" | "more" | "new-spotify-connect" | "offline" | "pause" | "phone" | "play" | "playlist" | "playlist-folder" | "plus-alt" | "plus2px" | "podcasts" | "projector" | "queue" | "repeat" | "repeat-once" | "search" | "search-active" | "shuffle" | "skip-back" | "skip-back15" | "skip-forward" | "skip-forward15" | "soundbetter" | "speaker" | "spotify" | "subtitles" | "tablet" | "ticket" | "twitter" | "visualizer" | "voice" | "volume" | "volume-off" | "volume-one-wave" | "volume-two-wave" | "watch" | "x";
     type Variant = "bass" | "forte" | "brio" | "altoBrio" | "alto" | "canon" | "celloCanon" | "cello" | "ballad" | "balladBold" | "viola" | "violaBold" | "mesto" | "mestoBold" | "metronome" | "finale" | "finaleBold" | "minuet" | "minuetBold";
     type SemanticColor = "textBase" | "textSubdued" | "textBrightAccent" | "textNegative" | "textWarning" | "textPositive" | "textAnnouncement" | "essentialBase" | "essentialSubdued" | "essentialBrightAccent" | "essentialNegative" | "essentialWarning" | "essentialPositive" | "essentialAnnouncement" | "decorativeBase" | "decorativeSubdued" | "backgroundBase" | "backgroundHighlight" | "backgroundPress" | "backgroundElevatedBase" | "backgroundElevatedHighlight" | "backgroundElevatedPress" | "backgroundTintedBase" | "backgroundTintedHighlight" | "backgroundTintedPress" | "backgroundUnsafeForSmallTextBase" | "backgroundUnsafeForSmallTextHighlight" | "backgroundUnsafeForSmallTextPress";
+    type ColorSet = "base" | "brightAccent" | "negative" | "warning" | "positive" | "announcement" | "invertedDark" | "invertedLight" | "mutedAccent" | "overMedia";
+    type ColorSetBackgroundColors = {
+        base: string;
+        highlight: string;
+        press: string;
+    };
+    type ColorSetNamespaceColors = {
+        announcement: string;
+        base: string;
+        brightAccent: string;
+        negative: string;
+        positive: string;
+        subdued: string;
+        warning: string;
+    };
+    type ColorSetBody = {
+        background: ColorSetBackgroundColors & {
+            elevated: ColorSetBackgroundColors;
+            tinted: ColorSetBackgroundColors;
+            unsafeForSmallText: ColorSetBackgroundColors;
+        };
+        decorative: {
+            base: string;
+            subdued: string;
+        };
+        essential: ColorSetNamespaceColors
+        text: ColorSetNamespaceColors
+    };
     type Metadata = Partial<Record<string, string>>;
     type ContextTrack = {
         uri: string;
@@ -1356,6 +1384,65 @@ declare namespace Spicetify {
              * @deprecated Use `onDrag` props instead.
              */
             onStepBackward?: () => void;
+        }
+        type ButtonProps = {
+            component: any;
+            /**
+             * Color set for the button.
+             * @default "brightAccent"
+             */
+            colorSet?: ColorSet;
+            /**
+             * Size for the button.
+             * @default "md"
+             */
+            buttonSize?: "sm" | "md" | "lg";
+            /**
+             * Size for the button.
+             * @deprecated Use `buttonSize` prop instead, as it will take precedence.
+             * @default "medium"
+             */
+            size?: "small" | "medium" | "large";
+            /**
+             * Unused by Spotify. Usage unknown.
+             */
+            fullWidth?: any;
+            /**
+             * React component to render for an icon placed before children. Component, not element!
+             */
+            iconLeading?: (props: any) => any | string;
+            /**
+             * React component to render for an icon placed after children. Component, not element!
+             */
+            iconTrailing?: (props: any) => any | string;
+            /**
+             * React component to render for an icon used as button body. Component, not element!
+             */
+            iconTrailing?: (props: any) => any | string;
+            /**
+             * Additional class name to apply to the button.
+             */
+            className?: string;
+            /**
+             * Label of the element for screen readers.
+             */
+            ["aria-label"]?: string;
+            /**
+             * ID of an element that describes the button for screen readers.
+             */
+            ["aria-labelledby"]?: string;
+            /**
+             * Unsafely set the color set for the button.
+             * Values from the colorSet will be pasted into the CSS.
+             */
+            UNSAFE_colorSet?: ColorSetBody
+            onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+            onMouseEnter?: (event: MouseEvent<HTMLButtonElement>) => void;
+            onMouseLeave?: (event: MouseEvent<HTMLButtonElement>) => void;
+            onMouseDown?: (event: MouseEvent<HTMLButtonElement>) => void;
+            onMouseUp?: (event: MouseEvent<HTMLButtonElement>) => void;
+            onFocus?: (event: FocusEvent<HTMLButtonElement>) => void;
+            onBlur?: (event: FocusEvent<HTMLButtonElement>) => void;
         }
         /**
          * Generic context menu provider

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -222,7 +222,10 @@ window.Spicetify = {
 			"PanelSkeleton",
 			"PanelHeader",
 			"Slider",
-			"RemoteConfigProvider"
+			"RemoteConfigProvider",
+			"ButtonPrimary",
+			"ButtonSecondary",
+			"ButtonTertiary",
 		];
 
 		const REACT_HOOK = ["DragHandler", "usePanelState", "useExtractedColor"];
@@ -394,6 +397,9 @@ window.Spicetify = {
 				modules.find(m => m?.render?.toString().includes("scrollBarContainer")) ||
 				functionModules.find(m => m.toString().includes("scrollBarContainer")),
 			PanelSkeleton: functionModules.find(m => m.toString().includes("label") && m.toString().includes("aside")) || modules.find(m => m?.render?.toString().includes('"section"')),
+			ButtonPrimary: modules.find(m => m?.render && m?.displayName === "ButtonPrimary"),
+			ButtonSecondary: modules.find(m => m?.render && m?.displayName === "ButtonSecondary"),
+			ButtonTertiary: modules.find(m => m?.render && m?.displayName === "ButtonTertiary"),
 			...Object.fromEntries(menus)
 		},
 		ReactHook: {


### PR DESCRIPTION
Exposes the `ButtonPrimary`, `ButtonSecondary` and `ButtonTertiary` react components to make Spotify buttons.

Also adds types for ColorSets, though Spotify's own ColorSets have not been exposed.

```js
var exampleIconComponent = (props) => Spicetify.React.createElement(Spicetify.ReactComponent.IconComponent, {...props, dangerouslySetInnerHTML: {__html:`<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 76.465 68.262"><path d="M151.909 72.923v6.5h10.097l8.663 44.567h48.968v-6.5h-43.61l-1.2-6.172h42.974l10.35-33.91h-59.915l-.872-4.485H151.91zm17.59 10.984h49.867l-6.393 20.91h-39.409l-4.064-20.91zm5.626 44.11a6.5 6.5 0 0 0-6.5 6.5 6.5 6.5 0 0 0 6.5 6.501 6.5 6.5 0 0 0 6.5-6.5 6.5 6.5 0 0 0-6.5-6.5zm38.274 0a6.5 6.5 0 0 0-6.5 6.5 6.5 6.5 0 0 0 6.5 6.501 6.5 6.5 0 0 0 6.5-6.5 6.5 6.5 0 0 0-6.5-6.5z" style="fill:currentColor;stroke-width:.264583" transform="translate(-151.909 -72.923)"/></svg>`}})
    
Spicetify.ReactDOM.render(
    Spicetify.React.createElement(Spicetify.React.Fragment, {},
        Spicetify.React.createElement(Spicetify.ReactComponent.ButtonPrimary, {
            iconLeading: exampleIconComponent,
            colorSet: "warning"
        }, "PRIMARY"),
        Spicetify.React.createElement(Spicetify.ReactComponent.ButtonSecondary, {
            buttonSize: "lg"
        }, "SECONDARY"),
        Spicetify.React.createElement(Spicetify.ReactComponent.ButtonTertiary, {
            onClick: () => alert("Hi")
        }, "TERTIARY")
    ),
    document.getElementById("ReactTEST")
)
```
![image](https://github.com/spicetify/spicetify-cli/assets/38393797/6f411c6c-b18f-4b37-98bb-d89dda4de7aa)


