### PR TITLE
fix(lyrics-plus/utils): force usage of OpenCC standard

### DIFF
--- a/CustomApps/lyrics-plus/Utils.js
+++ b/CustomApps/lyrics-plus/Utils.js
@@ -78,7 +78,9 @@ class Utils {
 		}
 
 		// translate it to Simplified Chinese
-		return Utils.#translator.convertChinese(s, "tw", "cn");
+
+		// As Traditional Chinese differs between HK and TW, forcing to use OpenCC standard
+		return Utils.#translator.convertChinese(s, "t", "cn");
 	}
 
 	static removeSongFeat(s) {

--- a/CustomApps/lyrics-plus/Utils.js
+++ b/CustomApps/lyrics-plus/Utils.js
@@ -77,9 +77,8 @@ class Utils {
 			Utils.#translator = new Translator("zh");
 		}
 
-		// translate it to Simplified Chinese
-
-		// As Traditional Chinese differs between HK and TW, forcing to use OpenCC standard
+		// translate to Simplified Chinese
+		// as Traditional Chinese differs between HK and TW, forcing to use OpenCC standard
 		return Utils.#translator.convertChinese(s, "t", "cn");
 	}
 


### PR DESCRIPTION
A small nit-pick about #2508, Traditional Chinese is divided to Hong Kong Traditional Chinese and Taiwan Traditional Chinese. Those regional variants of Traditional Chinese uses different characters in some instances, for example: 着 in Hong Kong and 著 in Taiwan. 

When I first implement the function of converting Simplified Chinese to Traditional Chinese and vice versa. It became obvious that some songs uses either Hong Kong Traditional Chinese or Taiwan Traditional Chinese. Figuring out how to differentiate those two Traditional Chinese was hard until I dig into the OpenCC's character convert website. They pretend that those two as OpenCC Traditional Chinese standard (which is specific to OpenCC only) instead of figuring out what is what.

Seeing the commit, I see that in the implementation of converting song names from Traditional Chinese to Simplified Chinese, all Traditional Characters are treated as Taiwan Traditional Chinese, which might cause problems when converting characters specific to Hong Kong Traditional Chinese. This PR fixes that to what the OpenCC website (and my implementation of converting Traditional Chinese lyrics to Simplified Chinese) handles them.

The intention is to ensure accuracy and consistency in handling these different variations of Traditional Chinese.