### PR TITLE
fix(lyrics-plus): add missing params for mxm richsync

### DIFF
--- a/CustomApps/lyrics-plus/ProviderMusixmatch.js
+++ b/CustomApps/lyrics-plus/ProviderMusixmatch.js
@@ -58,7 +58,8 @@ const ProviderMusixmatch = (function () {
 		const baseURL = `https://apic-desktop.musixmatch.com/ws/1.1/track.richsync.get?format=json&subtitle_format=mxm&app_id=web-desktop-app-v1.0&`;
 
 		const params = {
-			subtitle_length: meta.track.track_length,
+			f_subtitle_length: meta.track.track_length,
+			q_duration: meta.track.track_length,
 			commontrack_id: meta.track.commontrack_id,
 			usertoken: CONFIG.providers.musixmatch.token
 		};


### PR DESCRIPTION
This PR modifies the parameters of Musixmatch API `track.richsync.get` (method to get karaoke lyrics) based on the latest Musixmatch Studio (https://curators.musixmatch.com) implementation.

This will allow you to get word-by-word synchronization data that matches the duration of the song.