### PR TITLE
fix(shuffle+): add context support for Queue

### DIFF
--- a/Extensions/shuffle+.js
+++ b/Extensions/shuffle+.js
@@ -463,7 +463,29 @@
 
 		await Spicetify.Platform.PlayerAPI.clearQueue();
 
-		Spicetify.Platform.PlayerAPI.addToQueue(list.map(uri => ({ uri })));
+		{
+			const { _queue, _client } = Spicetify.Platform.PlayerAPI._queue;
+			const { prevTracks, queueRevision } = _queue;
+
+			const nextTracks = list.map(uri => ({
+				contextTrack: {
+					uri,
+					uid: "",
+					metadata: {
+						is_queued: "false"
+					}
+				},
+				removed: [],
+				blocked: [],
+				provider: "context"
+			}));
+
+			_client.setQueue({
+				nextTracks,
+				prevTracks,
+				queueRevision
+			});
+		}
 
 		if (context) {
 			const { sessionId } = Spicetify.Platform.PlayerAPI.getState();

--- a/Extensions/shuffle+.js
+++ b/Extensions/shuffle+.js
@@ -459,14 +459,14 @@
 	async function Queue(list, context = null, type) {
 		const count = list.length;
 
+		// Delimits the end of our list, as Spotify may add new context tracks to the queue
 		list.push("spotify:delimiter");
-
-		await Spicetify.Platform.PlayerAPI.clearQueue();
 
 		{
 			const { _queue, _client } = Spicetify.Platform.PlayerAPI._queue;
 			const { prevTracks, queueRevision } = _queue;
 
+			// Format tracks with default values 
 			const nextTracks = list.map(uri => ({
 				contextTrack: {
 					uri,
@@ -480,6 +480,7 @@
 				provider: "context"
 			}));
 
+			// Lowest level setQueue method from vendor~xpui.js
 			_client.setQueue({
 				nextTracks,
 				prevTracks,

--- a/Extensions/shuffle+.js
+++ b/Extensions/shuffle+.js
@@ -465,6 +465,11 @@
 
 		Spicetify.Platform.PlayerAPI.addToQueue(list.map(uri => ({ uri })));
 
+		if (context) {
+			const { sessionId } = Spicetify.Platform.PlayerAPI.getState();
+			Spicetify.Platform.PlayerAPI.updateContext(sessionId, { uri: context, url: "context://" + context });
+		}
+
 		Spicetify.Player.next();
 
 		switch (type) {

--- a/Extensions/shuffle+.js
+++ b/Extensions/shuffle+.js
@@ -463,15 +463,7 @@
 
 		await Spicetify.Platform.PlayerAPI.clearQueue();
 
-		Spicetify.Platform.PlayerAPI.addToQueue(
-			list.map(uri => ({
-				uri,
-				provider: "context",
-				metadata: {
-					is_queued: "false"
-				}
-			}))
-		);
+		Spicetify.Platform.PlayerAPI.addToQueue(list.map(uri => ({ uri })));
 
 		Spicetify.Player.next();
 


### PR DESCRIPTION
PlayerAPI.addToQueue really only takes an array of uri objects, the rest is ignored inside PlayerAPI._queue.createQueueItem
To set the playing context, we can just use PlayerAPI.updateContext