### PR TITLE
fix(wrapper): playbar.button match Spotify structure

### DIFF
--- a/CustomApps/lyrics-plus/PlaybarButton.js
+++ b/CustomApps/lyrics-plus/PlaybarButton.js
@@ -6,7 +6,7 @@
 
 	const button = new Spicetify.Playbar.Button(
 		"Lyrics Plus",
-		`<svg role="img" height="16" width="16" aria-hidden="true" viewBox="0 0 16 16" data-encore-id="icon" class="Svg-sc-ytk21e-0 Svg-img-16-icon"><path d="M13.426 2.574a2.831 2.831 0 0 0-4.797 1.55l3.247 3.247a2.831 2.831 0 0 0 1.55-4.797zM10.5 8.118l-2.619-2.62A63303.13 63303.13 0 0 0 4.74 9.075L2.065 12.12a1.287 1.287 0 0 0 1.816 1.816l3.06-2.688 3.56-3.129zM7.12 4.094a4.331 4.331 0 1 1 4.786 4.786l-3.974 3.493-3.06 2.689a2.787 2.787 0 0 1-3.933-3.933l2.676-3.045 3.505-3.99z"></path></svg>`,
+		`<svg role="img" height="16" width="16" aria-hidden="true" viewBox="0 0 16 16" data-encore-id="icon" fill="currentColor"><path d="M13.426 2.574a2.831 2.831 0 0 0-4.797 1.55l3.247 3.247a2.831 2.831 0 0 0 1.55-4.797zM10.5 8.118l-2.619-2.62A63303.13 63303.13 0 0 0 4.74 9.075L2.065 12.12a1.287 1.287 0 0 0 1.816 1.816l3.06-2.688 3.56-3.129zM7.12 4.094a4.331 4.331 0 1 1 4.786 4.786l-3.974 3.493-3.06 2.689a2.787 2.787 0 0 1-3.933-3.933l2.676-3.045 3.505-3.99z"></path></svg>`,
 		() =>
 			Spicetify.Platform.History.location.pathname !== "/lyrics-plus"
 				? Spicetify.Platform.History.push("/lyrics-plus")

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1842,7 +1842,9 @@ Spicetify.Playbar = (function () {
 		constructor(label, icon, onClick = () => {}, disabled = false, active = false, registerOnCreate = true) {
 			this.element = document.createElement("button");
 			this.element.classList.add("main-genericButton-button");
-			this.element.style.display = "block";
+			this.iconElement = document.createElement("span");
+			this.iconElement.classList.add("IconWrapper__Wrapper-sc-16usrgb-0", "Wrapper-sm-only");
+			this.element.appendChild(this.iconElement);
 			this.icon = icon;
 			this.onClick = onClick;
 			this.disabled = disabled;
@@ -1871,7 +1873,7 @@ Spicetify.Playbar = (function () {
 				input = `<svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor" stroke="currentColor">${Spicetify.SVGIcons[input]}</svg>`;
 			}
 			this._icon = input;
-			this.element.innerHTML = input;
+			this.iconElement.innerHTML = input;
 		}
 		get onClick() {
 			return this._onClick;

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1843,7 +1843,7 @@ Spicetify.Playbar = (function () {
 			this.element = document.createElement("button");
 			this.element.classList.add("main-genericButton-button");
 			this.iconElement = document.createElement("span");
-			this.iconElement.classList.add("IconWrapper__Wrapper-sc-16usrgb-0", "Wrapper-sm-only");
+			this.iconElement.classList.add("Wrapper-sm-only");
 			this.element.appendChild(this.iconElement);
 			this.icon = icon;
 			this.onClick = onClick;


### PR DESCRIPTION
Spotify has started wrapping playbar buttons in a span instead of displaying as block, to prevent weird padding behaviour between ours and their buttons; we should do the same.

before:
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/a720fa9f-92b8-40c5-9b96-8b99bedc0cc8)

after:
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/bf7acf9d-3a00-4f1b-8477-4a824b3743ff)
