### PR TITLE
fix(cmd/patch): support `~` in file names

### DIFF
--- a/src/cmd/patch.go
+++ b/src/cmd/patch.go
@@ -12,7 +12,7 @@ import (
 func Patch() {
 	keys := patchSection.Keys()
 
-	re := regexp.MustCompile(`^([\w\d\-\.]+)_find_(\d+)$`)
+	re := regexp.MustCompile(`^([\w\d\-~\.]+)_find_(\d+)$`)
 	for _, key := range keys {
 		keyName := key.Name()
 		matches := re.FindStringSubmatch(keyName)


### PR DESCRIPTION
required if you need, for example, to patch `vendor~xpui.js`
![image](https://github.com/spicetify/spicetify-cli/assets/115353812/524a421c-a89b-498a-9b1b-762d90e8d2ed)
