### PR TITLE
fix(lyrics-plus): synced line width

### DIFF
--- a/CustomApps/lyrics-plus/style.css
+++ b/CustomApps/lyrics-plus/style.css
@@ -139,6 +139,7 @@
 	transition-timing-function: cubic-bezier(0, 0, 0.58, 1);
 	transition-duration: calc(var(--animation-index) * var(--animation-tempo) + 0.1s);
 	transition-property: transform, color, opacity;
+	width: fit-content;
 }
 
 .lyrics-lyricsContainer-LyricsContainer.blur-enabled .lyrics-lyricsContainer-SyncedLyrics .lyrics-lyricsContainer-LyricsLine {


### PR DESCRIPTION
removes unnecessary horizontal scrollbar for me when window width is more than 2500px (98% of my display width)

before:

![Без имени-1](https://github.com/spicetify/spicetify-cli/assets/115353812/70f5fb40-8524-4ff9-9d5b-43ad43d769da)

after:

![Без имени-2](https://github.com/spicetify/spicetify-cli/assets/115353812/c76ecc98-c653-4469-a3f3-f77b363d8bb2)
