### PR TITLE
fix(wrapper): correct webpack module for `Spicetify.ReactComponent.Menu`

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -383,7 +383,7 @@ window.Spicetify = {
 			...Spicetify.ReactComponent,
 			TextComponent: modules.find(m => m?.h1 && m?.render),
 			ConfirmDialog: functionModules.find(m => m.toString().includes("isOpen") && m.toString().includes("shouldCloseOnEsc")),
-			Menu: functionModules.find(m => m.toString().includes("getInitialFocusElement")),
+			Menu: functionModules.find(m => m.toString().includes("getInitialFocusElement") && m.toString().includes("children")),
 			MenuItem: functionModules.find(m => m.toString().includes("handleMouseEnter") && m.toString().includes("onClick")),
 			Slider: wrapProvider(functionModules.find(m => m.toString().includes("onStepBackward"))),
 			RemoteConfigProvider: functionModules.find(m => m.toString().includes("resolveSuspense") && m.toString().includes("configuration")),


### PR DESCRIPTION
before:
![image](https://github.com/spicetify/spicetify-cli/assets/115353812/1165467f-777e-4bf7-a966-c70392835526)
`encore-dark-theme main-contextMenu-menu` classes are missing

after:
![image](https://github.com/spicetify/spicetify-cli/assets/115353812/08db43ec-2a9b-4bc4-9d05-7d914d261651)
