### PR TITLE
ci(github/actions): re-enable HTTPS on AUR update request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Update AUR package
         uses: fjogeleit/http-request-action@master
         with:
-          url: http://vps.itsmeow.dev:8079/
+          url: https://vps.itsmeow.dev/spicetify-update
           method: GET
       - name: Update Homebrew tap
         uses: mislav/bump-homebrew-formula-action@v2


### PR DESCRIPTION
I've fixed the reverse proxy on my server as well as fixed the .SRCINFO issues, so I'm putting it back with the old URL. I did test this and it works.

Partial revert of #2058