### PR TITLE
chore: bump homebrew action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,13 +98,12 @@ jobs:
           url: https://vps.itsmeow.dev/spicetify-update
           method: GET
       - name: Update Homebrew tap
-        uses: mislav/bump-homebrew-formula-action@v2
-        if: "!contains(github.ref_name, '-')"
+        uses: mislav/bump-homebrew-formula-action@v3
+        if: ${{ !contains(github.ref, '-') }}
         with:
           formula-name: spicetify-cli
           formula-path: spicetify-cli.rb
           homebrew-tap: spicetify/homebrew-tap
-          tag-name: ${{ github.ref_name }}
           base-branch: main
           download-url: https://github.com/spicetify/spicetify-cli/archive/${{ github.ref_name }}.tar.gz
           commit-message: |


### PR DESCRIPTION
The bug we found in #2576 has now been fixed in https://github.com/mislav/bump-homebrew-formula-action/releases/tag/v3.1.