### PR TITLE
feat(lyrics-plus): add cutlet japanese transliteration method

### DIFF
--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -121,6 +121,7 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation }) => {
 				modeOptions = {
 					furigana: "Furigana",
 					romaji: "Romaji",
+					romajiCutlet: "Romaji (Cutlet)",
 					hiragana: "Hiragana",
 					katakana: "Katakana"
 				};

--- a/CustomApps/lyrics-plus/Translator.js
+++ b/CustomApps/lyrics-plus/Translator.js
@@ -98,11 +98,25 @@ class Translator {
 		}
 	}
 
-	async romajifyText(text, target = "romaji", mode = "spaced") {
+	async romajifyText(text, target = "romaji", mode = "spaced", provider) {
 		if (!this.finished.ja) {
 			await Translator.#sleep(100);
 			return this.romajifyText(text, target, mode);
 		}
+
+		if (target === "romajiCutlet") {
+			const baseURL = `https://cutlet.1sal.me/api/transliterate`;
+
+			const params = {
+				uri: Spicetify.Player.data.item.uri.replace("spotify:track:", ""),
+				lyrics: text,
+				provider: provider.toLowerCase()
+			};
+	
+			let res = await CosmosAsync.post(baseURL, params);
+			return res;
+		}
+
 
 		return this.kuroshiro.convert(text, {
 			to: target,

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -17,7 +17,7 @@ const {
 
 // Define a function called "render" to specify app entry point
 // This function will be used to mount app to main view.
-function render() {
+function render() {	
 	return react.createElement(LyricsContainer, null);
 }
 
@@ -139,6 +139,7 @@ class LyricsContainer extends react.Component {
 			genius2: null,
 			currentLyrics: null,
 			romaji: null,
+			romajiCutlet: null,
 			furigana: null,
 			hiragana: null,
 			hangul: null,
@@ -292,7 +293,7 @@ class LyricsContainer extends react.Component {
 			CACHE[data.uri] = finalData;
 			return finalData;
 		}
-
+		
 		CACHE[trackInfo.uri] = finalData;
 		return finalData;
 	}
@@ -300,6 +301,7 @@ class LyricsContainer extends react.Component {
 	async fetchLyrics(track, mode = -1) {
 		this.state.furigana =
 			this.state.romaji =
+			this.state.romajiCutlet =
 			this.state.hiragana =
 			this.state.katakana =
 			this.state.hangul =
@@ -394,12 +396,13 @@ class LyricsContainer extends react.Component {
 
 		[
 			["romaji", "spaced", "romaji"],
+			["romajiCutlet", "romajiCutlet", "romajiCutlet"],
 			["hiragana", "furigana", "furigana"],
 			["hiragana", "normal", "hiragana"],
 			["katakana", "normal", "katakana"]
 		].forEach(params => {
 			if (language !== "ja") return;
-			this.translator.romajifyText(lyricText, params[0], params[1]).then(result => {
+			this.translator.romajifyText(lyricText, params[0], params[1], this.state.provider).then(result => {
 				Utils.processTranslatedLyrics(result, lyrics, { state: this.state, stateName: params[2] });
 				showNotification(200);
 				lyricContainerUpdate && lyricContainerUpdate();
@@ -664,7 +667,7 @@ class LyricsContainer extends react.Component {
 				break;
 			}
 			case "ja": {
-				isTranslated = !!(this.state.romaji || this.state.furigana || this.state.hiragana || this.state.katakana);
+				isTranslated = !!(this.state.romaji || this.state.romajiCutlet || this.state.furigana || this.state.hiragana || this.state.katakana);
 				break;
 			}
 			case "ko": {

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -17,7 +17,7 @@ const {
 
 // Define a function called "render" to specify app entry point
 // This function will be used to mount app to main view.
-function render() {	
+function render() {
 	return react.createElement(LyricsContainer, null);
 }
 
@@ -293,7 +293,7 @@ class LyricsContainer extends react.Component {
 			CACHE[data.uri] = finalData;
 			return finalData;
 		}
-		
+
 		CACHE[trackInfo.uri] = finalData;
 		return finalData;
 	}


### PR DESCRIPTION
The current japanese romaji method (kuroshiro) produces a lot of incorrect transliterations. I have compiled some of my findings here: https://www.notion.so/faishalirwn/e9c8db6a52fb43b0acaa6b89e600039a?v=638e78a3c0a540a1ac93bcede6915bad

There is a better library for Japanese transliteration called cutlet: https://github.com/polm/cutlet and it's actively maintained unlike kuroshiro. Unfortunately, it is written in Python, so I have created my own API for it: https://cutlet.1sal.me/docs. The source code for the API is available here: https://github.com/faishalirwn/cutlet-api

This PR adds an alternative romaji method that uses the cutlet API. The API can also correct wrong romaji using the `correction.json` file in the source code repo https://github.com/faishalirwn/cutlet-api/blob/main/corrections.json.