### PR TITLE
feat(preprocess): implement snackbar api

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -406,6 +406,7 @@ window.Spicetify = {
 			ButtonTertiary: modules.find(m => m?.render && m?.displayName === "ButtonTertiary"),
 			Snackbar: {
 				//...Spicetify.Snackbar.props.Components, -> doesnt exist for a while
+				wrapper: functionModules.find(m => m.toString().includes('encore-light-theme')),
 				simpleLayout: functionModules.find(m => m.toString().includes("leading")),
 				ImageLayout: functionModules.find(m => m.toString().includes("enqueueCustomSnackbar")),
 				ctaText: functionModules.find(m => m.toString().includes("ctaText"))

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -126,6 +126,7 @@ window.Spicetify = {
 			"LocalStorage",
 			"Queue",
 			"removeFromQueue",
+			"notification",
 			"showNotification",
 			"Menu",
 			"ContextMenu",
@@ -445,6 +446,25 @@ window.Spicetify = {
 	if (playlistMenuChunk) Spicetify.ReactComponent.PlaylistMenu = Object.values(require(playlistMenuChunk[0])).find(m => typeof m === "function");
 
 	if (Spicetify.Color) Spicetify.Color.CSSFormat = modules.find(m => m?.RGBA);
+
+	// Combine snackbar and notification
+	(async function bindShowNotification() {
+		if (!(Spicetify.Snackbar && Spicetify.notification)) {
+			setTimeout(bindShowNotification, 10);
+			return;
+		}
+
+		Spicetify.showNotification = (message, isError = false, msTimeout, snack = true) => {
+			if (snack) {
+				Spicetify.Snackbar.enqueueSnackbar(message, {
+					variant: isError ? "error" : "default",
+					autoHideDuration: msTimeout
+				});
+			} else {
+				Spicetify.notification(message, isError, msTimeout);
+			}
+		};
+	})();
 
 	// Image color extractor
 	(async function bindColorExtractor() {

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -402,6 +402,11 @@ window.Spicetify = {
 			ButtonPrimary: modules.find(m => m?.render && m?.displayName === "ButtonPrimary"),
 			ButtonSecondary: modules.find(m => m?.render && m?.displayName === "ButtonSecondary"),
 			ButtonTertiary: modules.find(m => m?.render && m?.displayName === "ButtonTertiary"),
+			Snackbar: {
+				// somehow append Spicetify.Snackbar.props.Components
+				simpleLayout: functionModules.find(m => m.toString().includes("leading")),
+			   	simpleImageLayout: functionModules.find(m => m.toString().includes("enqueueCustomSnackbar"))
+			},
 			...Object.fromEntries(menus)
 		},
 		ReactHook: {

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -459,7 +459,7 @@ window.Spicetify = {
 				Spicetify.notification(message, isError, msTimeout);
 				return;
 			}
-			
+
 			Spicetify.Snackbar.enqueueSnackbar(message, {
 				variant: isError ? "error" : "default",
 				autoHideDuration: msTimeout

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -405,10 +405,8 @@ window.Spicetify = {
 			ButtonSecondary: modules.find(m => m?.render && m?.displayName === "ButtonSecondary"),
 			ButtonTertiary: modules.find(m => m?.render && m?.displayName === "ButtonTertiary"),
 			Snackbar: {
-				//...Spicetify.Snackbar.props.Components, -> doesnt exist for a while
-				wrapper: functionModules.find(m => m.toString().includes('encore-light-theme')),
+				wrapper: functionModules.find(m => m.toString().includes("encore-light-theme")),
 				simpleLayout: functionModules.find(m => m.toString().includes("leading")),
-				ImageLayout: functionModules.find(m => m.toString().includes("enqueueCustomSnackbar")),
 				ctaText: functionModules.find(m => m.toString().includes("ctaText"))
 			},
 			...Object.fromEntries(menus)

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -126,7 +126,7 @@ window.Spicetify = {
 			"LocalStorage",
 			"Queue",
 			"removeFromQueue",
-			"notification",
+			"sendNotification",
 			"showNotification",
 			"Menu",
 			"ContextMenu",
@@ -449,20 +449,21 @@ window.Spicetify = {
 
 	// Combine snackbar and notification
 	(async function bindShowNotification() {
-		if (!(Spicetify.Snackbar && Spicetify.notification)) {
+		if (!(Spicetify.Snackbar || Spicetify.sendNotification)) {
 			setTimeout(bindShowNotification, 10);
 			return;
 		}
 
-		Spicetify.showNotification = (message, isError = false, msTimeout, snack = true) => {
-			if (snack) {
-				Spicetify.Snackbar.enqueueSnackbar(message, {
-					variant: isError ? "error" : "default",
-					autoHideDuration: msTimeout
-				});
-			} else {
+		Spicetify.showNotification = (message, isError = false, msTimeout) => {
+			if (!Spicetify.Snackbar?.enqueueSnackbar) {
 				Spicetify.notification(message, isError, msTimeout);
+				return;
 			}
+			
+			Spicetify.Snackbar.enqueueSnackbar(message, {
+				variant: isError ? "error" : "default",
+				autoHideDuration: msTimeout
+			});
 		};
 	})();
 

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -456,7 +456,7 @@ window.Spicetify = {
 
 		Spicetify.showNotification = (message, isError = false, msTimeout) => {
 			if (!Spicetify.Snackbar?.enqueueSnackbar) {
-				Spicetify.notification(message, isError, msTimeout);
+				Spicetify.sendNotification(message, isError, msTimeout);
 				return;
 			}
 

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -163,7 +163,8 @@ window.Spicetify = {
 			"ReactQuery",
 			"Color",
 			"extractColorPreset",
-			"ReactDOMServer"
+			"ReactDOMServer",
+			"Snackbar"
 		];
 
 		const PLAYER_METHOD = [
@@ -225,7 +226,8 @@ window.Spicetify = {
 			"RemoteConfigProvider",
 			"ButtonPrimary",
 			"ButtonSecondary",
-			"ButtonTertiary"
+			"ButtonTertiary",
+			"Snackbar"
 		];
 
 		const REACT_HOOK = ["DragHandler", "usePanelState", "useExtractedColor"];
@@ -403,9 +405,9 @@ window.Spicetify = {
 			ButtonSecondary: modules.find(m => m?.render && m?.displayName === "ButtonSecondary"),
 			ButtonTertiary: modules.find(m => m?.render && m?.displayName === "ButtonTertiary"),
 			Snackbar: {
-				// somehow append Spicetify.Snackbar.props.Components
+				//...Spicetify.Snackbar.props.Components, -> doesnt exist for a while
 				simpleLayout: functionModules.find(m => m.toString().includes("leading")),
-			   	simpleImageLayout: functionModules.find(m => m.toString().includes("enqueueCustomSnackbar"))
+				ImageLayout: functionModules.find(m => m.toString().includes("enqueueCustomSnackbar"))
 			},
 			...Object.fromEntries(menus)
 		},

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -407,7 +407,8 @@ window.Spicetify = {
 			Snackbar: {
 				//...Spicetify.Snackbar.props.Components, -> doesnt exist for a while
 				simpleLayout: functionModules.find(m => m.toString().includes("leading")),
-				ImageLayout: functionModules.find(m => m.toString().includes("enqueueCustomSnackbar"))
+				ImageLayout: functionModules.find(m => m.toString().includes("enqueueCustomSnackbar")),
+				ctaText: functionModules.find(m => m.toString().includes("ctaText"))
 			},
 			...Object.fromEntries(menus)
 		},

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -273,7 +273,7 @@ func exposeAPIs_main(input string) string {
 	utils.Replace(
 		&input,
 		`(?:\w+ |,)([\w$]+)=(\([\w$]+=[\w$]+\.dispatch)`,
-		`;globalThis.Spicetify.showNotification=(message,isError=false,msTimeout)=>${1}({message,feedbackType:isError?"ERROR":"NOTICE",msTimeout});const ${1}=${2}`)
+		`;globalThis.Spicetify.notification=(message,isError=false,msTimeout)=>${1}({message,feedbackType:isError?"ERROR":"NOTICE",msTimeout});const ${1}=${2}`)
 
 	// Remove list of exclusive shows
 	utils.Replace(

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -440,7 +440,7 @@ if (${1}.popper?.firstChild?.id === "context-menu") {
 	utils.Replace(
 		&input,
 		`(\w+)\s*=\s*e\.call\(this,[^)]+\)\s*\|\|\s*this\)\.enqueueSnackbar`,
-		`(globalThis.Spicetify.Snackbar = n = e.call(this, t) || this).enqueueSnackbar`)
+		`globalThis.Spicetify.Snackbar = n = e.call(this, t) || this).enqueueSnackbar`)
 
 	return input
 }

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -354,6 +354,12 @@ Spicetify.React.useEffect(() => {
 		`case [\w$.]+BuddyFeed:(?:return ?|[\w$]+=)[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?;(?:break;)?(?:case [\w$.]+:(?:return ?|[\w$]+=)[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;(?:break;)?)*default:(?:return ?|[\w$]+=)`,
 		`${0} Spicetify.Panel?.render()??`)
 
+	// Snackbar https://mui.com/material-ui/react-snackbar/
+	utils.Replace(
+		&input,
+		`\b\w\s*\(\)\s*[^;,]*enqueueCustomSnackbar:\s*(\w)\s*[^;]*;`,
+		`${0} globalThis.Spicetify.Snackbar.enqueueCustomSnackbar = ${1};`)
+
 	return input
 }
 
@@ -439,8 +445,8 @@ if (${1}.popper?.firstChild?.id === "context-menu") {
 	// Snackbar https://mui.com/material-ui/react-snackbar/
 	utils.Replace(
 		&input,
-		`(\w+)\s*=\s*e\.call\(this,[^)]+\)\s*\|\|\s*this\)\.enqueueSnackbar`,
-		`globalThis.Spicetify.Snackbar = n = e.call(this, t) || this).enqueueSnackbar`)
+		`\w+\s*=\s*\w\.call\(this,[^)]+\)\s*\|\|\s*this\)\.enqueueSnackbar`,
+		`globalThis.Spicetify.Snackbar = ${0}`)
 
 	return input
 }

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -446,7 +446,7 @@ if (${1}.popper?.firstChild?.id === "context-menu") {
 	utils.Replace(
 		&input,
 		`\w+\s*=\s*\w\.call\(this,[^)]+\)\s*\|\|\s*this\)\.enqueueSnackbar`,
-		`globalThis.Spicetify.Snackbar = ${0}`)
+		`Spicetify.Snackbar = ${0}`)
 
 	return input
 }

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -358,7 +358,7 @@ Spicetify.React.useEffect(() => {
 	utils.Replace(
 		&input,
 		`\b\w\s*\(\)\s*[^;,]*enqueueCustomSnackbar:\s*(\w)\s*[^;]*;`,
-		`${0} globalThis.Spicetify.Snackbar.enqueueCustomSnackbar = ${1};`)
+		`${0} Spicetify.Snackbar.enqueueCustomSnackbar = ${1};`)
 
 	return input
 }

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -354,6 +354,12 @@ Spicetify.React.useEffect(() => {
 		`case [\w$.]+BuddyFeed:(?:return ?|[\w$]+=)[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?;(?:break;)?(?:case [\w$.]+:(?:return ?|[\w$]+=)[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;(?:break;)?)*default:(?:return ?|[\w$]+=)`,
 		`${0} Spicetify.Panel?.render()??`)
 
+	// Snackbar https://mui.com/material-ui/react-snackbar/
+	utils.Replace(
+		&input,
+		`(\w+)\s*=\s*e\.call\(this,[^)]+\)\s*\|\|\s*this\)\.enqueueSnackbar`,
+		`(globalThis.Spicetify.Snackbar = n = e.call(this, t) || this).enqueueSnackbar`)
+
 	return input
 }
 

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -360,6 +360,11 @@ Spicetify.React.useEffect(() => {
 		`\b\w\s*\(\)\s*[^;,]*enqueueCustomSnackbar:\s*(\w)\s*[^;]*;`,
 		`${0} Spicetify.Snackbar.enqueueCustomSnackbar = ${1};`)
 
+	utils.Replace(
+		&input,
+		`\(\({[^}]*,\s*imageSrc`,
+		`Spicetify.Snackbar.enqueueImageSnackbar = ${0}`)
+
 	return input
 }
 

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -354,12 +354,6 @@ Spicetify.React.useEffect(() => {
 		`case [\w$.]+BuddyFeed:(?:return ?|[\w$]+=)[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?;(?:break;)?(?:case [\w$.]+:(?:return ?|[\w$]+=)[\w$?]*(?:\([\w$.,]+\)\([\w(){},.:]+)?[\w:]*;(?:break;)?)*default:(?:return ?|[\w$]+=)`,
 		`${0} Spicetify.Panel?.render()??`)
 
-	// Snackbar https://mui.com/material-ui/react-snackbar/
-	utils.Replace(
-		&input,
-		`(\w+)\s*=\s*e\.call\(this,[^)]+\)\s*\|\|\s*this\)\.enqueueSnackbar`,
-		`(globalThis.Spicetify.Snackbar = n = e.call(this, t) || this).enqueueSnackbar`)
-
 	return input
 }
 
@@ -441,6 +435,12 @@ if (${1}.popper?.firstChild?.id === "context-menu") {
 		&input,
 		`([\w$]+)=((?:function|\()([\w$.,{}()= ]+(?:springConfig|overshootClamping)){2})`,
 		`${1}=Spicetify.ReactFlipToolkit.spring=${2}`)
+
+	// Snackbar https://mui.com/material-ui/react-snackbar/
+	utils.Replace(
+		&input,
+		`(\w+)\s*=\s*e\.call\(this,[^)]+\)\s*\|\|\s*this\)\.enqueueSnackbar`,
+		`(globalThis.Spicetify.Snackbar = n = e.call(this, t) || this).enqueueSnackbar`)
 
 	return input
 }

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -273,7 +273,7 @@ func exposeAPIs_main(input string) string {
 	utils.Replace(
 		&input,
 		`(?:\w+ |,)([\w$]+)=(\([\w$]+=[\w$]+\.dispatch)`,
-		`;globalThis.Spicetify.notification=(message,isError=false,msTimeout)=>${1}({message,feedbackType:isError?"ERROR":"NOTICE",msTimeout});const ${1}=${2}`)
+		`;globalThis.Spicetify.sendNotification=(message,isError=false,msTimeout)=>${1}({message,feedbackType:isError?"ERROR":"NOTICE",msTimeout});const ${1}=${2}`)
 
 	// Remove list of exclusive shows
 	utils.Replace(
@@ -358,12 +358,12 @@ Spicetify.React.useEffect(() => {
 	utils.Replace(
 		&input,
 		`\b\w\s*\(\)\s*[^;,]*enqueueCustomSnackbar:\s*(\w)\s*[^;]*;`,
-		`${0} Spicetify.Snackbar.enqueueCustomSnackbar = ${1};`)
+		`${0}Spicetify.Snackbar.enqueueCustomSnackbar=${1};`)
 
 	utils.Replace(
 		&input,
 		`\(\({[^}]*,\s*imageSrc`,
-		`Spicetify.Snackbar.enqueueImageSnackbar = ${0}`)
+		`Spicetify.Snackbar.enqueueImageSnackbar=${0}`)
 
 	return input
 }
@@ -451,7 +451,7 @@ if (${1}.popper?.firstChild?.id === "context-menu") {
 	utils.Replace(
 		&input,
 		`\w+\s*=\s*\w\.call\(this,[^)]+\)\s*\|\|\s*this\)\.enqueueSnackbar`,
-		`Spicetify.Snackbar = ${0}`)
+		`Spicetify.Snackbar=${0}`)
 
 	return input
 }


### PR DESCRIPTION
implements Spotify's new (1.2.22.982) notification system resolves #2600
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/b2ea0696-08df-4bcb-adf7-b5bfb2f8214a)

## Example Usage

### "info" / iconVariation
```js
Spicetify.Snackbar.enqueueSnackbar('I am an exception', {
  autoHideDuration: 3000,
    style: {
        backgroundColor: "purple"
    },
    onClose() {
        console.log('closed')
    },
    variant: 'info',
})
```

![image](https://github.com/spicetify/spicetify-cli/assets/22730962/d2dcb544-5339-421f-823e-8292c50ca790)

### "default" / undefined
#### HTML
```js
Spicetify.Snackbar.enqueueSnackbar(
  `<div class="TcJ5lUfQ25AJNoCrWO5Z">
	  <div class="xaCo5LWfBMxqfWjUA3o2">
		  <img src="spotify:image:ab67706c0000da849e94705a00ff5f32789c8b8e" alt="" data-encore-id="image" class="Image-sc-1u215sg-3 Image-image">
	  </div>  
	   <div class="r4Hbxvv02KfOVeZ_v335">
		   <span data-encore-id="type" class="Type__TypeElement-sc-goli3j-0 TypeElement-ballad-textBase-type">
			   Added to 
			   <span data-encore-id="type" class="Type__TypeElement-sc-goli3j-0 TypeElement-balladBold-textBase-type">
					▸ Tasteful 👌
			   </span>
			</span>
		</div>
	</div>`,
  { persist: true },
);
```
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/28803a87-d314-4977-b58c-7ebb29630e1c)

#### Plaintext
```js
Spicetify.Snackbar.enqueueSnackbar('barebones snack')
```

![image](https://github.com/spicetify/spicetify-cli/assets/22730962/467f5629-9c81-432e-ad54-585f5fbb6e98)

### "headless" / enqueueCustomSnackbar
```js
Spicetify.Snackbar.enqueueSnackbar({
  key: "test",
  variant: "headless",
  children: Spicetify.ReactComponent.Slider(),
  style: { backgroundColor: "red" },
});

Spicetify.Snackbar.enqueueCustomSnackbar(
  { key: "test", children: Spicetify.ReactComponent.Slider() },
  { style: { backgroundColor: "red" } },
);
```

![image](https://github.com/spicetify/spicetify-cli/assets/22730962/fff6e746-585e-4e13-8976-62446288ad89)

### enqueueImageSnackbar
```js
Spicetify.Snackbar.enqueueImageSnackbar({
  message: "test",
  imageSrc:
    "https://images-ext-1.discordapp.net/external/i1dw80RDh1sbEY_rfZNwpY_4HpuPSDdoHj8NL9zNPZE/https/artworks.thetvdb.com/banners/v4/series/423030/backgrounds/64fe06fb91fee.jpg?width=921&height=518",
});
```
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/1023bad6-ccb3-4595-b620-ea10c31625d1)


## React Components
```js
Spicetify.Snackbar.enqueueCustomSnackbar({
  key: "test",
  children: Spicetify.ReactComponent.Snackbar.wrapper({
    children: Spicetify.ReactComponent.Snackbar.simpleLayout({
      leading: "start",
      center: "center",
      trailing: Spicetify.ReactComponent.Snackbar.ctaText({
        ctaText: "undo",
        onCtaClick: Spicetify.Snackbar.handleCloseSnack("test"),
      }),
    }),
  }),
});

```
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/0d50a7bd-c752-4733-8193-3ddf82775a6b)

## Relevant Documents
this is pretty much all users need to get started -> https://notistack.com/api-reference + https://mui.com/material-ui/react-snackbar

enqueue valid props:
```
  message: o,
  open: !0,
  entered: !1,
  requestClose: !1,
  persist: d("persist"),
  action: d("action"),
  content: d("content"),
  variant: d("variant"),
  anchorOrigin: d("anchorOrigin"),
  disableWindowBlurListener: d("disableWindowBlurListener"),
  autoHideDuration: d("autoHideDuration"),
  hideIconVariant: d("hideIconVariant"),
  TransitionComponent: d("TransitionComponent"),
  transitionDuration: d("transitionDuration"),
  TransitionProps: d("TransitionProps", !0),
  iconVariant: d("iconVariant", !0),
  style: d("style", !0),
  SnackbarProps: d("SnackbarProps", !0),
  className: a(n.props.className, c.className)
```