### PR TITLE
fix(keyboardShortcut): enable playlist selection

### DIFF
--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -268,7 +268,7 @@ function VimBind() {
 	 * @param {HTMLElement} element
 	 */
 	function click(element) {
-		if (element.hasAttribute("href") || element.tagName === "BUTTON") {
+		if (element.hasAttribute("href") || element.tagName === "BUTTON" || element.role === "button") {
 			element.click();
 			return;
 		}

--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -119,7 +119,7 @@
 })();
 
 function VimBind() {
-	const elementQuery = ["[href]", "button", "td.tl-play", "td.tl-number", "tr.TableRow"].join(",");
+	const elementQuery = ["[href]", "button", "td.tl-play", "td.tl-number", "tr.TableRow", "[role='button']"].join(",");
 
 	const keyList = "qwertasdfgzxcvyuiophjklbnm".split("");
 


### PR DESCRIPTION
Add an extra query selector to the vim bindings to enable interfacing with the playlist list in the main menu to the left.