### PR TITLE
refactor(wrapper): combine snackbar and notification apis

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -126,7 +126,6 @@ window.Spicetify = {
 			"LocalStorage",
 			"Queue",
 			"removeFromQueue",
-			"sendNotification",
 			"showNotification",
 			"Menu",
 			"ContextMenu",
@@ -448,23 +447,26 @@ window.Spicetify = {
 	if (Spicetify.Color) Spicetify.Color.CSSFormat = modules.find(m => m?.RGBA);
 
 	// Combine snackbar and notification
-	(async function bindShowNotification() {
-		if (!(Spicetify.Snackbar || Spicetify.sendNotification)) {
+	(function bindShowNotification() {
+		if (!Spicetify.Snackbar && !Spicetify.showNotification) {
 			setTimeout(bindShowNotification, 10);
 			return;
 		}
 
-		Spicetify.showNotification = (message, isError = false, msTimeout) => {
-			if (!Spicetify.Snackbar?.enqueueSnackbar) {
-				Spicetify.sendNotification(message, isError, msTimeout);
-				return;
-			}
-
-			Spicetify.Snackbar.enqueueSnackbar(message, {
-				variant: isError ? "error" : "default",
-				autoHideDuration: msTimeout
-			});
-		};
+		if (Spicetify.Snackbar?.enqueueSnackbar && !Spicetify.showNotification) {
+			Spicetify.showNotification = (message, isError = false, msTimeout) => {
+				Spicetify.Snackbar.enqueueSnackbar(message, {
+					variant: isError ? "error" : "default",
+					autoHideDuration: msTimeout
+				});
+			};
+		} else {
+			if (!Spicetify.Snackbar) Spicetify.Snackbar = {};
+			Spicetify.Snackbar.enqueueSnackbar = (message, { variant = "default", autoHideDuration }) => {
+				isError = variant === "error";
+				Spicetify.showNotification(message, isError, autoHideDuration);
+			};
+		}
 	})();
 
 	// Image color extractor

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -273,7 +273,7 @@ func exposeAPIs_main(input string) string {
 	utils.Replace(
 		&input,
 		`(?:\w+ |,)([\w$]+)=(\([\w$]+=[\w$]+\.dispatch)`,
-		`;globalThis.Spicetify.sendNotification=(message,isError=false,msTimeout)=>${1}({message,feedbackType:isError?"ERROR":"NOTICE",msTimeout});const ${1}=${2}`)
+		`;globalThis.Spicetify.showNotification=(message,isError=false,msTimeout)=>${1}({message,feedbackType:isError?"ERROR":"NOTICE",msTimeout});const ${1}=${2}`)
 
 	// Remove list of exclusive shows
 	utils.Replace(


### PR DESCRIPTION
Now we can deprecate `showNotification`