### PR TITLE
chore(css-map): view-homeShortcutsGrid-playingIcon

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1835,6 +1835,7 @@
 	"TbrIq3NG2VYFoAUMSmp9": "view-homeShortcutsGrid-nameWrapper",
 	"jb9xD5ECTqKFK02qe3HZ": "view-homeShortcutsGrid-shortcutLink",
 	"Kcb74zm1aMqGfPxTwO5s": "view-homeShortcutsGrid-PlayButtonContainer",
+	"jxXIarsEHgz2HoaVCVzA": "view-homeShortcutsGrid-playingIcon",
 	"HbKLiGoYM4dpuK8L4TMX": "x-downloadButton-button",
 	"wCl7pMTEE68v1xuZeZiB": "x-filterBox-expandButton",
 	"QZhV0hWVKlExlKr266jo": "x-filterBox-filterInput",


### PR DESCRIPTION
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/24383ae4-1b04-40a7-9f75-dc112a08bd53)
the new homescreen cards have an equalizer like main-trackList-playingIcon