### PR TITLE
fix(wrapper): make the snackbar a priority

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -449,7 +449,7 @@ window.Spicetify = {
 	// Combine snackbar and notification
 	(function bindShowNotification() {
 		if (!Spicetify.Snackbar && !Spicetify.showNotification) {
-			setTimeout(bindShowNotification, 100);
+			setTimeout(bindShowNotification, 250);
 			return;
 		}
 

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -449,24 +449,25 @@ window.Spicetify = {
 	// Combine snackbar and notification
 	(function bindShowNotification() {
 		if (!Spicetify.Snackbar && !Spicetify.showNotification) {
-			setTimeout(bindShowNotification, 10);
+			setTimeout(bindShowNotification, 100);
 			return;
 		}
 
-		if (Spicetify.Snackbar?.enqueueSnackbar && !Spicetify.showNotification) {
+		if (Spicetify.Snackbar?.enqueueSnackbar) {
 			Spicetify.showNotification = (message, isError = false, msTimeout) => {
 				Spicetify.Snackbar.enqueueSnackbar(message, {
 					variant: isError ? "error" : "default",
 					autoHideDuration: msTimeout
 				});
 			};
-		} else {
-			if (!Spicetify.Snackbar) Spicetify.Snackbar = {};
-			Spicetify.Snackbar.enqueueSnackbar = (message, { variant = "default", autoHideDuration }) => {
-				isError = variant === "error";
-				Spicetify.showNotification(message, isError, autoHideDuration);
-			};
+			return;
 		}
+
+		if (!Spicetify.Snackbar) Spicetify.Snackbar = {};
+		Spicetify.Snackbar.enqueueSnackbar = (message, { variant = "default", autoHideDuration } = {}) => {
+			isError = variant === "error";
+			Spicetify.showNotification(message, isError, autoHideDuration);
+		};
 	})();
 
 	// Image color extractor


### PR DESCRIPTION
Fixes #2621
Since function only waits 10ms for both functions (or one of them) to appear, `vendor~xpui.js` isn't loaded fully and one function is assigned faster than other one