### PR TITLE
feat(snackbar): styledImage component

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -408,7 +408,7 @@ window.Spicetify = {
 				wrapper: functionModules.find(m => m.toString().includes("encore-light-theme")),
 				simpleLayout: functionModules.find(m => m.toString().includes("leading")),
 				ctaText: functionModules.find(m => m.toString().includes("ctaText")),
-				styledImage: functionModules.find(m => m.toString().includes('placeholderSrc')),
+				styledImage: functionModules.find(m => m.toString().includes("placeholderSrc"))
 			},
 			...Object.fromEntries(menus)
 		},

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -407,7 +407,8 @@ window.Spicetify = {
 			Snackbar: {
 				wrapper: functionModules.find(m => m.toString().includes("encore-light-theme")),
 				simpleLayout: functionModules.find(m => m.toString().includes("leading")),
-				ctaText: functionModules.find(m => m.toString().includes("ctaText"))
+				ctaText: functionModules.find(m => m.toString().includes("ctaText")),
+				styledImage: functionModules.find(m => m.toString().includes('placeholderSrc')),
 			},
 			...Object.fromEntries(menus)
 		},


### PR DESCRIPTION
This allows the user to not have to rely on enqueueImageSnackbar if they want to say, have the image come after the text instead of before or in the example below add an undo button since that component has no trailing prop.

```js
Spicetify.Snackbar.enqueueCustomSnackbar({
  key: "test",
  children: Spicetify.ReactComponent.Snackbar.wrapper({
    children: Spicetify.ReactComponent.Snackbar.simpleLayout({
      leading: Spicetify.ReactComponent.Snackbar.styledImage({
        src: "https://i.imgur.com/uPbnZkz.png",
        imageHeight: "24px",
        imageWidth: "24px"   
      }),
      center: "song action",
      trailing: Spicetify.ReactComponent.Snackbar.ctaText({
        ctaText: "undo",
        onCtaClick: Spicetify.Snackbar.handleCloseSnack("test"),
      }),
    }),
  }),
});
```

However, this component isnt only used for snacks and as such can also be used like so:
```js
Spicetify.ReactDOM.render(
  Spicetify.React.createElement(Spicetify.ReactComponent.Snackbar.styledImage, {
    src: "https://i.imgur.com/uPbnZkz.png",
    alt: "",
    imageHeight: "240px",
    imageWidth: "240px",
    borderRadius: "40px",
  }),
  document.getElementById("main"),
);
 ```

 It can also accept a lot of other props, because of this im not sure if this would make more sense being its own new component, though its only really used for snacks and a few other random image divs to do with user profile and Jams.
 
 This is technically the parent component of the actual snackbar specific one that uses this component in its return, however since that one would need more regex i thought why not just use the parent, this means the user has to define the width and height manually though.
 
 If regex isnt an issue i can change this.