### PR TITLE
fix(wrapper): confirmdialog component

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -384,7 +384,9 @@ window.Spicetify = {
 		ReactComponent: {
 			...Spicetify.ReactComponent,
 			TextComponent: modules.find(m => m?.h1 && m?.render),
-			ConfirmDialog: functionModules.find(m => m.toString().includes("isOpen") && m.toString().includes("shouldCloseOnEsc") && m.toString().includes("onClose")),
+			ConfirmDialog: functionModules.find(
+				m => m.toString().includes("isOpen") && m.toString().includes("shouldCloseOnEsc") && m.toString().includes("onClose")
+			),
 			Menu: functionModules.find(m => m.toString().includes("getInitialFocusElement") && m.toString().includes("children")),
 			MenuItem: functionModules.find(m => m.toString().includes("handleMouseEnter") && m.toString().includes("onClick")),
 			Slider: wrapProvider(functionModules.find(m => m.toString().includes("onStepBackward"))),

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -384,7 +384,7 @@ window.Spicetify = {
 		ReactComponent: {
 			...Spicetify.ReactComponent,
 			TextComponent: modules.find(m => m?.h1 && m?.render),
-			ConfirmDialog: functionModules.find(m => m.toString().includes("isOpen") && m.toString().includes("shouldCloseOnEsc")),
+			ConfirmDialog: functionModules.find(m => m.toString().includes("confirm-dialog-description")),
 			Menu: functionModules.find(m => m.toString().includes("getInitialFocusElement") && m.toString().includes("children")),
 			MenuItem: functionModules.find(m => m.toString().includes("handleMouseEnter") && m.toString().includes("onClick")),
 			Slider: wrapProvider(functionModules.find(m => m.toString().includes("onStepBackward"))),

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -384,7 +384,7 @@ window.Spicetify = {
 		ReactComponent: {
 			...Spicetify.ReactComponent,
 			TextComponent: modules.find(m => m?.h1 && m?.render),
-			ConfirmDialog: functionModules.find(m => m.toString().includes("confirm-dialog-description")),
+			ConfirmDialog: functionModules.find(m => m.toString().includes("isOpen") && m.toString().includes("shouldCloseOnEsc") && m.toString().includes("onClose")),
 			Menu: functionModules.find(m => m.toString().includes("getInitialFocusElement") && m.toString().includes("children")),
 			MenuItem: functionModules.find(m => m.toString().includes("handleMouseEnter") && m.toString().includes("onClick")),
 			Slider: wrapProvider(functionModules.find(m => m.toString().includes("onStepBackward"))),


### PR DESCRIPTION
New versions of Spotify do not select the correct function, whilst it would be preferable to use `functionModules.find(m => m.toString().includes("confirm-dialog-description"))` i do not have the patience to check every supported version of spotify to see if that classname is present. This approach should theoretically cover all older versions since kyries original pr showed onclose being passed as a prop.
```js
Spicetify.ReactDOM.render(
  Spicetify.ReactComponent.ConfirmDialog({
    titleText: "hi",
    descriptionText: "hi",
    cancelText: "hi",
    confirmText: "hi",
    confirmLabel: "hi",
  }),
  document.querySelector(".ReactModalPortal"),
);
```
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/4291f830-eee2-4771-991f-851f68a70ba7)

