### PR TITLE
fix(wrapper): wrong icons color

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -705,7 +705,8 @@ Spicetify._getStyledClassName = (args, component) => {
 		"iconSize",
 		"position",
 		"data-encore-id",
-		"$size" // >= 1.2.23
+		"$size",
+		"$iconColor"
 	];
 	const customKeys = ["padding", "blocksize"];
 


### PR DESCRIPTION
before:

![image](https://github.com/spicetify/spicetify-cli/assets/115353812/ce60f794-2a23-4361-8bbb-834df1412b6a)

after:

![image](https://github.com/spicetify/spicetify-cli/assets/115353812/0f42d12d-010a-4a19-8f97-b4a2e02c3924)
