### PR TITLE
fix(fullAppDisplay): return when `Player.data` is null

### DIFF
--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -702,6 +702,10 @@ body.video-full-screen.video-full-screen--hide-ui {
 	}
 
 	async function activate() {
+		if (!Spicetify.Player.data) {
+			return
+		}
+
 		await toggleFullscreen();
 
 		document.body.classList.add(...classes);

--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -702,9 +702,7 @@ body.video-full-screen.video-full-screen--hide-ui {
 	}
 
 	async function activate() {
-		if (!Spicetify.Player.data) {
-			return
-		}
+		if (!Spicetify.Player.data) return;
 
 		await toggleFullscreen();
 


### PR DESCRIPTION
Corrected as it was not designed for the case where the music was not selected.