### PR TITLE
feat: `update` rework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version-file: "go.mod"
 
       - name: Build
         run: go build .
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version-file: "go.mod"
 
       - name: Build
         if: env.IS_UNIX == 'true' || env.IS_WIN == 'true'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spicetify/spicetify-cli
 
-go 1.19
+go 1.21
 
 require (
 	github.com/go-ini/ini v1.67.0

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -2368,9 +2368,8 @@ Spicetify.Playbar = (function () {
                 <ol>
                     <li>Update Spicetify CLI</li>
                     <pre class="spicetify-update-little-space">spicetify update</pre>
-                    <p class="spicetify-update-space">If you installed Spicetify via a package manager, update using said package manager.</p>
-                    <li>Apply changes to Spotify</li>
-                    <pre>spicetify restore backup apply</pre>
+                    <p>Spicetify will automatically apply changes to Spotify after upgrading to the latest version.</p>
+                    <p>If you installed Spicetify via a package manager, update using said package manager.</p>
                 </ol>
             `;
 

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -2286,9 +2286,9 @@ Spicetify.Playbar = (function () {
 		setTimeout(checkForUpdate, 300);
 		return;
 	}
-	const { check_spicetify_upgrade, version } = Spicetify.Config;
+	const { check_spicetify_update, version } = Spicetify.Config;
 	// Skip checking if upgrade check is disabled, or version is Dev/version is not set
-	if (!check_spicetify_upgrade || !version || version === "Dev") {
+	if (!check_spicetify_update || !version || version === "Dev") {
 		return;
 	}
 	// Fetch latest version from GitHub
@@ -2367,7 +2367,7 @@ Spicetify.Playbar = (function () {
                 <p>Run these commands in the terminal:</p>
                 <ol>
                     <li>Update Spicetify CLI</li>
-                    <pre class="spicetify-update-little-space">spicetify upgrade</pre>
+                    <pre class="spicetify-update-little-space">spicetify update</pre>
                     <p class="spicetify-update-space">If you installed Spicetify via a package manager, update using said package manager.</p>
                     <li>Apply changes to Spotify</li>
                     <pre>spicetify restore backup apply</pre>

--- a/spicetify.go
+++ b/spicetify.go
@@ -232,8 +232,8 @@ func main() {
 
 	utils.PrintBold("spicetify v" + version)
 	if slices.Contains(commands, "upgrade") || slices.Contains(commands, "update") {
-		upgradeStatus := cmd.Update(version)
-		if upgradeStatus {
+		updateStatus := cmd.Update(version)
+		if updateStatus {
 			ex, err := os.Executable()
 			if err != nil {
 				ex = "spicetify"
@@ -418,7 +418,7 @@ color               1. Print all color fields and values.
 
 config-dir          Shows config directory in file viewer
 
-upgrade|update      Upgrade spicetify latest version
+upgrade|update      Update spicetify latest version
 
 ` + utils.Bold("FLAGS") + `
 -q, --quiet         Quiet mode (no output). Be careful, dangerous operations
@@ -481,6 +481,9 @@ spotify_launch_flags
 always_enable_devtools <0 | 1>
     Whether Chrome DevTools is enabled when launching/restarting Spotify.
 
+check_spicetify_update <0 | 1>
+		Whether to check for spicetify-cli update when running Spicetify.
+
 ` + utils.Bold("[Preprocesses]") + `
 disable_sentry <0 | 1>
     Prevents Sentry and Amazon Qualaroo to send console log/error/warning to Spotify developers.
@@ -498,10 +501,6 @@ remove_rtl_rule <0 | 1>
 expose_apis <0 | 1>
     Leaks some Spotify's API, functions, objects to Spicetify global object that
     are useful for making extensions to extend Spotify functionality.
-
-disable_upgrade_check <0 | 1>
-    Prevent Spotify checking new version and visually notifying user.
-    [Windows] Note: Automatic update still works if you don't manually delete "SpotifyMigrator.exe" and "SpotifyUpdate.exe".
 
 ` + utils.Bold("[AdditionalOptions]") + `
 custom_apps <string>

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -11,17 +11,17 @@ import (
 
 // Flag enables/disables additional feature
 type Flag struct {
-	CurrentTheme          string
-	ColorScheme           string
-	InjectThemeJS         bool
-	CheckSpicetifyUpgrade bool
-	Extension             []string
-	CustomApp             []string
-	SidebarConfig         bool
-	HomeConfig            bool
-	ExpFeatures           bool
-	SpicetifyVer          string
-	SpotifyVer            string
+	CurrentTheme         string
+	ColorScheme          string
+	InjectThemeJS        bool
+	CheckSpicetifyUpdate bool
+	Extension            []string
+	CustomApp            []string
+	SidebarConfig        bool
+	HomeConfig           bool
+	ExpFeatures          bool
+	SpicetifyVer         string
+	SpotifyVer           string
 }
 
 // AdditionalOptions .
@@ -129,9 +129,9 @@ func htmlMod(htmlPath string, flags Flag) {
 			Spicetify.Config["color_scheme"]="%s";
 			Spicetify.Config["extensions"] = [%s];
 			Spicetify.Config["custom_apps"] = [%s];
-			Spicetify.Config["check_spicetify_upgrade"]=%v;
+			Spicetify.Config["check_spicetify_update"]=%v;
 		</script>
-		`, flags.SpicetifyVer, flags.CurrentTheme, flags.ColorScheme, extList, customAppList, flags.CheckSpicetifyUpgrade)
+		`, flags.SpicetifyVer, flags.CurrentTheme, flags.ColorScheme, extList, customAppList, flags.CheckSpicetifyUpdate)
 	}
 
 	for _, v := range flags.Extension {

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -69,17 +69,17 @@ func Apply(spicetifyVersion string) {
 
 	utils.PrintBold(`Applying additional modifications:`)
 	apply.AdditionalOptions(appDestPath, apply.Flag{
-		CurrentTheme:          settingSection.Key("current_theme").MustString(""),
-		ColorScheme:           settingSection.Key("color_scheme").MustString(""),
-		InjectThemeJS:         injectJS,
-		CheckSpicetifyUpgrade: settingSection.Key("check_spicetify_upgrade").MustBool(false),
-		Extension:             extensionList,
-		CustomApp:             customAppsList,
-		SidebarConfig:         featureSection.Key("sidebar_config").MustBool(false),
-		HomeConfig:            featureSection.Key("home_config").MustBool(false),
-		ExpFeatures:           featureSection.Key("experimental_features").MustBool(false),
-		SpicetifyVer:          backupSection.Key("with").MustString(""),
-		SpotifyVer:            supportedSpotifyVersion,
+		CurrentTheme:         settingSection.Key("current_theme").MustString(""),
+		ColorScheme:          settingSection.Key("color_scheme").MustString(""),
+		InjectThemeJS:        injectJS,
+		CheckSpicetifyUpdate: settingSection.Key("check_spicetify_update").MustBool(false),
+		Extension:            extensionList,
+		CustomApp:            customAppsList,
+		SidebarConfig:        featureSection.Key("sidebar_config").MustBool(false),
+		HomeConfig:           featureSection.Key("home_config").MustBool(false),
+		ExpFeatures:          featureSection.Key("experimental_features").MustBool(false),
+		SpicetifyVer:         backupSection.Key("with").MustString(""),
+		SpotifyVer:           supportedSpotifyVersion,
 	})
 	utils.PrintGreen("OK")
 

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -16,8 +16,6 @@ import (
 // Apply .
 func Apply(spicetifyVersion string) {
 	utils.MigrateConfigFolder()
-	checkStates()
-	InitSetting()
 
 	backupSpicetifyVersion := backupSection.Key("with").MustString("")
 	if spicetifyVersion != backupSpicetifyVersion {
@@ -58,23 +56,7 @@ func Apply(spicetifyVersion string) {
 		utils.PrintGreen("OK")
 	}
 
-	utils.PrintBold(`Transferring user.css:`)
-	updateCSS()
-	utils.PrintGreen("OK")
-
-	if injectJS {
-		utils.PrintBold(`Transferring theme.js:`)
-		pushThemeJS()
-		utils.PrintGreen("OK")
-	} else {
-		utils.CheckExistAndDelete(filepath.Join(appDestPath, "xpui", "extensions/theme.js"))
-	}
-
-	if overwriteAssets {
-		utils.PrintBold(`Overwriting custom assets:`)
-		updateAssets()
-		utils.PrintGreen("OK")
-	}
+	RefreshTheme()
 
 	if preprocSection.Key("expose_apis").MustBool(false) {
 		utils.CopyFile(
@@ -103,14 +85,14 @@ func Apply(spicetifyVersion string) {
 
 	if len(extensionList) > 0 {
 		utils.PrintBold(`Transferring extensions:`)
-		pushExtensions("", extensionList...)
+		RefreshExtensions(extensionList...)
 		utils.PrintGreen("OK")
 		nodeModuleSymlink()
 	}
 
 	if len(customAppsList) > 0 {
 		utils.PrintBold(`Transferring custom apps:`)
-		pushApps(customAppsList...)
+		RefreshApps(customAppsList...)
 		utils.PrintGreen("OK")
 	}
 
@@ -123,26 +105,25 @@ func Apply(spicetifyVersion string) {
 	utils.PrintSuccess("Spotify is spiced up!")
 }
 
-// UpdateTheme updates user.css + theme.js and overwrites custom assets
-func UpdateTheme() {
-	checkStates()
-	InitSetting()
-
+// RefreshTheme updates user.css + theme.js and overwrites custom assets
+func RefreshTheme() {
 	if len(themeFolder) == 0 {
 		utils.PrintWarning(`Nothing is updated: Config "current_theme" is blank.`)
 		return
 	}
 
-	updateCSS()
+	refreshThemeCSS()
 	utils.PrintSuccess("Custom CSS is updated")
 
 	if injectJS {
-		pushThemeJS()
+		refreshThemeJS()
 		utils.PrintSuccess("Theme's JS is updated")
+	} else {
+		utils.CheckExistAndDelete(filepath.Join(appDestPath, "xpui", "extensions/theme.js"))
 	}
 
 	if overwriteAssets {
-		updateAssets()
+		refreshThemeAssets()
 		utils.PrintSuccess("Custom assets are updated")
 	}
 }
@@ -153,7 +134,7 @@ type spicetifyConfigJson struct {
 	Schemes    map[string]map[string]string `json:"schemes"`
 }
 
-func updateCSS() {
+func refreshThemeCSS() {
 	var scheme map[string]string = nil
 	if colorSection != nil {
 		scheme = colorSection.KeysHash()
@@ -192,14 +173,16 @@ func updateCSS() {
 	}
 }
 
-func updateAssets() {
+func refreshThemeAssets() {
 	apply.UserAsset(appDestPath, themeFolder)
 }
 
-// UpdateAllExtension pushes all extensions to Spotify
-func UpdateAllExtension() {
-	checkStates()
-	list := featureSection.Key("extensions").Strings("|")
+// RefreshExtensions pushes all extensions to Spotify
+func RefreshExtensions(list ...string) {
+	if len(list) == 0 {
+		list = featureSection.Key("extensions").Strings("|")
+	}
+
 	if len(list) > 0 {
 		pushExtensions("", list...)
 		utils.PrintSuccess(utils.PrependTime("All extensions are updated."))
@@ -208,9 +191,9 @@ func UpdateAllExtension() {
 	}
 }
 
-// checkStates examines both Backup and Spotify states to prompt informative
+// CheckStates examines both Backup and Spotify states to prompt informative
 // instruction for users
-func checkStates() {
+func CheckStates() {
 	backupVersion := backupSection.Key("version").MustString("")
 	backStat := backupstatus.Get(prefsPath, backupFolder, backupVersion)
 	spotStat := spotifystatus.Get(appPath)
@@ -244,7 +227,7 @@ func checkStates() {
 	}
 }
 
-func pushThemeJS() {
+func refreshThemeJS() {
 	utils.CopyFile(
 		filepath.Join(themeFolder, "theme.js"),
 		filepath.Join(appDestPath, "xpui", "extensions"))
@@ -300,7 +283,11 @@ func pushExtensions(destExt string, list ...string) {
 	}
 }
 
-func pushApps(list ...string) {
+func RefreshApps(list ...string) {
+	if len(list) == 0 {
+		list = featureSection.Key("custom_apps").Strings("|")
+	}
+
 	for _, app := range list {
 		appName := `spicetify-routes-` + app
 

--- a/src/cmd/auto.go
+++ b/src/cmd/auto.go
@@ -29,6 +29,8 @@ func Auto(spicetifyVersion string) {
 	}
 
 	if !spotStat.IsApplied() && backStat.IsBackuped() {
+		CheckStates()
+		InitSetting()
 		Apply(spicetifyVersion)
 	}
 }

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -282,7 +282,7 @@ func ReadAnswer(info string, defaultAnswer bool, quietModeAnswer bool) bool {
 
 // CheckUpdate fetches latest package version from Github API and inform user if there is new release
 func CheckUpdate(version string) {
-	if !settingSection.Key("check_spicetify_upgrade").MustBool() {
+	if !settingSection.Key("check_spicetify_update").MustBool() {
 		return
 	}
 
@@ -300,6 +300,6 @@ func CheckUpdate(version string) {
 		utils.PrintInfo("Spicetify up-to-date")
 	} else {
 		utils.PrintWarning("New version available: v" + latestTag + " (currently on: v" + version + ")")
-		utils.PrintWarning(`Run "spicetify upgrade" or using package manager to upgrade spicetify`)
+		utils.PrintWarning(`Run "spicetify update" or using package manager to update spicetify`)
 	}
 }

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -280,8 +280,8 @@ func ReadAnswer(info string, defaultAnswer bool, quietModeAnswer bool) bool {
 	return ReadAnswer(info, defaultAnswer, quietModeAnswer)
 }
 
-// CheckUpgrade fetches latest package version from Github API and inform user if there is new release
-func CheckUpgrade(version string) {
+// CheckUpdate fetches latest package version from Github API and inform user if there is new release
+func CheckUpdate(version string) {
 	if !settingSection.Key("check_spicetify_upgrade").MustBool() {
 		return
 	}
@@ -299,7 +299,7 @@ func CheckUpgrade(version string) {
 	if latestTag == version {
 		utils.PrintInfo("Spicetify up-to-date")
 	} else {
-		utils.PrintWarning("New version available!")
+		utils.PrintWarning("New version available: v" + latestTag + " (currently on: v" + version + ")")
 		utils.PrintWarning(`Run "spicetify upgrade" or using package manager to upgrade spicetify`)
 	}
 }

--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spicetify/spicetify-cli/src/utils"
 )
 
-func Upgrade(currentVersion string) bool {
+func Update(currentVersion string) bool {
 	utils.PrintBold("Fetch latest release info:")
 	tagName, err := utils.FetchLatestTag()
 	if err != nil {

--- a/src/cmd/watch.go
+++ b/src/cmd/watch.go
@@ -54,8 +54,8 @@ func Watch(liveUpdate bool) {
 					utils.Fatal(err)
 				}
 
-				pushThemeJS()
-				utils.PrintSuccess(utils.PrependTime("Theme's JS is updated"))
+				refreshThemeJS()
+				utils.PrintSuccess(utils.PrependTime("Theme's JS was reloaded"))
 			}, autoReloadFunc)
 		}
 	}
@@ -69,8 +69,8 @@ func Watch(liveUpdate bool) {
 					utils.Fatal(err)
 				}
 
-				updateAssets()
-				utils.PrintSuccess(utils.PrependTime("Custom assets are updated"))
+				refreshThemeAssets()
+				utils.PrintSuccess(utils.PrependTime("Custom assets were reloaded"))
 			}, autoReloadFunc)
 		}
 	}
@@ -81,7 +81,7 @@ func Watch(liveUpdate bool) {
 		}
 
 		InitSetting()
-		updateCSS()
+		refreshThemeCSS()
 		utils.PrintSuccess(utils.PrependTime("Custom CSS is updated"))
 	}, autoReloadFunc)
 }
@@ -193,7 +193,7 @@ func WatchCustomApp(appName []string, liveUpdate bool) {
 				os.Exit(1)
 			}
 
-			pushApps(appName)
+			RefreshApps(appName)
 
 			utils.PrintSuccess(utils.PrependTime(`Custom app "` + appName + `" is updated.`))
 		}, autoReloadFunc)

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -13,17 +13,17 @@ import (
 var (
 	configLayout = map[string]map[string]string{
 		"Setting": {
-			"spotify_path":            "",
-			"prefs_path":              "",
-			"current_theme":           "",
-			"color_scheme":            "",
-			"inject_theme_js":         "1",
-			"inject_css":              "1",
-			"replace_colors":          "1",
-			"overwrite_assets":        "0",
-			"spotify_launch_flags":    "",
-			"check_spicetify_upgrade": "1",
-			"always_enable_devtools":  "0",
+			"spotify_path":           "",
+			"prefs_path":             "",
+			"current_theme":          "",
+			"color_scheme":           "",
+			"inject_theme_js":        "1",
+			"inject_css":             "1",
+			"replace_colors":         "1",
+			"overwrite_assets":       "0",
+			"spotify_launch_flags":   "",
+			"check_spicetify_update": "1",
+			"always_enable_devtools": "0",
 		},
 		"Preprocesses": {
 			"disable_sentry":     "1",


### PR DESCRIPTION
Following the discussions on #2528 and on Discord, this PR removes the `--check-update` flag and makes the `upgrade`/`update` semi-chainable. Also renamed the old `update` to `refresh` as it felt that it was the word that made the most sense based on what the function did and the PoV of the user.