### PR TITLE
feat(wrapper): add Chip component

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -227,7 +227,8 @@ window.Spicetify = {
 			"ButtonPrimary",
 			"ButtonSecondary",
 			"ButtonTertiary",
-			"Snackbar"
+			"Snackbar",
+			"Chip"
 		];
 
 		const REACT_HOOK = ["DragHandler", "usePanelState", "useExtractedColor"];
@@ -412,6 +413,7 @@ window.Spicetify = {
 				ctaText: functionModules.find(m => m.toString().includes("ctaText")),
 				styledImage: functionModules.find(m => m.toString().includes("placeholderSrc"))
 			},
+			Chip: modules.find(m => m?.render?.toString().includes("invertedDark")),
 			...Object.fromEntries(menus)
 		},
 		ReactHook: {

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -413,7 +413,7 @@ window.Spicetify = {
 				ctaText: functionModules.find(m => m.toString().includes("ctaText")),
 				styledImage: functionModules.find(m => m.toString().includes("placeholderSrc"))
 			},
-			Chip: modules.find(m => m?.render?.toString().includes("invertedDark")),
+			Chip: modules.find(m => m?.render?.toString().includes("invertedDark") && m?.render?.toString().includes("isUsingKeyboard")),
 			...Object.fromEntries(menus)
 		},
 		ReactHook: {


### PR DESCRIPTION
It can be used like:

```js
const container = document.createElement("div");
container.id = "spicetify-chip-examples";
container.style.width = '100%';
container.style.padding = '10px';
document.body.appendChild(container);

// JSX
ReactDOM.render(<div>

  <Spicetify.ReactComponent.Chip
    className="encore-dark-theme"
    isUsingKeyboard={false}
    onClick={(e: Event) => {
      Spicetify.showNotification("Chip clicked!");
    }}
  >Click me</Spicetify.ReactComponent.Chip>

  <Spicetify.ReactComponent.Chip
    className="encore-dark-theme my-class"
    isUsingKeyboard={false}
    size={true}
  >I'm resizeable</Spicetify.ReactComponent.Chip>

  <Spicetify.ReactComponent.Chip
    className="encore-dark-theme"
    isUsingKeyboard={false}
    iconTrailing={() => (
      <Spicetify.ReactComponent.IconComponent
        semanticColor="textBase"
        dangerouslySetInnerHTML={{ __html: Spicetify.SVGIcons["play"] }}
        iconSize={16}
        onClick={() => {
          Spicetify.showNotification("Trailing icon clicked!");

        }}
      />
    )}
  >Click my icon</Spicetify.ReactComponent.Chip>

</div>, container);

// Using `createElement`
const container2 = document.createElement("div");
container2.id = "spicetify-chip-examples-2";
container2.style.width = '100%';
container2.style.padding = '10px';
document.body.appendChild(container2);

const chip = React.createElement(Spicetify.ReactComponent.Chip, {
  className: "encore-dark-theme"
}, 'test')
ReactDOM.render(chip, container2);
```

Screenshot:

![image](https://github.com/spicetify/spicetify-cli/assets/661081/3c00d3a8-aec2-454e-984e-e9d1924cb803)


Please let me know if I need to modify anything else to make it easier to use or otherwise.