### PR TITLE
feat(wrapper): menuitem add trailingIcon parameter

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1127,7 +1127,7 @@ Spicetify.SVGIcons = {
 })();
 
 class _HTMLContextMenuItem extends HTMLLIElement {
-	constructor({ name, disabled = false, icon = "", actionIcon = "", divider = false }) {
+	constructor({ name, disabled = false, icon = undefined, actionIcon = undefined, divider = false }) {
 		super();
 		this.name = name;
 		(this.icon = icon), (this.actionIcon = actionIcon);
@@ -1148,9 +1148,9 @@ class _HTMLContextMenuItem extends HTMLLIElement {
 		<button class="main-contextMenu-menuItemButton ${this.disabled ? "main-contextMenu-disabled" : ""} ${
 			this.divider ? "main-contextMenu-dividerAfter" : ""
 		}">
-			${icons[0]}
+			${icons[0] || ""}
 			<span class="ellipsis-one-line main-type-mesto main-contextMenu-menuItemLabel">${this.name}</span>
-			${icons[1]}
+			${icons[1] || ""}
 		</button>`;
 	}
 

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -951,7 +951,7 @@ Spicetify.SVGIcons = {
 	car: '<path d="M2.92 2.375A2.75 2.75 0 015.303 1h5.395c.983 0 1.89.524 2.382 1.375L14.017 4h1.233a.75.75 0 010 1.5h-.237c.989.9.988 2.117.987 2.707v7.043a.75.75 0 01-.75.75h-1.5a.75.75 0 01-.75-.75V14H3v1.25a.75.75 0 01-.75.75H.75a.75.75 0 01-.75-.75V8.207C0 7.617-.002 6.4.987 5.5H.75a.75.75 0 010-1.5h1.233l.938-1.625zm2.382.125c-.446 0-.859.238-1.082.625L3.137 5h9.726L11.78 3.125a1.25 1.25 0 00-1.083-.625H5.302zm8.57 4H2.128a2.72 2.72 0 01-.055.046c-.473.377-.556.894-.57 1.454h2.429a1 1 0 011 1v.5H1.5v3h13v-3h-3.43V9a1 1 0 011-1h2.427c-.013-.56-.096-1.077-.569-1.454a2.585 2.585 0 01-.055-.046z"/>',
 	"chart-down": '<path d="M3 6l5 5.794L13 6z"/>',
 	"chart-up": '<path d="M13 10L8 4.206 3 10z"/>',
-	check: '<path d="M13.985 2.383L5.127 12.754 1.388 8.375l-.658.77 4.397 5.149 9.618-11.262z"/>',
+	check: '<path d="M15.53 2.47a.75.75 0 0 1 0 1.06L4.907 14.153.47 9.716a.75.75 0 0 1 1.06-1.06l3.377 3.376L14.47 2.47a.75.75 0 0 1 1.06 0z"/>',
 	"check-alt-fill":
 		'<path d="M7.5 0C3.354 0 0 3.354 0 7.5S3.354 15 7.5 15 15 11.646 15 7.5 11.646 0 7.5 0zM6.246 12.086l-3.16-3.707 1.05-1.232 2.111 2.464 4.564-5.346 1.221 1.05-5.786 6.771z"/><path fill="none" d="M0 0h16v16H0z"/>',
 	"chevron-left": '<path d="M11.521 1.38l-.65-.76L2.23 8l8.641 7.38.65-.76L3.77 8z"/>',
@@ -1127,26 +1127,31 @@ Spicetify.SVGIcons = {
 })();
 
 class _HTMLContextMenuItem extends HTMLLIElement {
-	constructor({ name, disabled = false, icon = undefined, divider = false }) {
+	constructor({ name, disabled = false, icon = "", actionIcon = "", divider = false }) {
 		super();
 		this.name = name;
-		this.icon = icon || "";
+		(this.icon = icon), (this.actionIcon = actionIcon);
 		this.disabled = disabled;
 		this.divider = divider;
 		this.classList.add("main-contextMenu-menuItem");
 	}
+
 	render() {
-		let icon = this.icon;
-		if (icon && Spicetify.SVGIcons[icon]) {
-			icon = `<svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons[icon]}</svg>`;
-		}
+		const icons = [this.icon, this.actionIcon];
+		icons.forEach((icon, index) => {
+			if (icon && Spicetify.SVGIcons[icon]) {
+				icons[index] = `<svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons[icon]}</svg>`;
+			}
+		});
+
 		this.innerHTML = `
-<button class="main-contextMenu-menuItemButton ${this.disabled ? "main-contextMenu-disabled" : ""} ${
+		<button class="main-contextMenu-menuItemButton ${this.disabled ? "main-contextMenu-disabled" : ""} ${
 			this.divider ? "main-contextMenu-dividerAfter" : ""
 		}">
-    <span class="ellipsis-one-line main-type-mesto" dir="auto">${this.name}</span>
-    ${icon || ""}
-</button>`;
+			${icons[0]}
+			<span class="ellipsis-one-line main-type-mesto main-contextMenu-menuItemLabel">${this.name}</span>
+			${icons[1]}
+		</button>`;
 	}
 
 	connectedCallback() {
@@ -1259,7 +1264,7 @@ Spicetify.Menu = (function () {
 	};
 
 	class Item {
-		constructor(name, isEnabled, onClick, icon = undefined) {
+		constructor(name, isEnabled, onClick, icon = "") {
 			this._name = name;
 			this._isEnabled = isEnabled;
 			this._icon = icon;
@@ -1268,13 +1273,14 @@ Spicetify.Menu = (function () {
 			};
 			this._element = new _HTMLContextMenuItem({
 				name: name,
-				icon: isEnabled ? "check" : icon ?? ""
+				icon: icon,
+				actionIcon: isEnabled ? "check" : ""
 			});
 		}
 
 		setState(isEnabled) {
 			this._isEnabled = isEnabled;
-			this._element.update("icon", isEnabled ? "check" : this._icon ?? "");
+			this._element.update("actionIcon", isEnabled ? "check" : "");
 		}
 		set isEnabled(bool) {
 			this.setState(bool);
@@ -1314,12 +1320,17 @@ Spicetify.Menu = (function () {
 	}
 
 	class SubMenu {
-		constructor(name, items) {
+		constructor(name, items, icon, actionIcon) {
 			this._name = name;
 			this._items = new Set(items);
+			this._icon = icon;
+			this._actionIcon = actionIcon;
 			this._element = new _HTMLContextMenuItem({
 				name: name,
-				icon: `<svg role="img" height="16" width="16" fill="currentColor" class="main-contextMenu-subMenuIcon" viewBox="0 0 16 16"><path d="M13 10L8 4.206 3 10z"></path></svg>`
+				icon: icon,
+				actionIcon:
+					actionIcon ||
+					`<span><svg role="img" height="16" width="16" fill="currentColor" class="main-contextMenu-subMenuIcon" viewBox="0 0 16 16"><path d="M14 10 8 4l-6 6h12z"></path></svg></span>`
 			});
 		}
 
@@ -1341,6 +1352,28 @@ Spicetify.Menu = (function () {
 			this._items.delete(item);
 		}
 
+		setIcon(icon) {
+			this._icon = icon;
+			this._element.update("icon", icon);
+		}
+		set icon(icon) {
+			this.setIcon(icon);
+		}
+		get icon() {
+			return this._icon;
+		}
+
+		setActionIcon(actionIcon) {
+			this._actionIcon = actionIcon;
+			this._element.update("actionIcon", actionIcon);
+		}
+		set actionIcon(actionIcon) {
+			this.setActionIcon(actionIcon);
+		}
+		get actionIcon() {
+			return this._actionIcon;
+		}
+
 		register() {
 			collection.add(this);
 		}
@@ -1357,15 +1390,17 @@ Spicetify.ContextMenu = (function () {
 	const iconList = Object.keys(Spicetify.SVGIcons);
 
 	class Item {
-		constructor(name, onClick, shouldAdd = uris => true, icon = undefined, disabled = false) {
+		constructor(name, onClick, shouldAdd = uris => true, icon = "", actionIcon = "", disabled = false) {
 			this.onClick = onClick;
 			this.shouldAdd = shouldAdd;
 			this._name = name;
 			this._icon = icon;
+			this._actionIcon = actionIcon;
 			this._disabled = disabled;
 			this._element = new _HTMLContextMenuItem({
 				name: name,
 				icon: icon,
+				actionIcon: actionIcon,
 				disabled: disabled
 			});
 		}
@@ -1383,6 +1418,14 @@ Spicetify.ContextMenu = (function () {
 		}
 		get icon() {
 			return this._icon;
+		}
+
+		set actionIcon(name) {
+			this._actionIcon = name;
+			this._element.update("actionIcon", name);
+		}
+		get actionIcon() {
+			return this._actionIcon;
 		}
 
 		set disabled(bool) {
@@ -1404,14 +1447,19 @@ Spicetify.ContextMenu = (function () {
 	Item.iconList = iconList;
 
 	class SubMenu {
-		constructor(name, items, shouldAdd = uris => true, disabled = false) {
+		constructor(name, items, shouldAdd = uris => true, disabled = false, icon = "", actionIcon = "") {
 			this._items = new Set(items);
 			this.shouldAdd = shouldAdd;
 			this._name = name;
 			this._disabled = disabled;
+			this._icon = icon;
+			this._actionIcon = actionIcon;
 			this._element = new _HTMLContextMenuItem({
 				name: name,
-				icon: `<svg role="img" height="16" width="16" fill="currentColor" class="main-contextMenu-subMenuIcon" viewBox="0 0 16 16"><path d="M13 10L8 4.206 3 10z"></path></svg>`,
+				icon: icon,
+				actionIcon:
+					actionIcon ||
+					`<span><svg role="img" height="16" width="16" fill="currentColor" class="main-contextMenu-subMenuIcon" viewBox="0 0 16 16"><path d="M14 10 8 4l-6 6h12z"></path></svg></span>`,
 				disabled: disabled
 			});
 		}

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1142,7 +1142,7 @@ class _HTMLContextMenuItem extends HTMLLIElement {
 			if (icon && Spicetify.SVGIcons[icon]) {
 				return `<svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons[icon]}</svg>`;
 			}
-			return "";
+			return icon || "";
 		};
 
 		this.innerHTML = `

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1130,7 +1130,8 @@ class _HTMLContextMenuItem extends HTMLLIElement {
 	constructor({ name, disabled = false, icon = undefined, actionIcon = undefined, divider = false }) {
 		super();
 		this.name = name;
-		(this.icon = icon), (this.actionIcon = actionIcon);
+		this.icon = icon;
+		this.actionIcon = actionIcon;
 		this.disabled = disabled;
 		this.divider = divider;
 		this.classList.add("main-contextMenu-menuItem");
@@ -1330,7 +1331,7 @@ Spicetify.Menu = (function () {
 				icon: icon,
 				actionIcon:
 					actionIcon ||
-					`<span><svg role="img" height="16" width="16" fill="currentColor" class="main-contextMenu-subMenuIcon" viewBox="0 0 16 16"><path d="M14 10 8 4l-6 6h12z"></path></svg></span>`
+					'<span><svg role="img" height="16" width="16" fill="currentColor" class="main-contextMenu-subMenuIcon" viewBox="0 0 16 16"><path d="M14 10 8 4l-6 6h12z"></path></svg></span>'
 			});
 		}
 
@@ -1459,7 +1460,7 @@ Spicetify.ContextMenu = (function () {
 				icon: icon,
 				actionIcon:
 					actionIcon ||
-					`<span><svg role="img" height="16" width="16" fill="currentColor" class="main-contextMenu-subMenuIcon" viewBox="0 0 16 16"><path d="M14 10 8 4l-6 6h12z"></path></svg></span>`,
+					'<span><svg role="img" height="16" width="16" fill="currentColor" class="main-contextMenu-subMenuIcon" viewBox="0 0 16 16"><path d="M14 10 8 4l-6 6h12z"></path></svg></span>',
 				disabled: disabled
 			});
 		}

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1138,20 +1138,20 @@ class _HTMLContextMenuItem extends HTMLLIElement {
 	}
 
 	render() {
-		const icons = [this.icon, this.trailingIcon];
-		icons.forEach((icon, index) => {
+		const parseIcon = icon => {
 			if (icon && Spicetify.SVGIcons[icon]) {
-				icons[index] = `<svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons[icon]}</svg>`;
+				return `<svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons[icon]}</svg>`;
 			}
-		});
+			return "";
+		};
 
 		this.innerHTML = `
 		<button class="main-contextMenu-menuItemButton ${this.disabled ? "main-contextMenu-disabled" : ""} ${
 			this.divider ? "main-contextMenu-dividerAfter" : ""
 		}">
-			${icons[0] || ""}
+			${parseIcon(this.icon)}
 			<span class="ellipsis-one-line main-type-mesto main-contextMenu-menuItemLabel">${this.name}</span>
-			${icons[1] || ""}
+			${parseIcon(this.trailingIcon)}
 		</button>`;
 	}
 

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1127,18 +1127,18 @@ Spicetify.SVGIcons = {
 })();
 
 class _HTMLContextMenuItem extends HTMLLIElement {
-	constructor({ name, disabled = false, icon = undefined, actionIcon = undefined, divider = false }) {
+	constructor({ name, disabled = false, icon = undefined, trailingIcon = undefined, divider = false }) {
 		super();
 		this.name = name;
 		this.icon = icon;
-		this.actionIcon = actionIcon;
+		this.trailingIcon = trailingIcon;
 		this.disabled = disabled;
 		this.divider = divider;
 		this.classList.add("main-contextMenu-menuItem");
 	}
 
 	render() {
-		const icons = [this.icon, this.actionIcon];
+		const icons = [this.icon, this.trailingIcon];
 		icons.forEach((icon, index) => {
 			if (icon && Spicetify.SVGIcons[icon]) {
 				icons[index] = `<svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor">${Spicetify.SVGIcons[icon]}</svg>`;
@@ -1275,13 +1275,13 @@ Spicetify.Menu = (function () {
 			this._element = new _HTMLContextMenuItem({
 				name: name,
 				icon: icon,
-				actionIcon: isEnabled ? "check" : ""
+				trailingIcon: isEnabled ? "check" : ""
 			});
 		}
 
 		setState(isEnabled) {
 			this._isEnabled = isEnabled;
-			this._element.update("actionIcon", isEnabled ? "check" : "");
+			this._element.update("trailingIcon", isEnabled ? "check" : "");
 		}
 		set isEnabled(bool) {
 			this.setState(bool);
@@ -1321,16 +1321,16 @@ Spicetify.Menu = (function () {
 	}
 
 	class SubMenu {
-		constructor(name, items, icon, actionIcon) {
+		constructor(name, items, icon, trailingIcon) {
 			this._name = name;
 			this._items = new Set(items);
 			this._icon = icon;
-			this._actionIcon = actionIcon;
+			this._trailingIcon = trailingIcon;
 			this._element = new _HTMLContextMenuItem({
 				name: name,
 				icon: icon,
-				actionIcon:
-					actionIcon ||
+				trailingIcon:
+					trailingIcon ||
 					'<span><svg role="img" height="16" width="16" fill="currentColor" class="main-contextMenu-subMenuIcon" viewBox="0 0 16 16"><path d="M14 10 8 4l-6 6h12z"></path></svg></span>'
 			});
 		}
@@ -1364,15 +1364,15 @@ Spicetify.Menu = (function () {
 			return this._icon;
 		}
 
-		setActionIcon(actionIcon) {
-			this._actionIcon = actionIcon;
-			this._element.update("actionIcon", actionIcon);
+		settrailingIcon(trailingIcon) {
+			this._trailingIcon = trailingIcon;
+			this._element.update("trailingIcon", trailingIcon);
 		}
-		set actionIcon(actionIcon) {
-			this.setActionIcon(actionIcon);
+		set trailingIcon(trailingIcon) {
+			this.settrailingIcon(trailingIcon);
 		}
-		get actionIcon() {
-			return this._actionIcon;
+		get trailingIcon() {
+			return this._trailingIcon;
 		}
 
 		register() {
@@ -1391,17 +1391,17 @@ Spicetify.ContextMenu = (function () {
 	const iconList = Object.keys(Spicetify.SVGIcons);
 
 	class Item {
-		constructor(name, onClick, shouldAdd = uris => true, icon = "", actionIcon = "", disabled = false) {
+		constructor(name, onClick, shouldAdd = uris => true, icon = "", trailingIcon = "", disabled = false) {
 			this.onClick = onClick;
 			this.shouldAdd = shouldAdd;
 			this._name = name;
 			this._icon = icon;
-			this._actionIcon = actionIcon;
+			this._trailingIcon = trailingIcon;
 			this._disabled = disabled;
 			this._element = new _HTMLContextMenuItem({
 				name: name,
 				icon: icon,
-				actionIcon: actionIcon,
+				trailingIcon: trailingIcon,
 				disabled: disabled
 			});
 		}
@@ -1421,12 +1421,12 @@ Spicetify.ContextMenu = (function () {
 			return this._icon;
 		}
 
-		set actionIcon(name) {
-			this._actionIcon = name;
-			this._element.update("actionIcon", name);
+		set trailingIcon(name) {
+			this._trailingIcon = name;
+			this._element.update("trailingIcon", name);
 		}
-		get actionIcon() {
-			return this._actionIcon;
+		get trailingIcon() {
+			return this._trailingIcon;
 		}
 
 		set disabled(bool) {
@@ -1448,18 +1448,18 @@ Spicetify.ContextMenu = (function () {
 	Item.iconList = iconList;
 
 	class SubMenu {
-		constructor(name, items, shouldAdd = uris => true, disabled = false, icon = "", actionIcon = "") {
+		constructor(name, items, shouldAdd = uris => true, disabled = false, icon = "", trailingIcon = "") {
 			this._items = new Set(items);
 			this.shouldAdd = shouldAdd;
 			this._name = name;
 			this._disabled = disabled;
 			this._icon = icon;
-			this._actionIcon = actionIcon;
+			this._trailingIcon = trailingIcon;
 			this._element = new _HTMLContextMenuItem({
 				name: name,
 				icon: icon,
-				actionIcon:
-					actionIcon ||
+				trailingIcon:
+					trailingIcon ||
 					'<span><svg role="img" height="16" width="16" fill="currentColor" class="main-contextMenu-subMenuIcon" viewBox="0 0 16 16"><path d="M14 10 8 4l-6 6h12z"></path></svg></span>',
 				disabled: disabled
 			});

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1364,12 +1364,12 @@ Spicetify.Menu = (function () {
 			return this._icon;
 		}
 
-		settrailingIcon(trailingIcon) {
+		setTrailingIcon(trailingIcon) {
 			this._trailingIcon = trailingIcon;
 			this._element.update("trailingIcon", trailingIcon);
 		}
 		set trailingIcon(trailingIcon) {
-			this.settrailingIcon(trailingIcon);
+			this.setTrailingIcon(trailingIcon);
 		}
 		get trailingIcon() {
 			return this._trailingIcon;


### PR DESCRIPTION
resolves #2646
improves upon #2647

Completed:
- updated check icon
- updated dropdown icon
- added trailingIcon
- ability to override dropdown icon for custom icon
- ability to have both a prepended icon (icon) and appended icon (trailingIcon)

Showcase:
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/9599f22d-f457-46f5-914e-24f175271e97)
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/bcacd4f7-29c1-44c9-8313-f65d486c1475)
Not a realistic use case for the last image, just to show the ability to override as devs wish.