### PR TITLE
fix(lyrics-plus): optionsMenu-dropBox tippy

### DIFF
--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -55,7 +55,7 @@ const OptionsMenu = react.memo(({ options, onSelect, selected, defaultValue, bol
 			),
 			trigger: "click",
 			action: "toggle",
-			renderInline: true
+			renderInline: false
 		},
 		react.createElement(
 			"button",


### PR DESCRIPTION
The removal of root__topbar in later versions of spotify means rendering inline is no longer possible.
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/212ae4d3-6ee2-4917-b74e-2ed9b9191670)
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/7b37d754-bea1-4824-b183-e1aa052312f4)
