### PR TITLE
fix(wrapper): remove outdated `attachObserver` function

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1955,7 +1955,7 @@ Spicetify.Topbar = (function () {
 		}
 	}
 
-	function waitForTopbarMounted() {
+	(function waitForTopbarMounted() {
 		leftContainer = document.querySelector(".main-topBar-historyButtons");
 		rightContainer = document.querySelector(".main-noConnection");
 		if (!leftContainer || !rightContainer) {
@@ -1964,9 +1964,7 @@ Spicetify.Topbar = (function () {
 		}
 		leftContainer.append(...leftButtonsStash);
 		rightContainer.after(...rightButtonsStash);
-	}
-
-	waitForTopbarMounted();
+	})();
 
 	return { Button };
 })();

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1968,24 +1968,6 @@ Spicetify.Topbar = (function () {
 
 	waitForTopbarMounted();
 
-	(function attachObserver() {
-		const topBar = document.querySelector(".Root__top-bar");
-		if (!topBar) {
-			setTimeout(attachObserver, 300);
-			return;
-		}
-		const observer = new MutationObserver(mutations => {
-			mutations.forEach(mutation => {
-				if (mutation.removedNodes.length > 0) {
-					leftContainer = null;
-					rightContainer = null;
-					waitForTopbarMounted();
-				}
-			});
-		});
-		observer.observe(topBar, { childList: true });
-	})();
-
 	return { Button };
 })();
 


### PR DESCRIPTION
#1912 isn't reproducible with spotify v1.2.0, and since spotify v1.2.23 this function calls itself endlessly because of the `.Root__top-bar` element removal
