### PR TITLE
feat(wrapper): remove `appchange` event from player

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -2357,37 +2357,6 @@ Spicetify.Playbar = (function () {
 	Spicetify.Panel.subPanelState(() => clearTimeout(refreshTimeout));
 })();
 
-(function waitForHistoryAPI() {
-	const main = document.querySelector(".main-view-container__scroll-node-child > main");
-	if (!main || !Spicetify.Platform?.History) {
-		setTimeout(waitForHistoryAPI, 300);
-		return;
-	}
-
-	let currentPath;
-	const observer = new MutationObserver(() => {
-		const child = main.lastElementChild;
-		const isPlaceholder = child?.tagName === "DIV" && !child?.children.length;
-		if (!isPlaceholder) {
-			const event = new Event("appchange");
-			event.data = {
-				path: currentPath,
-				container: child
-			};
-			Spicetify.Player.dispatchEvent(event);
-			observer.disconnect();
-		}
-	});
-
-	Spicetify.Platform.History.listen(({ pathname }) => {
-		if (!Spicetify.Player.eventListeners["appchange"]?.length) {
-			return;
-		}
-		currentPath = pathname;
-		observer.observe(main, { childList: true });
-	});
-})();
-
 (async function checkForUpdate() {
 	if (!Spicetify.Config) {
 		setTimeout(checkForUpdate, 300);


### PR DESCRIPTION
definitely some super-legacy thing, also no one uses it
didn't touch the types because will create a separate pr for them
