### PR TITLE
fix(wrapper): add optional chaining to `colorExtractor`

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -765,7 +765,7 @@ Spicetify.colorExtractor = async uri => {
 	if (body.entries && body.entries.length) {
 		const list = {};
 		for (const color of body.entries[0].color_swatches) {
-			list[color.preset] = `#${color.color.toString(16).padStart(6, "0")}`;
+			list[color.preset] = `#${color.color?.toString(16).padStart(6, "0")}`;
 		}
 		return list;
 	} else {


### PR DESCRIPTION
spotify moment, i guess 

![image](https://github.com/spicetify/spicetify-cli/assets/115353812/5907f40f-2e42-49be-acaf-00660dfb1d7c)
