### PR TITLE
fix(wrapper): simpleLayout & wrapper

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -421,8 +421,8 @@ window.Spicetify = {
 			ButtonSecondary: modules.find(m => m?.render && m?.displayName === "ButtonSecondary"),
 			ButtonTertiary: modules.find(m => m?.render && m?.displayName === "ButtonTertiary"),
 			Snackbar: {
-				wrapper: functionModules.find(m => m.toString().includes("encore-light-theme")),
-				simpleLayout: functionModules.find(m => m.toString().includes("leading")),
+				wrapper: functionModules.find(m => m.toString().includes("encore-light-theme") && m.toString().includes("elevated")),
+				simpleLayout: functionModules.find(m => ["leading", "center", "trailing"].every(keyword => m.toString().includes(keyword))),
 				ctaText: functionModules.find(m => m.toString().includes("ctaText")),
 				styledImage: functionModules.find(m => m.toString().includes("placeholderSrc"))
 			},


### PR DESCRIPTION
before:
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/685bacf5-6331-4b39-8318-9f40470da7f3)

after:
![image](https://github.com/spicetify/spicetify-cli/assets/22730962/007eb3e5-68ff-41ef-8bae-a02d9d1701ba)


i havent tested on older versions, but it doesnt look like these functions have changed its just that newer functions added to xpui happened to use the same keywords, so likely unnecessary to test