### PR TITLE
feat(css-map): update css mapping for search browse-all wrapper

### DIFF
--- a/CustomApps/lyrics-plus/TabBar.js
+++ b/CustomApps/lyrics-plus/TabBar.js
@@ -193,7 +193,7 @@ const TabBar = react.memo(({ links, activeLink, lockLink, switchCallback, lockCa
 						items: droplistItem.map(i => options[i]).filter(i => i),
 						switchTo: switchCallback,
 						lockIn: lockCallback
-				  })
+					})
 				: null
 		)
 	);

--- a/CustomApps/new-releases/Card.js
+++ b/CustomApps/new-releases/Card.js
@@ -4,7 +4,7 @@ function DraggableComponent({ uri, title, children }) {
 		? react.cloneElement(children, {
 				onDragStart: dragHandler,
 				draggable: "true"
-		  })
+			})
 		: children;
 }
 

--- a/CustomApps/reddit/TabBar.js
+++ b/CustomApps/reddit/TabBar.js
@@ -166,7 +166,7 @@ const TabBar = react.memo(({ links, activeLink, switchCallback, windowSize = Inf
 				? react.createElement(TabBarMore, {
 						items: droplistItem.map(i => options[i]).filter(i => i),
 						switchTo: switchCallback
-				  })
+					})
 				: null
 		)
 	);

--- a/css-map.json
+++ b/css-map.json
@@ -2012,6 +2012,7 @@
 	"CCi1L2OQvgdZvxkRHeKE": "search-searchBrowse-SearchBrowse",
 	"rvvoAdb7aaUPYRasW7sK": "search-searchBrowse-browseAllContainer",
 	"UdXTcsz1eiiInKThkfYp": "search-searchBrowse-browseAllWrapper",
+	"M7LKuAFiIKaigK0fVguF": "search-searchBrowse-browseAllWrapper",
 	"khkfPsJuVBQyL_5cLT7y": "search-recentSearches-searchPageGrid",
 	"fVB_YDdnaDlztX7CcWTA": "search-searchCategory-SearchCategory",
 	"e179_Eg8r7Ub6yjjxctr": "search-searchCategory-container",

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -2338,7 +2338,7 @@ Spicetify.Playbar = (function () {
 							}),
 							Spicetify.React.cloneElement(children, { panel: id })
 						)
-				  );
+					);
 
 			contentMap.set(id, Spicetify.React.createElement(ErrorBoundary, { id }, content));
 


### PR DESCRIPTION
Adds mapping for `.search-searchBrowse-browseAllWrapper` in Spotify 1.2.26.1187.g36b715a1