### PR TITLE
fix(shuffle+): remove context for local tracks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Executables
-bin/
+bin
 spicetify-cli
 spicetify
 *.exe
@@ -14,3 +14,6 @@ package.json
 
 # Logs
 install.log
+
+# VSCode
+.vscode

--- a/Extensions/shuffle+.js
+++ b/Extensions/shuffle+.js
@@ -574,7 +574,7 @@
 				}
 
 				context = rawUri;
-				if (type === "folder" || type === "collection") {
+				if (type === "folder" || type === "collection" || type === "local") {
 					context = null;
 				}
 			}


### PR DESCRIPTION
Fixes #2689

spotify's internal magic breaks on setting context for local files