### PR TITLE
refactor(cmd): rewrite `InitPaths` func

### DIFF
--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -77,12 +77,6 @@ func InitPaths() {
 		cfg.Write()
 	}
 
-	if runtime.GOOS == "windows" {
-		if strings.Contains(spotifyPath, "SpotifyAB.SpotifyMusic") || strings.Contains(prefsPath, "SpotifyAB.SpotifyMusic") {
-			isAppX = true
-		}
-	}
-
 	if _, err := os.Stat(prefsPath); err != nil {
 		actualPrefsPath := utils.FindPrefFilePath()
 
@@ -97,6 +91,12 @@ func InitPaths() {
 		prefsPath = actualPrefsPath
 		settingSection.Key("prefs_path").SetValue(prefsPath)
 		cfg.Write()
+	}
+
+	if runtime.GOOS == "windows" {
+		if strings.Contains(spotifyPath, "SpotifyAB.SpotifyMusic") || strings.Contains(prefsPath, "SpotifyAB.SpotifyMusic") {
+			isAppX = true
+		}
 	}
 
 	appPath = filepath.Join(spotifyPath, "Apps")

--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -66,7 +66,8 @@ func InitPaths() {
 
 		if len(actualSpotifyPath) == 0 {
 			if len(spotifyPath) != 0 {
-				utils.PrintError(spotifyPath + ` does not exist or is not a valid path.`)
+				utils.PrintError(spotifyPath + ` is not a valid path. Please manually set "spotify_path" in config-xpui.ini to correct directory of Spotify.`)
+				os.Exit(1)
 			}
 			utils.PrintError(`Cannot detect Spotify location. Please manually set "spotify_path" in config-xpui.ini`)
 			os.Exit(1)
@@ -82,7 +83,8 @@ func InitPaths() {
 
 		if len(actualPrefsPath) == 0 {
 			if len(prefsPath) != 0 {
-				utils.PrintError(prefsPath + ` does not exist or is not a valid path.`)
+				utils.PrintError(prefsPath + ` does not exist or is not a valid path. Please manually set "prefs_path" in config-xpui.ini to correct path of "prefs" file.`)
+				os.Exit(1)
 			}
 			utils.PrintError(`Cannot detect Spotify "prefs" file location. Please manually set "prefs_path" in config-xpui.ini`)
 			os.Exit(1)

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -209,7 +209,7 @@ func FindPrefFilePath() string {
 
 func winApp() string {
 	path := filepath.Join(os.Getenv("APPDATA"), "Spotify")
-	if _, err := os.Stat(path); err == nil {
+	if _, err := os.Stat(filepath.Join(path, "Spotify.exe")); err == nil {
 		return path
 	}
 


### PR DESCRIPTION
more readable code + no more "i switched to the classic version, but spicetify still says that i have the ms store one"