### PR TITLE
fix(cmd): check for spotify.exe existence instead of app folder

### DIFF
--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -60,8 +60,13 @@ func InitPaths() {
 
 	spotifyPath = utils.ReplaceEnvVarsInString(spotifyPath)
 	prefsPath = utils.ReplaceEnvVarsInString(prefsPath)
+	testPath := spotifyPath
 
-	if _, err := os.Stat(spotifyPath); err != nil {
+	if runtime.GOOS == "windows" {
+		testPath = filepath.Join(spotifyPath, "Spotify.exe")
+	}
+
+	if _, err := os.Stat(testPath); err != nil {
 		actualSpotifyPath := utils.FindAppPath()
 
 		if len(actualSpotifyPath) == 0 {


### PR DESCRIPTION
so that's why the check was there

![image](https://github.com/spicetify/spicetify-cli/assets/115353812/73ed1edc-43c6-4410-9e00-b8d2477553bf)
