### PR TITLE
feat: bring back option to disable spotify self-updates

### DIFF
--- a/spicetify.go
+++ b/spicetify.go
@@ -492,7 +492,7 @@ disable_ui_logging <0 | 1>
     Various elements logs every user clicks, scrolls.
     Enable to stop logging and improve user experience.
 
-disable_self_update <0 | 1>
+disable_self_updates <0 | 1>
 	Prevent Spotify from self-updating. Won't affect updates via package managers.
 
 remove_rtl_rule <0 | 1>

--- a/spicetify.go
+++ b/spicetify.go
@@ -478,7 +478,7 @@ spotify_launch_flags
     List of valid flags: https://spicetify.app/docs/development/spotify-cli-flags
 
 always_enable_devtools <0 | 1>
-    Whether Chrome DevTools is enabled when launching/restarting Spotify.
+    Whether Chrome DevTools is enabled when launching/restarting Spotify using Spicetify.
 
 check_spicetify_update <0 | 1>
 		Whether to check for spicetify-cli update when running Spicetify.
@@ -491,6 +491,9 @@ disable_sentry <0 | 1>
 disable_ui_logging <0 | 1>
     Various elements logs every user clicks, scrolls.
     Enable to stop logging and improve user experience.
+
+disable_self_update <0 | 1>
+	Diables self-updates for Spotify. Won't affect package manager updates.
 
 remove_rtl_rule <0 | 1>
     To support Arabic and other Right-To-Left language, Spotify added a lot of

--- a/spicetify.go
+++ b/spicetify.go
@@ -493,7 +493,7 @@ disable_ui_logging <0 | 1>
     Enable to stop logging and improve user experience.
 
 disable_self_update <0 | 1>
-	Diables self-updates for Spotify. Won't affect package manager updates.
+	Prevent Spotify from self-updating. Won't affect updates via package managers.
 
 remove_rtl_rule <0 | 1>
     To support Arabic and other Right-To-Left language, Spotify added a lot of

--- a/spicetify.go
+++ b/spicetify.go
@@ -492,7 +492,7 @@ disable_ui_logging <0 | 1>
     Various elements logs every user clicks, scrolls.
     Enable to stop logging and improve user experience.
 
-disable_self_updates <0 | 1>
+disable_spotify_updates <0 | 1>
     Prevent Spotify from self-updating. Won't affect updates via package managers.
 
 remove_rtl_rule <0 | 1>

--- a/spicetify.go
+++ b/spicetify.go
@@ -493,7 +493,7 @@ disable_ui_logging <0 | 1>
     Enable to stop logging and improve user experience.
 
 disable_self_updates <0 | 1>
-	Prevent Spotify from self-updating. Won't affect updates via package managers.
+    Prevent Spotify from self-updating. Won't affect updates via package managers.
 
 remove_rtl_rule <0 | 1>
     To support Arabic and other Right-To-Left language, Spotify added a lot of

--- a/src/cmd/backup.go
+++ b/src/cmd/backup.go
@@ -71,6 +71,7 @@ Modded Spotify cannot be launched using original Shortcut/Start menu tile. To co
 		preprocess.Flag{
 			DisableSentry:  preprocSection.Key("disable_sentry").MustBool(false),
 			DisableLogging: preprocSection.Key("disable_ui_logging").MustBool(false),
+			DisableUpdates: preprocSection.Key("disable_self_update").MustBool(false),
 			RemoveRTL:      preprocSection.Key("remove_rtl_rule").MustBool(false),
 			ExposeAPIs:     preprocSection.Key("expose_apis").MustBool(false)},
 	)

--- a/src/cmd/backup.go
+++ b/src/cmd/backup.go
@@ -71,7 +71,7 @@ Modded Spotify cannot be launched using original Shortcut/Start menu tile. To co
 		preprocess.Flag{
 			DisableSentry:  preprocSection.Key("disable_sentry").MustBool(false),
 			DisableLogging: preprocSection.Key("disable_ui_logging").MustBool(false),
-			DisableUpdates: preprocSection.Key("disable_self_updates").MustBool(false),
+			DisableUpdates: preprocSection.Key("disable_spotify_updates").MustBool(false),
 			RemoveRTL:      preprocSection.Key("remove_rtl_rule").MustBool(false),
 			ExposeAPIs:     preprocSection.Key("expose_apis").MustBool(false)},
 	)

--- a/src/cmd/backup.go
+++ b/src/cmd/backup.go
@@ -71,7 +71,7 @@ Modded Spotify cannot be launched using original Shortcut/Start menu tile. To co
 		preprocess.Flag{
 			DisableSentry:  preprocSection.Key("disable_sentry").MustBool(false),
 			DisableLogging: preprocSection.Key("disable_ui_logging").MustBool(false),
-			DisableUpdates: preprocSection.Key("disable_self_update").MustBool(false),
+			DisableUpdates: preprocSection.Key("disable_self_updates").MustBool(false),
 			RemoveRTL:      preprocSection.Key("remove_rtl_rule").MustBool(false),
 			ExposeAPIs:     preprocSection.Key("expose_apis").MustBool(false)},
 	)

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -273,7 +273,7 @@ func disableLogging(input string) string {
 }
 
 func disableUpdates(input string) string {
-	utils.Replace(&input, `"sp:\/\/desktop\/v1\/upgrade[\/\w]*"`, `""`)
+	utils.Replace(&input, `"sp:\/\/desktop\/v\d+\/upgrade[\/\w]*"`, `""`)
 	return input
 }
 

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -22,6 +22,8 @@ type Flag struct {
 	DisableSentry bool
 	// DisableLogging stops various elements to log user interaction.
 	DisableLogging bool
+	// DisableUpdates prevents Spotify from self-updating.
+	DisableUpdates bool
 	// RemoveRTL removes all Right-To-Left CSS rules to simplify CSS files.
 	RemoveRTL bool
 	// ExposeAPIs leaks some Spotify's API, functions, objects to Spicetify global object.
@@ -95,6 +97,10 @@ func Start(version string, extractedAppsPath string, flags Flag) {
 
 				if flags.DisableLogging {
 					content = disableLogging(content)
+				}
+
+				if flags.DisableUpdates && fileName == "xpui.js" {
+					content = disableUpdates(content)
 				}
 
 				if flags.ExposeAPIs {
@@ -263,6 +269,11 @@ func disableLogging(input string) string {
 	utils.Replace(&input, `(\}send\([\w,:=!\d{}]+\))\{.+?\}(hasContext)`, "${1}{return;}${2}")
 	utils.Replace(&input, `(\}lastFlush\(\))\{.+?\}(flush\(\))`, "${1}{return;}${2}")
 
+	return input
+}
+
+func disableUpdates(input string) string {
+	utils.Replace(&input, `"sp:\/\/desktop\/v1\/upgrade[\/\w]*"`, `""`)
 	return input
 }
 

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -26,10 +26,11 @@ var (
 			"always_enable_devtools": "0",
 		},
 		"Preprocesses": {
-			"disable_sentry":     "1",
-			"disable_ui_logging": "1",
-			"remove_rtl_rule":    "1",
-			"expose_apis":        "1",
+			"disable_sentry":       "1",
+			"disable_ui_logging":   "1",
+			"disable_self_update":  "0",
+			"remove_rtl_rule":      "1",
+			"expose_apis":          "1",
 		},
 		"AdditionalOptions": {
 			"extensions":            "",

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -28,7 +28,7 @@ var (
 		"Preprocesses": {
 			"disable_sentry":       "1",
 			"disable_ui_logging":   "1",
-			"disable_self_update":  "0",
+			"disable_self_updates":  "0",
 			"remove_rtl_rule":      "1",
 			"expose_apis":          "1",
 		},

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -26,11 +26,11 @@ var (
 			"always_enable_devtools": "0",
 		},
 		"Preprocesses": {
-			"disable_sentry":       "1",
-			"disable_ui_logging":   "1",
+			"disable_sentry":          "1",
+			"disable_ui_logging":      "1",
 			"disable_spotify_updates": "0",
-			"remove_rtl_rule":      "1",
-			"expose_apis":          "1",
+			"remove_rtl_rule":         "1",
+			"expose_apis":             "1",
 		},
 		"AdditionalOptions": {
 			"extensions":            "",

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -28,7 +28,7 @@ var (
 		"Preprocesses": {
 			"disable_sentry":       "1",
 			"disable_ui_logging":   "1",
-			"disable_self_updates": "0",
+			"disable_spotify_updates": "0",
 			"remove_rtl_rule":      "1",
 			"expose_apis":          "1",
 		},

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -28,7 +28,7 @@ var (
 		"Preprocesses": {
 			"disable_sentry":       "1",
 			"disable_ui_logging":   "1",
-			"disable_self_updates":  "0",
+			"disable_self_updates": "0",
 			"remove_rtl_rule":      "1",
 			"expose_apis":          "1",
 		},


### PR DESCRIPTION
re-implements the feature removed in #2512