### PR TITLE
feat(fullAppDisplay): enable all options by default

### DIFF
--- a/Extensions/fullAppDisplay.js
+++ b/Extensions/fullAppDisplay.js
@@ -779,7 +779,7 @@ body.video-full-screen.video-full-screen--hide-ui {
 	}
 
 	const ConfigItem = ({ name, field, func, disabled = false }) => {
-		const [value, setValue] = useState(CONFIG[field]);
+		const [value, setValue] = useState(true);
 		return react.createElement(
 			"div",
 			{ className: "setting-row" },


### PR DESCRIPTION
- Whenever Spicetify gets an update, the `state` in `fullAppDisplay` seems lost, and I have to enable all those options **one by one every time**.
- For personal preference, I check all the options in `fullAppDisplay`, it's such a great extension, so why not enable it by default if someone like me clicks it and wanna the gorgeous experience of FULL app display mode?
- Now, the `state` is `true` by default. I am pretty sure the number of enabled options is greater than the number of disabled options if you wanna use `fullAppDisplay`.