### PR TITLE
fix(popupLyrics): increase setTimeout time

### DIFF
--- a/Extensions/popupLyrics.js
+++ b/Extensions/popupLyrics.js
@@ -14,7 +14,7 @@ if (!navigator.serviceWorker) {
 	onmessage = event => {
 		if (event.data === "popup-lyric-request-update") {
 			console.warn("popup-lyric-request-update");
-			num = setInterval(() => postMessage("popup-lyric-update-ui"), 8);
+			num = setInterval(() => postMessage("popup-lyric-update-ui"), 15);
 		} else if (event.data === "popup-lyric-stop-update") {
 			clearInterval(num);
 			num = null;
@@ -719,22 +719,20 @@ function PopupLyrics() {
 		} else if (!audio.duration || lyrics.length === 0) {
 			drawText(lyricCtx, audio.currentSrc ? "Loading" : "Waiting");
 		}
-		if (lyrics?.length) {
-			if (document.hidden) {
-				if (!workerIsRunning) {
-					worker.postMessage("popup-lyric-request-update");
-					workerIsRunning = true;
-				}
-			} else {
-				if (workerIsRunning) {
-					worker.postMessage("popup-lyric-stop-update");
-					workerIsRunning = false;
-				}
 
-				requestAnimationFrame(() => tick(options));
+		if (!lyrics?.length) return setTimeout(tick, 1000, options);
+		if (document.hidden) {
+			if (!workerIsRunning) {
+				worker.postMessage("popup-lyric-request-update");
+				workerIsRunning = true;
 			}
 		} else {
-			setTimeout(tick, 80, options);
+			if (workerIsRunning) {
+				worker.postMessage("popup-lyric-stop-update");
+				workerIsRunning = false;
+			}
+
+			requestAnimationFrame(() => tick(options));
 		}
 	}
 


### PR DESCRIPTION
I don't know who thought calling a tick function every `8`ms and then doing additional setTimeout every `80`ms when no lyrics are found thought it's an good idea. However, that being said, I think `1000`ms is pretty reasonable when no lyrics are found, and changed the `update-ui` message to be called every 16.6ms (would result in UI being rendered in ~`60`fps instead of `125`fps).

Fixes #2807