### PR TITLE
fix(wrapper/topbar): use `History.listen` event instead of the observer

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -137,6 +137,7 @@
 	"ATUzFKub89lzvkmvhpyE": "main-navBar-navBarLink",
 	"moDRd9td0KtitPDzR7OJ": "main-navBar-navBarLinkActive",
 	"GTAFfOA_w5vh_bDaGJAG": "main-noConnection",
+	"NPvLJSRWfv1Joo8dF0D8": "main-noConnection",
 	"WIGgdAaAzrXm7f_loaXi": "main-noConnection-button",
 	"vQNZsbpzoUFSW5fsFOAw": "main-notificationBubble-NotificationBubble",
 	"ZKFK00olAYy6LtYMjEIa": "main-notificationBubble-enter",

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1892,7 +1892,6 @@ Object.defineProperty(Spicetify, "TippyProps", {
 Spicetify.Topbar = (() => {
 	let leftContainer;
 	let rightContainer;
-	let timeout;
 	const leftButtonsStash = new Set();
 	const rightButtonsStash = new Set();
 
@@ -1966,25 +1965,12 @@ Spicetify.Topbar = (() => {
 	}
 
 	waitForTopbarMounted();
-	(function attachObserver() {
-		if (timeout) clearTimeout(timeout);
-		const topBar = document.querySelector(".main-topBar-container");
-		if (!topBar) {
-			setTimeout(attachObserver, 100);
+	(function waitForPlatform() {
+		if (!Spicetify.Platform?.History) {
+			setTimeout(waitForPlatform, 1000);
 			return;
 		}
-		const observer = new MutationObserver(mutations => {
-			for (const mutation of mutations) {
-				if (mutation.removedNodes.length > 0) {
-					leftContainer = null;
-					rightContainer = null;
-					waitForTopbarMounted();
-					observer.disconnect();
-					timeout = setTimeout(attachObserver, 300);
-				}
-			}
-		});
-		observer.observe(topBar, { childList: true, subtree: true });
+		Spicetify.Platform.History.listen(() => waitForTopbarMounted());
 	})();
 
 	return { Button };

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1967,7 +1967,7 @@ Spicetify.Topbar = (() => {
 	waitForTopbarMounted();
 	(function waitForPlatform() {
 		if (!Spicetify.Platform?.History) {
-			setTimeout(waitForPlatform, 1000);
+			setTimeout(waitForPlatform, 100);
 			return;
 		}
 		Spicetify.Platform.History.listen(() => waitForTopbarMounted());


### PR DESCRIPTION
fixes #2806
explanation: the topbar is only re-rendered in few specific page switches so