### PR TITLE
fix(wrapper/topbar): apply `main-topBar-button` on button not element

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -2009,7 +2009,7 @@ Spicetify.Topbar = (() => {
 				rightButtonsStash.add(this.element);
 				rightContainer?.prepend(this.element);
 			} else {
-				this.element.classList.add("main-topBar-button");
+				this.button.classList.add("main-topBar-button");
 				leftButtonsStash.add(this.element);
 				leftContainer?.append(this.element);
 			}


### PR DESCRIPTION
This fixes #2879 (https://github.com/spicetify/spicetify-cli/commit/c866648e6b40412fd4610a4534a04e945976ef92). Without applying `main-topBar-button` class on the button itself it will create blocky element on the left items
before:
![image](https://github.com/spicetify/spicetify-cli/assets/9348108/36db7551-e26c-4cf3-bf74-af3d000de4ec)
after:
![image](https://github.com/spicetify/spicetify-cli/assets/9348108/c6068104-d653-4a54-bf80-6fe3c95e5ece)
