### PR TITLE
ci: remove 'update the homebrew tap' step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,19 +98,6 @@ jobs:
         with:
           url: https://vps.itsmeow.dev/spicetify-update
           method: GET
-      - name: Update Homebrew tap
-        uses: mislav/bump-homebrew-formula-action@v3
-        if: ${{ !contains(github.ref, '-') }}
-        with:
-          formula-name: spicetify-cli
-          formula-path: spicetify-cli.rb
-          homebrew-tap: spicetify/homebrew-tap
-          base-branch: main
-          download-url: https://github.com/spicetify/spicetify-cli/archive/${{ github.ref_name }}.tar.gz
-          commit-message: |
-            feat: {{version}} release
-        env:
-          COMMITTER_TOKEN: ${{ secrets.SPICETIFY_GITHUB_TOKEN }}
       - name: Update Winget package
         uses: vedantmgoyal2009/winget-releaser@v2
         with:


### PR DESCRIPTION
Spicetify has its own formula in `homebrew-core` repo, https://github.com/Homebrew/homebrew-core/blob/master/Formula/s/spicetify-cli.rb, so we don't really need to maintain our own tap for this. Anyone that uses our tap should switch to core tap

thanks to https://github.com/khanhas/homebrew-tap/pull/14, otherwise I wouldn't know that's the case tbh. 
We **should also archive** https://github.com/spicetify/homebrew-tap after merging this pull request