### PR TITLE
fix(styledClassName): add another key and exclude one

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -989,7 +989,7 @@ Spicetify._getStyledClassName = (args, component) => {
 		}
 	}
 
-	const excludedKeys = ["children", "className", "style", "dir", "key", "ref", "as", "$autoMirror", "$isInteractive", "$hasFocus", ""];
+	const excludedKeys = ["children", "className", "style", "dir", "key", "ref", "as", "$autoMirror", "$hasFocus", ""];
 	const excludedPrefix = ["aria-"];
 
 	const childrenProps = ["iconLeading", "iconTrailing", "iconOnly"];
@@ -1003,7 +1003,8 @@ Spicetify._getStyledClassName = (args, component) => {
 	for (const key of booleanKeys) {
 		if (excludedKeys.includes(key)) continue;
 		if (excludedPrefix.some(prefix => key.startsWith(prefix))) continue;
-		className += `-${key}`;
+		const sanitizedKey = key.startsWith("$") ? key.slice(1) : key;
+		className += `-${sanitizedKey}`;
 	}
 
 	const customEntries = Object.entries(element).filter(

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -965,7 +965,8 @@ Spicetify._getStyledClassName = (args, component) => {
 		"position",
 		"data-encore-id",
 		"$size",
-		"$iconColor"
+		"$iconColor",
+		"$variant"
 	];
 	const customKeys = ["padding", "blocksize"];
 
@@ -988,7 +989,7 @@ Spicetify._getStyledClassName = (args, component) => {
 		}
 	}
 
-	const excludedKeys = ["children", "className", "style", "dir", "key", "ref", "as", "$autoMirror", ""];
+	const excludedKeys = ["children", "className", "style", "dir", "key", "ref", "as", "$autoMirror", "$isInteractive", "$hasFocus", ""];
 	const excludedPrefix = ["aria-"];
 
 	const childrenProps = ["iconLeading", "iconTrailing", "iconOnly"];
@@ -1010,7 +1011,8 @@ Spicetify._getStyledClassName = (args, component) => {
 	);
 
 	for (const [key, value] of customEntries) {
-		className += `-${key}_${value.replace(/[^a-z0-9]/gi, "_")}`;
+		const sanitizedKey = key.startsWith("$") ? key.slice(1) : key;
+		className += `-${sanitizedKey}_${value.replace(/[^a-z0-9]/gi, "_")}`;
 	}
 
 	return className;


### PR DESCRIPTION
Fixes this for `1.2.33` and higher:
![image](https://github.com/spicetify/spicetify-cli/assets/9348108/cd63812d-27b5-42b1-ac21-8041834463ca)
after the fix:
![image](https://github.com/spicetify/spicetify-cli/assets/9348108/52a86137-6cdc-45cd-a393-51f99ec7819b)
