### PR TITLE
fix: make various changes to global navbar

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1221,7 +1221,7 @@
 	"Gw7E7MkWci1ttQhb4EK0": "npv-exitFullScreenButton-button",
 	"KAq2kDjXj2VS4eXrFL4i": "main-userWidget-box",
 	"LKfKy7bXKmlkMEANVJMS": "main-avatar-avatar",
-	"nRSfonXHVr6utXYgk2Ui": "main-globalNav-mainNav",
+	"nRSfonXHVr6utXYgk2Ui": "Root__globalNav",
 	"Z6t_8rA6LOBrX3huqRJG": "main-globalNav-historyButtonsContainer",
 	"VizXsWMIuNfKGN5pMyox": "main-globalNav-historyButtons",
 	"rBX1EWVZ2EaPwP4y1Gkd": "main-globalNav-icon",
@@ -1231,6 +1231,9 @@
 	"PvsV2JgJRDME1vDn6IJL": "main-globalNav-searchInputSection",
 	"fksI89zEXwqKWm1O6sJm": "main-globalNav-searchInputContainer",
 	"OomFKn3bsxs5JfNUoWhz": "main-globalNav-buddyFeed",
+	"bWBqSiXEceAj1SnzqusU": "main-globalNav-navLink",
+	"voA9ZoTTlPFyLpckNw3S": "main-globalNav-navLinkActive",
+	"cUwQnQoE3OqXqSYLT0hv": "link-subtle",
 	"rQ6LXqVlEOGZdGIG0LgP": "main-contextMenu-menuItem",
 	"mWj8N7D_OlsbDgtQx5GW": "main-contextMenu-menuItemButton",
 	"NbcaczStd8vD2rHWwaKv": "main-contextMenu-menu"

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1972,20 +1972,22 @@ Spicetify.Topbar = (() => {
 			this.label = label;
 
 			this.element.appendChild(this.button);
-			const historyButtons = document.querySelector(".main-globalNav-historyButtons");
+			const globalHistoryButtons = document.querySelector(".main-globalNav-historyButtons");
 			if (isRight) {
 				this.button.classList.add("encore-over-media-set", "main-topBar-buddyFeed");
-				if (historyButtons) this.button.classList.add("main-globalNav-buddyFeed");
+				if (globalHistoryButtons) this.button.classList.add("main-globalNav-buddyFeed");
+
 				rightButtonsStash.add(this.element);
 				rightContainer?.prepend(this.element);
 			} else {
 				this.button.classList.add("main-topBar-button");
-				if (historyButtons) {
+				if (globalHistoryButtons) {
 					this.button.classList.add(
 						"main-globalNav-icon",
 						"Button-medium-medium-buttonTertiary-iconOnly-condensed-disabled-useBrowserDefaultFocusStyle"
 					);
 				}
+
 				leftButtonsStash.add(this.element);
 				leftContainer?.append(this.element);
 			}

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1815,7 +1815,7 @@ Spicetify._renderNavLinks = (list, isTouchScreenUi) => {
 
 	const style = document.createElement("style");
 	style.innerHTML = `
-	:root {
+:root {
     --max-custom-navlink-count: 4;
 }
 

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1981,12 +1981,8 @@ Spicetify.Topbar = (() => {
 				rightContainer?.prepend(this.element);
 			} else {
 				this.button.classList.add("main-topBar-button");
-				if (globalHistoryButtons) {
-					this.button.classList.add(
-						"main-globalNav-icon",
-						"Button-medium-medium-buttonTertiary-iconOnly-condensed-disabled-useBrowserDefaultFocusStyle"
-					);
-				}
+				if (globalHistoryButtons)
+					this.button.classList.add("main-globalNav-icon", "Button-medium-medium-buttonTertiary-iconOnly-condensed-useBrowserDefaultFocusStyle");
 
 				leftButtonsStash.add(this.element);
 				leftContainer?.append(this.element);
@@ -2037,21 +2033,15 @@ Spicetify.Topbar = (() => {
 			setTimeout(waitForTopbarMounted, 100);
 			return;
 		}
+		if (globalHistoryButtons) globalHistoryButtons.style = "gap: 4px; padding-inline: 4px 4px;";
 		for (const button of leftButtonsStash) {
 			if (button.parentNode) button.parentNode.removeChild(button);
 
 			const buttonElement = button.querySelector("button");
-			if (globalHistoryButtons) {
-				buttonElement.classList.add(
-					"main-globalNav-icon",
-					"Button-medium-medium-buttonTertiary-iconOnly-condensed-disabled-useBrowserDefaultFocusStyle"
-				);
-			} else {
-				buttonElement.classList.remove(
-					"main-globalNav-icon",
-					"Button-medium-medium-buttonTertiary-iconOnly-condensed-disabled-useBrowserDefaultFocusStyle"
-				);
-			}
+			if (globalHistoryButtons)
+				buttonElement.classList.add("main-globalNav-icon", "Button-medium-medium-buttonTertiary-iconOnly-condensed-useBrowserDefaultFocusStyle");
+			else
+				buttonElement.classList.remove("main-globalNav-icon", "Button-medium-medium-buttonTertiary-iconOnly-condensed-useBrowserDefaultFocusStyle");
 		}
 		leftContainer.append(...leftButtonsStash);
 		for (const button of rightButtonsStash) {

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1839,7 +1839,7 @@ Spicetify._renderNavLinks = (list, isTouchScreenUi) => {
 	`;
 	document.head.appendChild(style);
 
-	const touchScreenUi = element =>
+	const wrapScrollableContainer = element =>
 		Spicetify.React.createElement(
 			"div",
 			{ className: "custom-navlinks-scrollable_container" },
@@ -1853,15 +1853,7 @@ Spicetify._renderNavLinks = (list, isTouchScreenUi) => {
 			registered.map(NavLinkElement => Spicetify.React.createElement(NavLink, NavLinkElement, null))
 		);
 
-	return isTouchScreenUi
-		? touchScreenUi(
-				Spicetify.React.createElement(
-					navLinkFactoryCtx.Provider,
-					{ value: navLinkFactory },
-					registered.map(NavLinkElement => Spicetify.React.createElement(NavLink, NavLinkElement, null))
-				)
-			)
-		: NavLinks();
+	return isTouchScreenUi ? wrapScrollableContainer(NavLinks()) : NavLinks();
 };
 
 const NavLink = ({ appProper, appRoutePath, icon, activeIcon }) => {

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1844,7 +1844,8 @@ const NavLinkSidebar = ({ appProper, appRoutePath, createIcon, isActive }) => {
 					"aria-label": appProper
 				},
 				createIcon(),
-				!isSidebarCollapsed && Spicetify.React.createElement(Spicetify.ReactComponent.TextComponent, { variant: "bodyMediumBold" }, appProper)
+				!isSidebarCollapsed &&
+					Spicetify.React.createElement(Spicetify.ReactComponent.TextComponent, { variant: "bodyMediumBold", weight: "bold" }, appProper)
 			)
 		)
 	);
@@ -1972,15 +1973,18 @@ Spicetify.Topbar = (() => {
 
 			this.element.appendChild(this.button);
 			if (isRight) {
-				this.button.classList.add("encore-over-media-set", "main-topBar-buddyFeed", "main-globalNav-buddyFeed");
+				this.button.classList.add("encore-over-media-set", "main-topBar-buddyFeed");
+				if (document.querySelector(".main-globalNav-historyButtons")) this.button.classList.add("main-globalNav-buddyFeed");
 				rightButtonsStash.add(this.element);
 				rightContainer?.prepend(this.element);
 			} else {
-				this.button.classList.add(
-					"main-topBar-button",
-					"main-globalNav-icon",
-					"Button-medium-medium-buttonTertiary-iconOnly-condensed-disabled-useBrowserDefaultFocusStyle"
-				);
+				this.button.classList.add("main-topBar-button");
+				if (document.querySelector(".main-globalNav-historyButtons")) {
+					this.button.classList.add(
+						"main-globalNav-icon",
+						"Button-medium-medium-buttonTertiary-iconOnly-condensed-disabled-useBrowserDefaultFocusStyle"
+					);
+				}
 				leftButtonsStash.add(this.element);
 				leftContainer?.append(this.element);
 			}
@@ -2031,10 +2035,27 @@ Spicetify.Topbar = (() => {
 		}
 		for (const button of leftButtonsStash) {
 			if (button.parentNode) button.parentNode.removeChild(button);
+
+			const buttonElement = button.querySelector("button");
+			if (document.querySelector(".main-globalNav-historyButtons")) {
+				buttonElement.classList.add(
+					"main-globalNav-icon",
+					"Button-medium-medium-buttonTertiary-iconOnly-condensed-disabled-useBrowserDefaultFocusStyle"
+				);
+			} else {
+				buttonElement.classList.remove(
+					"main-globalNav-icon",
+					"Button-medium-medium-buttonTertiary-iconOnly-condensed-disabled-useBrowserDefaultFocusStyle"
+				);
+			}
 		}
 		leftContainer.append(...leftButtonsStash);
 		for (const button of rightButtonsStash) {
 			if (button.parentNode) button.parentNode.removeChild(button);
+
+			const buttonElement = button.querySelector("button");
+			if (document.querySelector(".main-globalNav-historyButtons")) buttonElement.classList.add("main-globalNav-buddyFeed");
+			else buttonElement.classList.remove("main-globalNav-buddyFeed");
 		}
 		rightContainer.prepend(...rightButtonsStash);
 	}

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1972,11 +1972,15 @@ Spicetify.Topbar = (() => {
 
 			this.element.appendChild(this.button);
 			if (isRight) {
-				this.button.classList.add("encore-over-media-set", "main-topBar-buddyFeed");
+				this.button.classList.add("encore-over-media-set", "main-topBar-buddyFeed", "main-globalNav-buddyFeed");
 				rightButtonsStash.add(this.element);
 				rightContainer?.prepend(this.element);
 			} else {
-				this.button.classList.add("main-topBar-button");
+				this.button.classList.add(
+					"main-topBar-button",
+					"main-globalNav-icon",
+					"Button-medium-medium-buttonTertiary-iconOnly-condensed-disabled-useBrowserDefaultFocusStyle"
+				);
 				leftButtonsStash.add(this.element);
 				leftContainer?.append(this.element);
 			}
@@ -2019,7 +2023,7 @@ Spicetify.Topbar = (() => {
 	}
 
 	function waitForTopbarMounted() {
-		leftContainer = document.querySelector(".main-topBar-historyButtons");
+		leftContainer = document.querySelector(".main-topBar-historyButtons") ?? document.querySelector(".main-globalNav-historyButtons");
 		rightContainer = document.querySelector(".main-actionButtons");
 		if (!leftContainer || !rightContainer) {
 			setTimeout(waitForTopbarMounted, 100);

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1972,14 +1972,15 @@ Spicetify.Topbar = (() => {
 			this.label = label;
 
 			this.element.appendChild(this.button);
+			const historyButtons = document.querySelector(".main-globalNav-historyButtons");
 			if (isRight) {
 				this.button.classList.add("encore-over-media-set", "main-topBar-buddyFeed");
-				if (document.querySelector(".main-globalNav-historyButtons")) this.button.classList.add("main-globalNav-buddyFeed");
+				if (historyButtons) this.button.classList.add("main-globalNav-buddyFeed");
 				rightButtonsStash.add(this.element);
 				rightContainer?.prepend(this.element);
 			} else {
 				this.button.classList.add("main-topBar-button");
-				if (document.querySelector(".main-globalNav-historyButtons")) {
+				if (historyButtons) {
 					this.button.classList.add(
 						"main-globalNav-icon",
 						"Button-medium-medium-buttonTertiary-iconOnly-condensed-disabled-useBrowserDefaultFocusStyle"
@@ -2027,7 +2028,8 @@ Spicetify.Topbar = (() => {
 	}
 
 	function waitForTopbarMounted() {
-		leftContainer = document.querySelector(".main-topBar-historyButtons") ?? document.querySelector(".main-globalNav-historyButtons");
+		const globalHistoryButtons = document.querySelector(".main-globalNav-historyButtons");
+		leftContainer = document.querySelector(".main-topBar-historyButtons") ?? globalHistoryButtons;
 		rightContainer = document.querySelector(".main-actionButtons");
 		if (!leftContainer || !rightContainer) {
 			setTimeout(waitForTopbarMounted, 100);
@@ -2037,7 +2039,7 @@ Spicetify.Topbar = (() => {
 			if (button.parentNode) button.parentNode.removeChild(button);
 
 			const buttonElement = button.querySelector("button");
-			if (document.querySelector(".main-globalNav-historyButtons")) {
+			if (globalHistoryButtons) {
 				buttonElement.classList.add(
 					"main-globalNav-icon",
 					"Button-medium-medium-buttonTertiary-iconOnly-condensed-disabled-useBrowserDefaultFocusStyle"
@@ -2054,7 +2056,7 @@ Spicetify.Topbar = (() => {
 			if (button.parentNode) button.parentNode.removeChild(button);
 
 			const buttonElement = button.querySelector("button");
-			if (document.querySelector(".main-globalNav-historyButtons")) buttonElement.classList.add("main-globalNav-buddyFeed");
+			if (globalHistoryButtons) buttonElement.classList.add("main-globalNav-buddyFeed");
 			else buttonElement.classList.remove("main-globalNav-buddyFeed");
 		}
 		rightContainer.prepend(...rightButtonsStash);

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1816,12 +1816,12 @@ Spicetify._renderNavLinks = (list, isTouchScreenUi) => {
 	const style = document.createElement("style");
 	style.innerHTML = `
 :root {
-    --max-custom-navlink-count: 4;
+  --max-custom-navlink-count: 4;
 }
 
 .custom-navlinks-scrollable_container {
-    max-width: calc(48px * var(--max-custom-navlink-count) + 8px * (var(--max-custom-navlink-count) - 1));
-    -webkit-app-region: no-drag;
+  max-width: calc(48px * var(--max-custom-navlink-count) + 8px * (var(--max-custom-navlink-count) - 1));
+  -webkit-app-region: no-drag;
 }
 
 .custom-navlinks-scrollable_container div[role="presentation"] > *:not(:last-child) {
@@ -1834,24 +1834,34 @@ Spicetify._renderNavLinks = (list, isTouchScreenUi) => {
 }
 
 .custom-navlink {
-    -webkit-app-region: unset;
+  -webkit-app-region: unset;
 }
 	`;
 	document.head.appendChild(style);
 
-	return Spicetify.React.createElement(
-		"div",
-		{ className: "custom-navlinks-scrollable_container" },
+	const touchScreenUi = element =>
 		Spicetify.React.createElement(
-			Spicetify.ReactComponent.ScrollableContainer,
-			null,
-			Spicetify.React.createElement(
-				navLinkFactoryCtx.Provider,
-				{ value: navLinkFactory },
-				registered.map(NavLinkElement => Spicetify.React.createElement(NavLink, NavLinkElement, null))
+			"div",
+			{ className: "custom-navlinks-scrollable_container" },
+			Spicetify.React.createElement(Spicetify.ReactComponent.ScrollableContainer, null, element)
+		);
+
+	const NavLinks = () =>
+		Spicetify.React.createElement(
+			navLinkFactoryCtx.Provider,
+			{ value: navLinkFactory },
+			registered.map(NavLinkElement => Spicetify.React.createElement(NavLink, NavLinkElement, null))
+		);
+
+	return isTouchScreenUi
+		? touchScreenUi(
+				Spicetify.React.createElement(
+					navLinkFactoryCtx.Provider,
+					{ value: navLinkFactory },
+					registered.map(NavLinkElement => Spicetify.React.createElement(NavLink, NavLinkElement, null))
+				)
 			)
-		)
-	);
+		: NavLinks();
 };
 
 const NavLink = ({ appProper, appRoutePath, icon, activeIcon }) => {

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -345,11 +345,11 @@ func insertNavLink(str string, appNameArray string) string {
 		return str
 	}
 	index := findMatchingPos(str, loc[0], 1, []string{"(", ")"}, 1)
-	str = str[:index] + ",Spicetify._renderNavLinks([" + appNameArray + "], false)," + str[index:]
+	str = fmt.Sprintf(`%s,Spicetify._renderNavLinks([%s], false),%s`, str[:index], appNameArray, str[index:])
 
 	// Global Navbar
 	utils.ReplaceOnce(&str, `(,[a-zA-Z_\$][\w\$]*===(?:[a-zA-Z_\$][\w\$]*\.){2}HOME_NEXT_TO_NAVIGATION&&.+?)\]`, func(submatches ...string) string {
-		return submatches[1] + ",Spicetify._renderNavLinks([" + appNameArray + "], true)]"
+		return fmt.Sprintf(`%s,Spicetify._renderNavLinks([%s], true)]`, submatches[1], appNameArray)
 	})
 
 	return str

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -345,11 +345,11 @@ func insertNavLink(str string, appNameArray string) string {
 		return str
 	}
 	index := findMatchingPos(str, loc[0], 1, []string{"(", ")"}, 1)
-	str = fmt.Sprintf(`%s,Spicetify._renderNavLinks([%s], false),%s`, str[:index], appNameArray, str[index:])
+	str = fmt.Sprintf("%s,Spicetify._renderNavLinks([%s], false),%s", str[:index], appNameArray, str[index:])
 
 	// Global Navbar
 	utils.ReplaceOnce(&str, `(,[a-zA-Z_\$][\w\$]*===(?:[a-zA-Z_\$][\w\$]*\.){2}HOME_NEXT_TO_NAVIGATION&&.+?)\]`, func(submatches ...string) string {
-		return fmt.Sprintf(`%s,Spicetify._renderNavLinks([%s], true)]`, submatches[1], appNameArray)
+		return fmt.Sprintf("%s,Spicetify._renderNavLinks([%s], true)]", submatches[1], appNameArray)
 	})
 
 	return str

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -145,7 +145,7 @@ func Start(version string, extractedAppsPath string, flags Flag) {
 					tags += "<!-- spicetify helpers -->\n"
 				}
 
-				utils.Replace(&content, `<body>`, func(submatches ...string) string {
+				utils.Replace(&content, `<body(\sclass="[^"]*")?>`, func(submatches ...string) string {
 					return fmt.Sprintf("%s\n%s", submatches[0], tags)
 				})
 

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -359,6 +359,9 @@ func disableLogging(input string) string {
 	utils.Replace(&input, `key:"createLoggingParams",value:function\([^)]*\)\s*\{`, func(submatches ...string) string {
 		return fmt.Sprintf("%sreturn {interactionIds:null,pageInstanceIds:null};", submatches[0])
 	})
+	utils.Replace(&input, `key:"addEventsToESSData",value:function\([^)]*\)\s*\{`, func(submatches ...string) string {
+		return fmt.Sprintf("%sreturn;", submatches[0])
+	})
 
 	utils.Replace(&input, `registerEventListeners\([^)]*\)\s*\{`, func(submatches ...string) string {
 		return fmt.Sprintf("%sreturn;", submatches[0])
@@ -392,6 +395,9 @@ func disableLogging(input string) string {
 	})
 	utils.Replace(&input, `createLoggingParams\([^)]*\)\s*\{`, func(submatches ...string) string {
 		return fmt.Sprintf("%sreturn {interactionIds:null,pageInstanceIds:null};", submatches[0])
+	})
+	utils.Replace(&input, `addEventsToESSData\([^)]*\)\s*\{`, func(submatches ...string) string {
+		return fmt.Sprintf("%sreturn;", submatches[0])
 	})
 
 	return input


### PR DESCRIPTION
This pull request:
- adds topbar buttons on the left back
- adds scrollable container on navlinks so they don't overflow with other ui elements
- maps css
- adds polyfill for `1.2.13` -> `1.2.23` (chromium <117) for `Object.groupBy`
- adds old `classnames` regex back for `1.2.13`
- fixes adding jsHelpers to body tag in `1.2.34`