### PR TITLE
ci(release): add support for windows `arm64`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         run: echo "IS_UNIX=${{ matrix.os != 'windows' && matrix.arch != '386' }}" >> $GITHUB_ENV
 
       - name: Is Windows Platform
-        run: echo "IS_WIN=${{ matrix.os == 'windows' && matrix.arch != 'arm64' }}" >> $GITHUB_ENV
+        run: echo "IS_WIN=${{ matrix.os == 'windows' }}" >> $GITHUB_ENV
 
       - name: Setup Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
i don't kinda understand why we don't support windows arm64. Spotify supports it, so why won't we?