### PR TITLE
fix(new-releases): update `viewportSelector` for `1.2.34` and higher

### DIFF
--- a/CustomApps/new-releases/index.js
+++ b/CustomApps/new-releases/index.js
@@ -70,7 +70,7 @@ let separatedByDate = {};
 let dateList = [];
 
 class Grid extends react.Component {
-	viewportSelector = "#main .os-viewport";
+	viewportSelector = document.querySelector("#main .os-viewport") ? "#main .os-viewport" : "#main .main-view-container__scroll-node";
 
 	constructor() {
 		super();


### PR DESCRIPTION
i forgot to replace it in `new-releases`