### PR TITLE
fix: do not replace color variables in mini player css

### DIFF
--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -161,6 +161,11 @@ func Start(version string, extractedAppsPath string, flags Flag) {
 func StartCSS(extractedAppsPath string) {
 	appPath := filepath.Join(extractedAppsPath, "xpui")
 	filepath.Walk(appPath, func(path string, info os.FileInfo, err error) error {
+		// temp so text won't be black ._.
+		if info.Name() == "pip-mini-player.css" {
+			return nil
+		}
+
 		if filepath.Ext(info.Name()) == ".css" {
 			utils.ModifyFile(path, colorVariableReplace)
 		}


### PR DESCRIPTION
Fixes https://github.com/JulienMaille/spicetify-dynamic-theme/issues/68