### PR TITLE
fix(getStyledClassName): add `$semanticColor` to included keys

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -990,7 +990,8 @@ Spicetify._getStyledClassName = (args, component) => {
 		"data-encore-id",
 		"$size",
 		"$iconColor",
-		"$variant"
+		"$variant",
+		"$semanticColor"
 	];
 	const customKeys = ["padding", "blocksize"];
 
@@ -1025,6 +1026,7 @@ Spicetify._getStyledClassName = (args, component) => {
 	const booleanKeys = Object.keys(element).filter(key => typeof element[key] === "boolean" && element[key]);
 
 	for (const key of booleanKeys) {
+		console.log(key);
 		if (excludedKeys.includes(key)) continue;
 		if (excludedPrefix.some(prefix => key.startsWith(prefix))) continue;
 		const sanitizedKey = key.startsWith("$") ? key.slice(1) : key;

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1026,7 +1026,6 @@ Spicetify._getStyledClassName = (args, component) => {
 	const booleanKeys = Object.keys(element).filter(key => typeof element[key] === "boolean" && element[key]);
 
 	for (const key of booleanKeys) {
-		console.log(key);
 		if (excludedKeys.includes(key)) continue;
 		if (excludedPrefix.some(prefix => key.startsWith(prefix))) continue;
 		const sanitizedKey = key.startsWith("$") ? key.slice(1) : key;


### PR DESCRIPTION
Fixes this green color text on every component on `1.2.35`
![image](https://github.com/spicetify/spicetify-cli/assets/9348108/26de1ef5-3e34-499c-8875-367bde7a3991)
