### PR TITLE
fix: make `IconComponent` usable again

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1236,5 +1236,14 @@
 	"cUwQnQoE3OqXqSYLT0hv": "link-subtle",
 	"rQ6LXqVlEOGZdGIG0LgP": "main-contextMenu-menuItem",
 	"mWj8N7D_OlsbDgtQx5GW": "main-contextMenu-menuItemButton",
-	"NbcaczStd8vD2rHWwaKv": "main-contextMenu-menu"
+	"NbcaczStd8vD2rHWwaKv": "main-contextMenu-menu",
+	"ETjtwGvAB4lRVqSzm8nA": "main-globalNav-navLinkActive",
+	"dIfr5oVr5kotAi0HsIsW": "main-globalNav-link-icon",
+	"tDFP1X98EgqQIPaumxRt": "main-globalNav-searchInputSection",
+	"W9VXOkC43GP_7ULClgxQ": "main-globalNav-searchInputContainer",
+	"wp7mZFPzV7Qmo51F0NA_": "Root__globalNav",
+	"pIM9jg__39NIpOvXG89b": "main-globalNav-historyButtonsContainer",
+	"gj5VcIUC9oD2p4BsxzGE": "main-globalNav-searchSection",
+	"lj0eGI6WEtfxFX7irC03": "main-globalNav-searchContainer",
+	"VUXMMFKWudUWE1kIXZoS": "link-subtle"
 }

--- a/spicetify.go
+++ b/spicetify.go
@@ -51,7 +51,7 @@ func init() {
 
 	// Separates flags and commands
 	for _, v := range os.Args[1:] {
-		if v[0] == '-' && v != "-1" {
+		if len(v) > 0 && v[0] == '-' && v != "-1" {
 			if v[1] != '-' && len(v) > 2 {
 				for _, char := range v[1:] {
 					flags = append(flags, "-"+string(char))
@@ -356,17 +356,17 @@ path                Prints path of Spotify's executable, userdata, and more.
 
                     4. Toggle focus with flags:
                     spicetify path <flag> <option>
-	
+
                     Available Flags and Options:
                     "-e" (for extensions),
                     options: root, extension name, blank for all.
-					
+
                     "-a" (for custom apps),
                     options: root, <app-name>, blank for all.
-					
+
                     "-s" (for the active theme)
                     options: root, folder, color, css, js, assets, blank for all.
-					
+
                     "-c" (for config.ini)
                     options: N/A.
 

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -122,6 +122,12 @@ func arrayType(section *ini.Section, field, value string) {
 		utils.Fatal(err)
 	}
 
+	if strings.TrimSpace(value) == "" {
+		key.SetValue("")
+		changeSuccess(field, "")
+		return
+	}
+
 	allExts := make(map[string]bool)
 	for _, v := range key.Strings("|") {
 		allExts[v] = true

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -616,13 +616,6 @@ func exposeAPIs_vendor(input string) string {
 			return fmt.Sprintf("Spicetify._fontStyle=%s", submatches[0])
 		})
 
-	utils.ReplaceOnce(
-		&input,
-		`=(?:\(\w\)=>|function\(\w\)\{)\w+ ?\w=\w\.iconSize`,
-		func(submatches ...string) string {
-			return fmt.Sprintf("=Spicetify.ReactComponent.IconComponent%s", submatches[0])
-		})
-
 	// Mapping styled-components classes
 	utils.Replace(
 		&input,


### PR DESCRIPTION
- fixes `IconComponent` on `1.2.36`
- maps css for `1.2.36`
- fixes styling on `1.2.36` (`_getStyledClassName`)
- fixes config cmd: when provided value is empty, it should clear the field
- fixes check for `value`, to not cause panic when it's empty