### PR TITLE
fix(getStyledClassName): add `paddingBottom` back to `customExactKeys`

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1001,7 +1001,7 @@ Spicetify._getStyledClassName = (args, component) => {
 		"$iconSize"
 	];
 	const customKeys = ["blocksize"];
-	const customExactKeys = ["$padding", "padding"];
+	const customExactKeys = ["$padding", "$paddingBottom", "paddingBottom", "padding"];
 
 	const element = Array.from(args).find(
 		e =>


### PR DESCRIPTION
THIS wasn't needed for `1.2.36` ._.