### PR TITLE
chore(wrapper): remove additional graphql getters

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -2042,18 +2042,6 @@ declare namespace Spicetify {
 		 */
 		const Definitions: Record<Query | string, any>;
 		/**
-		 * GraphQL query definitions. Subset of `Definitions` that are used as query requests.
-		 */
-		const QueryDefinitions: Record<Query | string, any>;
-		/**
-		 * GraphQL mutation definitions. Subset of `Definitions` that are used as mutation requests.
-		 */
-		const MutationDefinitions: Record<Query | string, any>;
-		/**
-		 * GraphQL response definitions. Subset of `Definitions` that are used as response types.
-		 */
-		const ResponseDefinitions: Record<Query | string, any>;
-		/**
 		 * Sends a GraphQL query to Spotify.
 		 * @description A preinitialized version of `Spicetify.GraphQL.Handler` using current context.
 		 * @param query Query to send

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -515,25 +515,6 @@ window.Spicetify = {
 			get Request() {
 				return Spicetify.Platform?.GraphQLLoader || Spicetify.GraphQL.Handler?.(Spicetify.GraphQL.Context);
 			},
-			get QueryDefinitions() {
-				return Object.fromEntries(
-					Object.entries(Spicetify.GraphQL.Definitions).filter(([, value]) =>
-						value.definitions.some(def => def.kind === "OperationDefinition" && def.operation === "query")
-					)
-				);
-			},
-			get MutationDefinitions() {
-				return Object.fromEntries(
-					Object.entries(Spicetify.GraphQL.Definitions).filter(([, value]) =>
-						value.definitions.some(def => def.kind === "OperationDefinition" && def.operation === "mutation")
-					)
-				);
-			},
-			get ResponseDefinitions() {
-				return Object.fromEntries(
-					Object.entries(Spicetify.GraphQL.Definitions).filter(([, value]) => value.definitions.every(def => def.kind !== "OperationDefinition"))
-				);
-			},
 			Context: functionModules.find(m => m.toString().includes("subscription") && m.toString().includes("mutation")),
 			Handler: functionModules.find(m => m.toString().includes("GraphQL subscriptions are not supported"))
 		},


### PR DESCRIPTION
idk why this exists, it probably never worked after some update. just use `Spicetify.GraphQL.Definitions`