### PR TITLE
feat(wrapper/cards): re-add "Default" as `FeatureCard`

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -566,6 +566,9 @@ window.Spicetify = {
 			Toggle: functionModules.find(m => m.toString().includes("onSelected") && m.toString().includes('type:"checkbox"')),
 			Cards: {
 				Default: reactComponentsUI.Card,
+				FeatureCard: functionModules.find(
+					m => m.toString().includes("?highlight") && m.toString().includes("headerText") && m.toString().includes("imageContainer")
+				),
 				Hero: functionModules.find(m => m?.toString().includes('"herocard-click-handler"')),
 				CardImage: reactComponentsUI.CardImage,
 				...Object.fromEntries(cards)


### PR DESCRIPTION
This matches the type of card better, `Default` is a barebone card (which is exposed via `reactComponentsUI.Card`), but the `Default` card we had before is more as of `FeatureCard` that's why I'm re-adding it as this one

Fixes https://github.com/Bergbok/Spicetify-Creations/issues/6
Fixes https://github.com/harbassan/spicetify-apps/issues/87
however this requires **changing _Default_ export to _FeatureCard_**