### PR TITLE
fix(keyboardShortcut): correctly call functions for volume

### DIFF
--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -55,8 +55,8 @@
 		"ctrl+right": { callback: () => Spicetify.Player.next() },
 
 		// CTRL + Arrow Up Increase Volume CTRL + Arrow Down Decrease Volume
-		"ctrl+up": { callback: () => Spicetify.Player.setVolume(Spicetify.Player.getVolume() - 0.05) },
-		"ctrl+down": { callback: () => Spicetify.Player.setVolume(Spicetify.Player.getVolume() + 0.05) },
+		"ctrl+up": { callback: () => Spicetify.Player.setVolume(Spicetify.Player.getVolume() + 0.05) },
+		"ctrl+down": { callback: () => Spicetify.Player.setVolume(Spicetify.Player.getVolume() - 0.05) },
 
 		// Activate Vim mode and set cancel key to 'ESCAPE'
 		f: {


### PR DESCRIPTION
changed the keybinding ctrl+up to increase the volume instead of decrease