### PR TITLE
feat(keyboard shortcut): Vimium-Style Keybind Update

### DIFF
--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -133,7 +133,17 @@
 		const app = focusOnApp();
 		app.scroll(0, position === 0 ? 0 : app.scrollHeight);
 	}
-
+	
+	function scrollHalfPage(direction /* 1 | -1 */) {
+  		const app = focusOnApp();
+  		if (!app) return;
+  		const delta     = Math.floor(app.clientHeight / 2) * direction;
+  		const targetTop = Math.max(0,
+    		Math.min(app.scrollTop + delta, app.scrollHeight)
+  		);
+  		app.scroll(0, targetTop);
+	}
+	
 	/**
 	 * @returns {number | undefined}
 	 * @param {NodeListOf<Element>} allItems


### PR DESCRIPTION


## Added Vim Inspired Keys
- `shift+j`, `shift+k`: Rotate through sidebar
- `d`: Scroll down (half-page)
- `u`: Scroll up (half-page)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts: press “d” to scroll down half a page and “u” to scroll up half a page.
  * Added Shift+J and Shift+K to rotate through the sidebar items.
  * Existing keyboard shortcuts remain unchanged and continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->