### PR TITLE
fix(uri): hook correct chunk

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -997,7 +997,7 @@ applyScrollingFix();
 				// Avoid creating 2 arrays of the same values
 				try {
 					const values = Object.values(m);
-					return values.some((m) => typeof m === "function") && values.some((m) => m?.AD);
+					return values.some((m) => typeof m === "function") && values.some((m) => m?.PLAYLIST_V2);
 				} catch {
 					return false;
 				}
@@ -1005,7 +1005,7 @@ applyScrollingFix();
 		const URIModules = Object.values(URIChunk);
 
 		// URI.Type
-		Spicetify.URI.Type = URIModules.find((m) => m?.AD);
+		Spicetify.URI.Type = URIModules.find((m) => m?.PLAYLIST_V2);
 
 		// Parse functions
 		Spicetify.URI.from = URIModules.find((m) => typeof m === "function" && m.toString().includes("allowedTypes"));


### PR DESCRIPTION
AD captures the wrong chunk on 1.2.72.435 Tested on 1.2.14.1149 which is lowest supported spotify version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with recent app versions by updating how playlist URIs are detected.
  * Fixed intermittent failures when opening or navigating to playlists.
  * Increased reliability of features that depend on playlist links, reducing errors and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->