### PR TITLE
fix: use exact match with pkill to terminate Spotify

### DIFF
--- a/src/cmd/restart.go
+++ b/src/cmd/restart.go
@@ -24,8 +24,8 @@ func SpotifyKill() {
 			exec.Command("pkill", "-x", "spotify").Run()
 		}
 	case "darwin":
-		isRunning := exec.Command("pgrep", "-x", "Spotify")
-		_, err := isRunning.Output()
+		isRunning := exec.Command("sh", "-c", "ps aux | grep 'Spotify' | grep -v grep")
+		_, err := isRunning.CombinedOutput()
 		if err == nil {
 			exec.Command("pkill", "-x", "Spotify").Run()
 		}


### PR DESCRIPTION
Use exact match as it now kills apps like [spotify_player](https://github.com/aome510/spotify-player) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restart reliability on macOS and Linux by matching the exact Spotify process name to avoid terminating similarly named processes.
  * Reduces accidental shutdowns and makes restart flows more predictable.
  * No behavioral changes on Windows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->