### PR TITLE
fix(lyrics-plus): fix issue with non-standard translations from Musixmatch providers

### DIFF
--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -129,7 +129,7 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation, musixmat
 			const musixmatchOptions = availableMusixmatchLanguages.reduce((acc, code) => {
 				let label = "";
 				try {
-					label = musixmatchDisplay.of(code) || code.toUpperCase();
+					label = musixmatchDisplay.of(code) ?? code.toUpperCase();
 				} catch (e) {
 					label = code.toUpperCase();
 				}


### PR DESCRIPTION
In the case of the non-standard translation of the Musixmatch provider, the `DisplayNames.of()` function would return an exception instead of `null` or `undefined`, causing Spotify to crash.

Therefore, we modified this to handle exceptions using a try-catch statement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved error handling in the translation menu so label resolution now uses a safe lookup path with an explicit fallback. Labels will reliably display and will fall back to an uppercase language code when resolution fails, preventing UI errors and missing labels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->