### PR TITLE
fix(apply): add support for Spotify `1.2.78`+

### DIFF
--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -158,7 +158,7 @@ func htmlMod(htmlPath string, flags Flag) {
 			customAppList += fmt.Sprintf(`"%s",`, app)
 		}
 
-		helperHTML += fmt.Sprintf(`<script defer>
+		helperHTML += fmt.Sprintf(`<script>
 			Spicetify.Config={};
 			Spicetify.Config["version"]="%s";
 			Spicetify.Config["current_theme"]="%s";
@@ -275,7 +275,7 @@ func insertCustomApp(jsPath string, flags Flag) {
 			// JSX pattern (1.2.78+): (0,S.jsx)(se.qh,{path:"/collection/*",element:...})
 			`(\([\w$\.,]+\))\(([\w\.]+),\{path:"/collection(?:/[\w\*]+)?",?(element|children)?`,
 			// createElement pattern: X.createElement(Y,{path:"/collection"...})
-			`(\[\w_\$][\w_\$\d]*(?:\(\))?\.createElement|\([\w$\.,]+\))\(([\w\.]+),\{path:"\/collection"(?:,(element|children)?[:.\w,{}()$/*"]+)?\}`,
+			`([\w_\$][\w_\$\d]*(?:\(\))?\.createElement|\([\w$\.,]+\))\(([\w\.]+),\{path:"\/collection"(?:,(element|children)?[:.\w,{}()$/*"]+)?\}`,
 		}
 
 		reactSymbs, matchedReactPattern := utils.FindSymbolWithPattern(

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -948,11 +948,10 @@ func exposeAPIs_main(input string) string {
 		},
 		{
 			Name:  "Spotify Image Snackbar Interface",
-			Regex: `(=)(\(\({[^}]*,\s*imageSrc)`,
+			Regex: `\(\({[^}]*,\s*imageSrc`,
 			Replacement: func(submatches ...string) string {
-				return fmt.Sprintf("%sSpicetify.Snackbar.enqueueImageSnackbar=%s", submatches[1], submatches[2])
+				return fmt.Sprintf("Spicetify.Snackbar.enqueueImageSnackbar=%s", submatches[0])
 			},
-			Once: true,
 		},
 		{
 			Name:  "React Component: Navigation for navLinks",


### PR DESCRIPTION
## Summary
- Add new regex patterns for async React lazy loading in Spotify 1.2.78+
- Fix Image Snackbar preprocessing to only match in assignment context

## Test plan
- [x] Tested on Windows with Spotify 1.2.78.418

Relates to #3601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Expanded support for additional React code patterns and variations.
  * Improved compatibility with diverse React code structures, including async and Promise-based implementations.
  * Enhanced reliability in code detection and transformation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->