### PR TITLE
fix: nested symlink resolution in spotify_path autodetection on linux

### DIFF
--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -285,7 +285,7 @@ func linuxApp() string {
 			}
 
 			if (stat.Mode() & os.ModeSymlink) != 0 {
-				binDest, err := os.Readlink(v)
+				binDest, err := filepath.EvalSymlinks(bin)
 
 				if err != nil {
 					continue


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes the following error when running Spicetify on NixOS:

```
error  Cannot detect Spotify location. Please manually set "spotify_path" in config-xpui.ini
```

Resolves #2681 
Resolves #1453

---

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed symbolic link resolution to properly evaluate links to their final destination paths. This enhancement improves the reliability and accuracy of file path handling when working with symbolic links throughout the application, while maintaining all existing error handling behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->