### PR TITLE
feat(config/linux): add `lpf-spotify-client` path

### DIFF
--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -307,7 +307,7 @@ func linuxApp() string {
 		"/opt/spotify/spotify-client/",
 		"/usr/share/spotify/",
 		"/usr/libexec/spotify/",
-		"/usr/share/spotify-client",
+		"/usr/share/spotify-client/",
 		"/var/lib/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
 		"$HOME/.local/share/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
 		"$HOME/.local/share/spotify-launcher/install/usr/share/spotify/",


### PR DESCRIPTION
Adds /usr/share/spotify-client to the list of Spotify installation search paths. This allows for the detection of the lpf-spotify-client package commonly used on Fedora Linux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Spotify client detection on Linux by expanding the locations scanned for installations to include an additional common path variant, increasing detection reliability across setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->