### PR TITLE
Log skipped videos in Auto Skip Video script

### DIFF
--- a/Extensions/autoSkipVideo.js
+++ b/Extensions/autoSkipVideo.js
@@ -7,12 +7,12 @@
 (function SkipVideo() {
 	Spicetify.Player.addEventListener("songchange", () => {
 		const data = Spicetify.Player.data || Spicetify.Queue;
+		const meta = data?.item?.metadata;
 		if (!data) return;
 
-		const meta = data.item.metadata;
-		// Ads are also video media type so I need to exclude them out.
-		if (meta["media.type"] === "video" && meta.is_advertisement !== "true") {
-			Spicetify.Player.next();
+		if (meta["media.type"] === "video" && !meta.is_advertisement) {
+            console.log(`Skipping video: ${meta.name} by ${meta.artist_name}`);
+            Spicetify.Player.next();
 		}
 	});
 })();


### PR DESCRIPTION
Added console logging to the Auto Skip Video script to show the name and artist of videos being skipped. This helps with debugging and verifying that the script is correctly identifying and skipping video tracks while excluding advertisements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of the auto-skip video feature with enhanced null-safety checks.
  * Refined video advertisement detection for more consistent behavior when skipping ads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->