### PR TITLE
Better offline.bnk detection (linux)

### DIFF
--- a/src/cmd/devtools.go
+++ b/src/cmd/devtools.go
@@ -28,18 +28,21 @@ func EnableDevTools() {
 		{
 			homePath := os.Getenv("HOME")
 			snapSpotifyHome := homePath + "/snap/spotify/common"
-			if _, err := os.Stat(snapSpotifyHome); err == nil {
-				homePath = snapSpotifyHome
-			}
-
+			snapOfflineBNK := snapSpotifyHome + "/cache/spotify/offline.bnk"
 			flatpakHome := homePath + "/.var/app/com.spotify.Client"
-			if _, err := os.Stat(flatpakHome); err == nil {
-				homePath = flatpakHome
-				filePath = homePath + "/cache/spotify/offline.bnk"
-			} else {
-				filePath = homePath + "/.cache/spotify/offline.bnk"
-			}
+			flatpakOfflineBNK := flatpakHome + "/cache/spotify/offline.bnk"
 
+			if _, err := os.Stat(snapOfflineBNK); err == nil {
+				homePath = snapSpotifyHome
+				filePath = snapOfflineBNK
+			} else {
+				if _, err := os.Stat(flatpakOfflineBNK); err == nil {
+					homePath = flatpakHome
+					filePath = flatpakOfflineBNK
+				} else {
+					filePath = homePath + "/.cache/spotify/offline.bnk"
+				}
+			}
 		}
 	case "darwin":
 		filePath = os.Getenv("HOME") + "/Library/Application Support/Spotify/PersistentCache/offline.bnk"


### PR DESCRIPTION
`devtools.go` didn't check whether the path actually has `offline.bnk` before using it as the `filePath`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline cache detection for Snap and Flatpak installations on Linux, ensuring the application correctly locates cached data in the appropriate package manager directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->