### PR TITLE
ci: update URL for AUR package update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Update AUR package
         uses: fjogeleit/http-request-action@master
         with:
-          url: https://vps.itsmeow.dev/spicetify-update
+          url: https://spicetify-update.itsmeow.dev/spicetify-update
           method: GET
       - name: Update Winget package
         uses: vedantmgoyal9/winget-releaser@main


### PR DESCRIPTION
Having a specific subdomain will make this flow more resistant to migrations as I can pick what server it is routed to at all times rather than being reliant on the system hostname.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package distribution endpoint for AUR releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->