### PR TITLE
fix: skip ExclusiveModeAPI resolution to prevent Linux segfault

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -326,7 +326,7 @@ window.Spicetify = {
 		setTimeout(addMissingPlatformAPIs, 50);
 		return;
 	}
-	const os = Spicetify.Platform?.operatingSystem;
+	const os = Spicetify.Platform.operatingSystem;
 	const version = Spicetify.Platform.version.split(".").map((i) => Number.parseInt(i, 10));
 	if (version[0] === 1 && version[1] === 2 && version[2] < 38) return;
 


### PR DESCRIPTION
Needs platform check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of platform API initialization by adding an OS-specific guard to avoid resolving an incompatible API on Linux, while preserving existing resolution behavior and logging on other platforms.
  * No changes to public/exported interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->