### PR TITLE
fix: resolve resource leaks and add shared HTTP client

### DIFF
--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -55,7 +55,7 @@ func Update(currentVersion string) bool {
 	}
 	defer out.Close()
 
-	resp2, err := http.Get(assetURL)
+	resp2, err := utils.HTTPClient.Get(assetURL)
 	if err != nil {
 		spinner.Fail("Failed to download Spicetify")
 		utils.Fatal(err)

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -51,10 +50,13 @@ func applyPatches(input string, patches []Patch) string {
 
 func readRemoteCssMap(tag string, cssTranslationMap *map[string]string) error {
 	var cssMapURL string = "https://raw.githubusercontent.com/spicetify/cli/" + tag + "/css-map.json"
-	cssMapResp, err := http.Get(cssMapURL)
+	cssMapResp, err := utils.HTTPClient.Get(cssMapURL)
 	if err != nil {
 		return err
-	} else {
+	}
+	defer cssMapResp.Body.Close()
+
+	{
 		err := json.NewDecoder(cssMapResp.Body).Decode(cssTranslationMap)
 		if err != nil {
 			utils.PrintWarning("Remote CSS map JSON malformed.")
@@ -1125,7 +1127,7 @@ func FetchLatestTagMatchingVersion(version string) (string, error) {
 	if version == "Dev" {
 		return "Dev", nil
 	}
-	res, err := http.Get("https://api.github.com/repos/spicetify/cli/releases")
+	res, err := utils.HTTPClient.Get("https://api.github.com/repos/spicetify/cli/releases")
 	if err != nil {
 		return "", err
 	}

--- a/src/utils/http.go
+++ b/src/utils/http.go
@@ -1,0 +1,10 @@
+package utils
+
+import (
+	"net/http"
+	"time"
+)
+
+// HTTPClient is a shared HTTP client with a reasonable timeout.
+// Using the default http.Get has no timeout and can hang indefinitely.
+var HTTPClient = &http.Client{Timeout: 30 * time.Second}

--- a/src/utils/vcs.go
+++ b/src/utils/vcs.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"net/http"
 )
 
 type GithubRelease struct {
@@ -13,10 +12,11 @@ type GithubRelease struct {
 }
 
 func FetchLatestTag() (string, error) {
-	res, err := http.Get("https://api.github.com/repos/spicetify/cli/releases/latest")
+	res, err := HTTPClient.Get("https://api.github.com/repos/spicetify/cli/releases/latest")
 	if err != nil {
 		return "", err
 	}
+	defer res.Body.Close()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fix `defer` inside loop in `Unzip()` and `Copy()` — file descriptors accumulated until the loop completed, potentially exhausting OS limits on large archives. Extracted helper functions so `defer` runs per iteration.
- Fix 3 HTTP response body leaks (`vcs.go`, `watcher.go`, `preprocess.go`) by adding missing `defer resp.Body.Close()`.
- Add shared `utils.HTTPClient` with 30-second timeout. The default `http.Get` uses a client with no timeout and can hang indefinitely.
- Optimize `Watch()` and `WatchRecursive()` to compare file mtime/size instead of reading entire file contents every 200ms.

## Files Changed
- `src/utils/utils.go` — Extract `extractZipEntry()` and `copyOneFile()` helpers
- `src/utils/http.go` — New shared HTTP client
- `src/utils/vcs.go` — Body leak fix + use `HTTPClient`
- `src/utils/watcher.go` — Body leak fix + mtime-based polling
- `src/cmd/update.go` — Use `HTTPClient`
- `src/preprocess/preprocess.go` — Body leak fix + use `HTTPClient`

## Test plan
- [ ] `spicetify apply` works correctly
- [ ] `spicetify watch` detects file changes
- [ ] `spicetify update` downloads successfully
- [ ] No goroutine/fd leaks under repeated apply cycles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * HTTP requests across the application now use a unified client with a 30-second timeout, preventing indefinite hangs during update downloads and asset fetches.
  * File change detection has been optimized to compare file metadata (modification time and size) instead of reading full file contents, significantly reducing resource consumption and improving overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->