### PR TITLE
perf: optimize preprocessing with regex cache, batch CSS, and parallelism

### DIFF
--- a/src/utils/color.go
+++ b/src/utils/color.go
@@ -12,7 +12,9 @@ import (
 )
 
 var (
-	xrdb map[string]string
+	hexColorRegex = regexp.MustCompile("[a-fA-F0-9]+")
+	xrdbRegex     = regexp.MustCompile(`^\*\.?(\w+?):\s*?#([A-Za-z0-9]+)`)
+	xrdb          map[string]string
 
 	// BaseColorList is color names list and their default values
 	BaseColorList = map[string]string{
@@ -100,8 +102,7 @@ func ParseColor(raw string) Color {
 		blue = stringToInt(list[2], 10)
 
 	} else {
-		re := regexp.MustCompile("[a-fA-F0-9]+")
-		hex := re.FindString(raw)
+		hex := hexColorRegex.FindString(raw)
 
 		// Support short hex color form e.g. #fff, #121
 		if len(hex) == 3 {
@@ -165,10 +166,9 @@ func getXRDB() error {
 	}
 
 	scanner := bufio.NewScanner(bytes.NewReader(output))
-	re := regexp.MustCompile(`^\*\.?(\w+?):\s*?#([A-Za-z0-9]+)`)
 	for scanner.Scan() {
 		line := scanner.Text()
-		for _, match := range re.FindAllStringSubmatch(line, -1) {
+		for _, match := range xrdbRegex.FindAllStringSubmatch(line, -1) {
 			if match != nil {
 				db[match[1]] = match[2]
 			}


### PR DESCRIPTION
## Summary
- Add `sync.Map`-based regex compilation cache — the `Replace`, `ReplaceOnce`, `FindMatch`, `FindSymbol`, and `SeekToCloseParen` functions were recompiling identical regex patterns on every call across thousands of file patches.
- Hoist static regexes to package level in `color.go` (`hexColorRegex`, `xrdbRegex`) and `preprocess.go` (`uriRegex`, `buildRegex`).
- Replace per-entry CSS translation map loop (`for k, v := range cssTranslationMap { utils.Replace(...) }`) with `strings.NewReplacer` — this uses Aho-Corasick internally, turning N full-file regex scans into a single efficient pass per file.
- Replace `filepath.Walk` with `filepath.WalkDir` to avoid redundant `os.Lstat` syscalls.
- Parallelize file patching with a bounded worker pool (`runtime.NumCPU()` goroutines) since each file is independently read, modified, and written back.

## Files Changed
- `src/utils/utils.go` — Add regex cache, update 7 functions to use it
- `src/utils/color.go` — Hoist regexes to package level
- `src/preprocess/preprocess.go` — Hoist regexes, `NewReplacer`, `WalkDir`, parallel loop

## Test plan
- [ ] `spicetify apply` produces identical output to before
- [ ] CSS class translations still work correctly
- [ ] `spicetify apply` is noticeably faster on multi-core machines
- [ ] No race conditions (run with `-race` flag)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized file processing performance through concurrent worker pattern and centralized regex caching, improving overall application responsiveness.
  * Streamlined CSS patching application for efficiency.
  * Enhanced file system traversal mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->