### PR TITLE
refactor: consolidate version parsing and discover backup apps dynamically

### DIFF
--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/spicetify/cli/src/utils"
@@ -49,17 +48,8 @@ func AdditionalOptions(appsFolderPath string, flags Flag) {
 		},
 	}
 
-	verParts := strings.Split(flags.SpotifyVer, ".")
-	spotifyMajor, spotifyMinor, spotifyPatch := 0, 0, 0
-	if len(verParts) > 0 {
-		spotifyMajor, _ = strconv.Atoi(verParts[0])
-	}
-	if len(verParts) > 1 {
-		spotifyMinor, _ = strconv.Atoi(verParts[1])
-	}
-	if len(verParts) > 2 {
-		spotifyPatch, _ = strconv.Atoi(verParts[2])
-	}
+	spotifyVer := utils.ParseSpotifyVersion(flags.SpotifyVer)
+	spotifyMajor, spotifyMinor, spotifyPatch := spotifyVer.Major, spotifyVer.Minor, spotifyVer.Patch
 
 	filesToModified[filepath.Join(appsFolderPath, "xpui", "xpui.js")] = append(filesToModified[filepath.Join(appsFolderPath, "xpui", "xpui.js")], insertCustomApp)
 	if spotifyMajor >= 1 && spotifyMinor >= 2 && spotifyPatch >= 57 {

--- a/src/backup/backup.go
+++ b/src/backup/backup.go
@@ -1,8 +1,8 @@
 package backup
 
 import (
-	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spicetify/cli/src/utils"
 )
@@ -12,19 +12,18 @@ func Start(appPath, backupPath string) error {
 	return utils.Copy(appPath, backupPath, false, []string{".spa"})
 }
 
-// Extract all SPA files from backupPath to extractPath
+// Extract all SPA files from backupPath to extractPath.
+// Discovers .spa files dynamically so new Spotify apps are
+// automatically handled.
 func Extract(backupPath, extractPath string) {
 	spinner, _ := utils.Spinner.Start("Extracting backup")
-	for _, app := range []string{"xpui", "login"} {
-		appPath := filepath.Join(backupPath, app+".spa")
-		appExtractToFolder := filepath.Join(extractPath, app)
 
-		_, err := os.Stat(appPath)
-		if err != nil {
-			continue
-		}
+	spaFiles, _ := filepath.Glob(filepath.Join(backupPath, "*.spa"))
+	for _, spaFile := range spaFiles {
+		appName := strings.TrimSuffix(filepath.Base(spaFile), ".spa")
+		appExtractToFolder := filepath.Join(extractPath, appName)
 
-		err = utils.Unzip(appPath, appExtractToFolder)
+		err := utils.Unzip(spaFile, appExtractToFolder)
 		if err != nil {
 			spinner.Fail("Failed to extract backup")
 			utils.Fatal(err)

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -104,17 +104,8 @@ func Start(version string, spotifyBasePath string, extractedAppsPath string, fla
 		readLocalCssMap(&cssTranslationMap)
 	}
 
-	verParts := strings.Split(flags.SpotifyVer, ".")
-	spotifyMajor, spotifyMinor, spotifyPatch := 0, 0, 0
-	if len(verParts) > 0 {
-		spotifyMajor, _ = strconv.Atoi(verParts[0])
-	}
-	if len(verParts) > 1 {
-		spotifyMinor, _ = strconv.Atoi(verParts[1])
-	}
-	if len(verParts) > 2 {
-		spotifyPatch, _ = strconv.Atoi(verParts[2])
-	}
+	spotifyVer := utils.ParseSpotifyVersion(flags.SpotifyVer)
+	spotifyMajor, spotifyMinor, spotifyPatch := spotifyVer.Major, spotifyVer.Minor, spotifyVer.Patch
 
 	var spotifyBinaryPath string
 	switch runtime.GOOS {

--- a/src/utils/constants.go
+++ b/src/utils/constants.go
@@ -1,0 +1,11 @@
+package utils
+
+const (
+	// AppXPUI is the main Spotify web app.
+	AppXPUI = "xpui"
+	// AppLogin is the Spotify login app.
+	AppLogin = "login"
+)
+
+// KnownApps lists the Spotify apps that spicetify handles.
+var KnownApps = []string{AppXPUI, AppLogin}

--- a/src/utils/version.go
+++ b/src/utils/version.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"strconv"
+	"strings"
+)
+
+// SpotifyVersion holds parsed Spotify version components.
+type SpotifyVersion struct {
+	Major, Minor, Patch int
+}
+
+// ParseSpotifyVersion parses a dotted version string like "1.2.57"
+// into its major, minor, and patch components. Missing or invalid
+// parts default to 0.
+func ParseSpotifyVersion(ver string) SpotifyVersion {
+	ver = strings.TrimPrefix(ver, "v")
+	parts := strings.Split(ver, ".")
+	v := SpotifyVersion{}
+	if len(parts) > 0 {
+		v.Major, _ = strconv.Atoi(parts[0])
+	}
+	if len(parts) > 1 {
+		v.Minor, _ = strconv.Atoi(parts[1])
+	}
+	if len(parts) > 2 {
+		v.Patch, _ = strconv.Atoi(parts[2])
+	}
+	return v
+}
+
+// AtLeast returns true if v is greater than or equal to the given version.
+func (v SpotifyVersion) AtLeast(major, minor, patch int) bool {
+	if v.Major != major {
+		return v.Major > major
+	}
+	if v.Minor != minor {
+		return v.Minor > minor
+	}
+	return v.Patch >= patch
+}


### PR DESCRIPTION
## Summary
- Add `utils.SpotifyVersion` type with `ParseSpotifyVersion()` and `AtLeast()` method to eliminate duplicated version parsing logic that was copy-pasted in both `preprocess.go` and `apply.go`.
- Add `utils/constants.go` with app name constants (`AppXPUI`, `AppLogin`) and `KnownApps` slice.
- Make `backup.Extract()` discover `.spa` files dynamically via `filepath.Glob("*.spa")` instead of hardcoding `["xpui", "login"]`. This means new Spotify apps are automatically extracted without code changes.

## Files Changed
- `src/utils/version.go` — New `SpotifyVersion` type
- `src/utils/constants.go` — New app name constants
- `src/apply/apply.go` — Use `ParseSpotifyVersion`, remove unused `strconv`
- `src/preprocess/preprocess.go` — Use `ParseSpotifyVersion`
- `src/backup/backup.go` — Dynamic `.spa` discovery via `filepath.Glob`

## Test plan
- [ ] `spicetify apply` correctly applies version-gated patches
- [ ] `spicetify backup` + `spicetify restore` round-trips correctly
- [ ] Backup extraction handles both `xpui.spa` and `login.spa`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated Spotify version parsing logic across multiple modules for improved code maintainability and reduced duplication.
  * Enhanced backup extraction process to dynamically discover application files during extraction instead of relying on predefined file lists, providing greater flexibility for backup restoration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->