### PR TITLE
fix(wrapper): unmount `_HTMLGenericModal` React content on hide

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -2166,6 +2166,7 @@ const NavLinkGlobal = ({ appProper, appRoutePath, createIcon, isActive }) => {
 
 class _HTMLGenericModal extends HTMLElement {
 	hide() {
+		Spicetify.ReactDOM.unmountComponentAtNode(this.querySelector("main"));
 		this.remove();
 	}
 


### PR DESCRIPTION
we dont need an additional check since `unmountComponentAtNode` just does nothing if the element is not a React root

code snippet to verify that it works:
```js
Spicetify.PopupModal.display({ title: "HI", content: Spicetify.React.createElement(() => {
    Spicetify.React.useEffect(() => { console.log("mounted"); return () => console.log("unmounted"); });
    return "hi";
}, {}) })
```

i did verify that it does not crash or anything if content is not a React element

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal cleanup behavior to ensure React components are properly unmounted when modals are hidden, preventing memory leaks and related performance issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->