### PR TITLE
fix: update `loopyLoop` to handle Spotify DOM restructuring

### DIFF
--- a/Extensions/loopyLoop.js
+++ b/Extensions/loopyLoop.js
@@ -80,8 +80,8 @@
 	function createMenuItem(title, callback) {
 		const item = document.createElement("li");
 		item.setAttribute("role", "menuitem");
-		item.classList.add("main-contextMenu-menuItemButton");
 		const button = document.createElement("button");
+		button.classList.add("main-contextMenu-menuItemButton");
 		button.textContent = title;
 		button.onclick = () => {
 			contextMenu.hidden = true;


### PR DESCRIPTION
- Progress bar selector `.playback-bar .progress-bar` no longer matches, Spotify restructured the playback bar DOM with new hashed classes not present in the CSS map
 - Replaced selector with structural DOM traversal via `.playback-progressbar-container` and `input[type="range"]`
 - Replaced `ReactDOM.render(MenuItem)` with plain HTML menu items since,`MenuItem` now requires React Router context (`StableUseNavigateProvider`) which isn't available when rendering into a detached div
- Removed unnecessary `async`/`webpackLoaded` dependency since React components are no longer used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Faster, leaner initialization for improved responsiveness.
  * Menu rendering simplified to plain DOM elements; items are accessible buttons with direct event wiring.
  * Context menu now triggers from the progress area and uses element bounds for more reliable placement.

* **Bug Fixes**
  * Pointer position clamped to valid bounds to prevent out-of-range interactions and improve positioning stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->