### PR TITLE
fix(types): make `PopupModal` content accept `JSXElement`

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1294,7 +1294,8 @@ declare namespace Spicetify {
 			title: string;
 			/**
 			 * You can specify a string for simple text display
-			 * or a HTML element for interactive config/setting menu
+			 * or a HTML element for interactive config/setting menu,
+			 * or a React JSX element for React-based components
 			 */
 			content: string | Element | React.JSX.Element;
 			/**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved type definitions for modal content to accept React JSX elements, improving reliability and developer experience when composing UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->