### PR TITLE
fix(trashbin): context menu label not updating

### DIFF
--- a/Extensions/trashbin.js
+++ b/Extensions/trashbin.js
@@ -354,7 +354,7 @@
 		return false;
 	}
 
-	let cntxMenu = new Spicetify.ContextMenu.Item(THROW_TEXT, toggleThrow, shouldAddContextMenu, trashbinIcon);
+	const cntxMenu = new Spicetify.ContextMenu.Item(THROW_TEXT, toggleThrow, shouldAddContextMenu, trashbinIcon);
 	cntxMenu.register();
 
 	function putDataLocal() {


### PR DESCRIPTION
\`shouldAddContextMenu\` used \`this.name\` to update the context menu label, but \`this\` is no longer bound to the \`ContextMenu.Item\` in newer Spicetify versions. Referencing \`cntxMenu\` directly via closure fixes the stale label.

Fixes #3743

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected context-menu labeling in the trashbin extension so menu items display and reference the proper label for track and artist entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->