### PR TITLE
chore(wrapper): resolve pre-existing Biome lint warnings

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -423,7 +423,7 @@ applyScrollingFix();
 			const internalFetch = Reflect.get(target, prop, receiver);
 
 			if (typeof internalFetch !== "function" || !allowedMethodsSet.has(prop)) return internalFetch;
-			const version = Spicetify.Platform.version.split(".").map((i) => Number.parseInt(i));
+			const version = Spicetify.Platform.version.split(".").map((i) => Number.parseInt(i, 10));
 			if (version[1] >= 2 && version[2] < 31) return internalFetch;
 
 			return async function (url, body) {
@@ -2363,7 +2363,7 @@ let navLinkFactoryCtx = null;
 let refreshNavLinks = null;
 
 Spicetify._renderNavLinks = (list, isTouchScreenUi) => {
-	const [refreshCount, refresh] = Spicetify.React.useReducer((x) => x + 1, 0);
+	const [, refresh] = Spicetify.React.useReducer((x) => x + 1, 0);
 	refreshNavLinks = refresh;
 
 	if (


### PR DESCRIPTION
Two pre-existing Biome lint warnings in `jsHelper/spicetifyWrapper.js`, discovered during #3773 review:

1. **Line 426**: `Number.parseInt(i)` missing explicit radix parameter. Added `, 10` for base-10 parsing.
2. **Line 2366**: `refreshCount` destructured from `useReducer` but never read. Changed to `[, refresh]` to discard the unused value.

Both are mechanical fixes with no behavior change. The `refresh` function from the same destructuring is still used on line 2367.

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version number parsing logic for enhanced compatibility handling with Spicetify versions.

* **Refactor**
  * Removed unused variable binding to streamline code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->