### PR TITLE
feat(css-map): add more 1.2.86 classes and a few others

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1879,7 +1879,7 @@
 	"wBsWS202aGdsul2kEGUf": "main-yourLibraryX-filterArea",
 	"rjsuxO8gqIyaiYTHNpOQ": "main-yourLibraryX-filterArea",
 	"paiZmlAHHhmZonuGJRAr": "main-yourLibraryX-filterArea",
-	"bNIdoiXcaYCrJ5Do" : "main-yourLibraryX-filterArea",
+	"bNIdoiXcaYCrJ5Do": "main-yourLibraryX-filterArea",
 	"msaOP0MYt3paJGpbdeJs": "main-yourLibraryX-filters",
 	"MLbFLVC33caOj3FgSQMC": "main-yourLibraryX-filters",
 	"UvXqRORKQr_N3jlgGTcS": "main-yourLibraryX-header",


### PR DESCRIPTION
* This PR adds the following for 1.2.86:
  * `GenericModal__overlay` and `main-userWidget-box`, which is required for `Spicetify.PopupModal` and `Spicetify.Menu.Item` to work properly
  * A lot of dialog-related classes obtained by comparing `xpui-root-dialogs.css` and `xpui-routes-playlist.css` from Spotify 1.2.70, 1.2.84/85, and 1.2.86. Some adjacent classes that have been missing since 1.2.72 are also added.
  * Classes for the new `TrackCreditsModalV2`, which can be toggled in the experimental features in 1.2.70. The toggle has no effect on 1.2.84/1.2.86, and the new credits modal is always enabled.
  * Some other classes that WMPotify is using
  * Also fixes a wrong map (`lZCogpVJ9VYr762A`) and a map with a typo (`"nGNsefRulpsAkpRc": "main-yourLibraryX-libaryFilter"`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CSS class-to-hash mappings for many UI components (modals, widgets, pickers, loading states, now-playing views, playlists, credits modals, profile and home shortcut elements) to support additional UI elements and states.
  * Fixed an incorrect mapping key for a library filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->