### PR TITLE
feat(lyrics-plus): change Musixmatch API for higher rate limit

### DIFF
--- a/CustomApps/lyrics-plus/ProviderMusixmatch.js
+++ b/CustomApps/lyrics-plus/ProviderMusixmatch.js
@@ -2,9 +2,9 @@ const ProviderMusixmatch = (() => {
 	const headers = {
 		Host: "apic-appmobile.musixmatch.com",
 		authority: "apic-appmobile.musixmatch.com",
-		cookie: "x-mxm-token-guid=",
+		"X-Cookie": "x-mxm-token-guid=",
 		"x-mxm-app-version": "10.1.1",
-		"User-Agent": "Musixmatch/2025120901 CFNetwork/3860.300.31 Darwin/25.2.0",
+		"X-User-Agent": "Musixmatch/2025120901 CFNetwork/3860.300.31 Darwin/25.2.0",
 		"Accept-Language": "en-US,en;q=0.9",
 		Connection: "keep-alive",
 		Accept: "application/json",

--- a/CustomApps/lyrics-plus/ProviderMusixmatch.js
+++ b/CustomApps/lyrics-plus/ProviderMusixmatch.js
@@ -1,7 +1,13 @@
 const ProviderMusixmatch = (() => {
 	const headers = {
-		authority: "apic-desktop.musixmatch.com",
+		Host: "apic-appmobile.musixmatch.com",
+		authority: "apic-appmobile.musixmatch.com",
 		cookie: "x-mxm-token-guid=",
+		"x-mxm-app-version": "10.1.1",
+		"User-Agent": "Musixmatch/2025120901 CFNetwork/3860.300.31 Darwin/25.2.0",
+		"Accept-Language": "en-US,en;q=0.9",
+		Connection: "keep-alive",
+		Accept: "application/json",
 	};
 
 	function findTranslationStatus(body) {
@@ -36,7 +42,7 @@ const ProviderMusixmatch = (() => {
 
 	async function findLyrics(info) {
 		const baseURL =
-			"https://apic-desktop.musixmatch.com/ws/1.1/macro.subtitles.get?format=json&namespace=lyrics_richsynched&subtitle_format=mxm&app_id=web-desktop-app-v1.0&";
+			"https://apic-appmobile.musixmatch.com/ws/1.1/macro.subtitles.get?format=json&namespace=lyrics_richsynched&subtitle_format=mxm&app_id=mac-ios-v2.0&";
 
 		const durr = info.duration / 1000;
 
@@ -225,7 +231,7 @@ const ProviderMusixmatch = (() => {
 			return null;
 		}
 
-		const baseURL = "https://apic-desktop.musixmatch.com/ws/1.1/track.richsync.get?format=json&subtitle_format=mxm&app_id=web-desktop-app-v1.0&";
+		const baseURL = "https://apic-appmobile.musixmatch.com/ws/1.1/track.richsync.get?format=json&subtitle_format=mxm&app_id=mac-ios-v2.0&";
 
 		const params = {
 			f_subtitle_length: meta.track.track_length,
@@ -376,7 +382,7 @@ const ProviderMusixmatch = (() => {
 		if (selectedLanguage === "none") return null;
 
 		const baseURL =
-			"https://apic-desktop.musixmatch.com/ws/1.1/crowd.track.translations.get?translation_fields_set=minimal&comment_format=text&format=json&app_id=web-desktop-app-v1.0&";
+			"https://apic-appmobile.musixmatch.com/ws/1.1/crowd.track.translations.get?translation_fields_set=minimal&comment_format=text&format=json&app_id=mac-ios-v2.0&";
 
 		const params = {
 			track_id: trackId,
@@ -423,7 +429,7 @@ const ProviderMusixmatch = (() => {
 			console.warn("Failed to parse cached languages", e);
 		}
 
-		const baseURL = "https://apic-desktop.musixmatch.com/ws/1.1/languages.get?app_id=web-desktop-app-v1.0&get_romanized_info=1&";
+		const baseURL = "https://apic-appmobile.musixmatch.com/ws/1.1/languages.get?app_id=mac-ios-v2.0&get_romanized_info=1&";
 
 		const params = {
 			usertoken: CONFIG.providers.musixmatch.token,

--- a/CustomApps/lyrics-plus/Settings.js
+++ b/CustomApps/lyrics-plus/Settings.js
@@ -75,9 +75,9 @@ const RefreshTokenButton = ({ setTokenCallback }) => {
 			Spicetify.CosmosAsync.get("https://apic-appmobile.musixmatch.com/ws/1.1/token.get?app_id=mac-ios-v2.0", null, {
 				Host: "apic-appmobile.musixmatch.com",
 				authority: "apic-appmobile.musixmatch.com",
-				cookie: "x-mxm-token-guid=",
+				"X-Cookie": "x-mxm-token-guid=",
 				"x-mxm-app-version": "10.1.1",
-				"User-Agent": "Musixmatch/2025120901 CFNetwork/3860.300.31 Darwin/25.2.0",
+				"X-User-Agent": "Musixmatch/2025120901 CFNetwork/3860.300.31 Darwin/25.2.0",
 				"Accept-Language": "en-US,en;q=0.9",
 				Connection: "keep-alive",
 				Accept: "application/json",

--- a/CustomApps/lyrics-plus/Settings.js
+++ b/CustomApps/lyrics-plus/Settings.js
@@ -72,8 +72,15 @@ const RefreshTokenButton = ({ setTokenCallback }) => {
 
 	useEffect(() => {
 		if (buttonText === "Refreshing token...") {
-			Spicetify.CosmosAsync.get("https://apic-desktop.musixmatch.com/ws/1.1/token.get?app_id=web-desktop-app-v1.0", null, {
-				authority: "apic-desktop.musixmatch.com",
+			Spicetify.CosmosAsync.get("https://apic-appmobile.musixmatch.com/ws/1.1/token.get?app_id=mac-ios-v2.0", null, {
+				Host: "apic-appmobile.musixmatch.com",
+				authority: "apic-appmobile.musixmatch.com",
+				cookie: "x-mxm-token-guid=",
+				"x-mxm-app-version": "10.1.1",
+				"User-Agent": "Musixmatch/2025120901 CFNetwork/3860.300.31 Darwin/25.2.0",
+				"Accept-Language": "en-US,en;q=0.9",
+				Connection: "keep-alive",
+				Accept: "application/json",
 			})
 				.then(({ message: response }) => {
 					if (response.header.status_code === 200 && response.body.user_token) {


### PR DESCRIPTION
Modify the Musixmatch API to increase the request rate limit, so that a single token can handle more than 10 requests at the same time
[References](https://github.com/Strvm/musicxmatch-api/issues/16#issuecomment-3855763176)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of lyrics and karaoke synchronization, translation retrieval, language detection, and token refresh so content loads more consistently and stays in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->