### PR TITLE
chore(lyrics-plus): correct misspelled variable name

### DIFF
--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -590,8 +590,8 @@ class LyricsContainer extends react.Component {
 			const friendlyLanguage = language && new Intl.DisplayNames(["en"], { type: "language" }).of(language.split("-")[0])?.toLowerCase();
 			const targetConvert = CONFIG.visual[`translation-mode:${friendlyLanguage}`];
 
-			const isMemorey = CACHE[tempState.uri]?.[targetConvert];
-			if (CONFIG.visual.translate && defaultLanguage && !isMemorey) {
+			const isMemory = CACHE[tempState.uri]?.[targetConvert];
+			if (CONFIG.visual.translate && defaultLanguage && !isMemory) {
 				this.translateLyrics(language, this.state.currentLyrics, targetConvert).then((translated) => {
 					const res = { [targetConvert]: translated };
 					// Cache translated lyrics


### PR DESCRIPTION
Cache lookup for translated lyrics was using an incorrectly named variable, causing the cache check to always miss and re-process lyrics unnecessarily on every track load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the lyrics caching logic with no impact to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->