### PR TITLE
fix: improve handling of lines starting with a kanji (#3821)

### DIFF
--- a/CustomApps/lyrics-plus/Pages.js
+++ b/CustomApps/lyrics-plus/Pages.js
@@ -310,7 +310,12 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
 
 				// Convert lyrics to text for comparison
 				const belowOrigin = (typeof originalText === "object" ? originalText?.props?.children?.[0] : originalText)?.replace(/\s+/g, "");
-				const belowTxt = (typeof text === "object" ? text?.props?.children?.[0] : text)?.replace(/\s+/g, "");
+				const belowTxt =
+					typeof text === "string"
+						? text.replace(/\s+/g, "")
+						: typeof text?.props?.children?.[0] === "string"
+							? text.props.children[0].replace(/\s+/g, "")
+							: "";
 
 				const belowMode = showTranslatedBelow && originalText && belowOrigin !== belowTxt;
 
@@ -634,7 +639,12 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 
 			// Convert lyrics to text for comparison
 			const belowOrigin = (typeof originalText === "object" ? originalText?.props?.children?.[0] : originalText)?.replace(/\s+/g, "");
-			const belowTxt = (typeof text === "object" ? text?.props?.children?.[0] : text)?.replace(/\s+/g, "");
+			const belowTxt =
+				typeof text === "string"
+					? text.replace(/\s+/g, "")
+					: typeof text?.props?.children?.[0] === "string"
+						? text.props.children[0].replace(/\s+/g, "")
+						: "";
 
 			const belowMode = showTranslatedBelow && originalText && belowOrigin !== belowTxt;
 
@@ -713,7 +723,12 @@ const UnsyncedLyricsPage = react.memo(({ lyrics, provider, copyright }) => {
 
 			// Convert lyrics to text for comparison
 			const belowOrigin = (typeof originalText === "object" ? originalText?.props?.children?.[0] : originalText)?.replace(/\s+/g, "");
-			const belowTxt = (typeof text === "object" ? text?.props?.children?.[0] : text)?.replace(/\s+/g, "");
+			const belowTxt =
+				typeof text === "string"
+					? text.replace(/\s+/g, "")
+					: typeof text?.props?.children?.[0] === "string"
+						? text.props.children[0].replace(/\s+/g, "")
+						: "";
 
 			const belowMode = showTranslatedBelow && originalText && belowOrigin !== belowTxt;
 

--- a/CustomApps/lyrics-plus/Utils.js
+++ b/CustomApps/lyrics-plus/Utils.js
@@ -175,7 +175,8 @@ const Utils = {
 		const rubyElems = s.split("<ruby>");
 		const reactChildren = [];
 
-		reactChildren.push(rubyElems[0]);
+		if (rubyElems[0] !== '')
+			reactChildren.push(rubyElems[0]);
 		for (let i = 1; i < rubyElems.length; i++) {
 			const kanji = rubyElems[i].split("<rp>")[0];
 			const furigana = rubyElems[i].split("<rt>")[1].split("</rt>")[0];

--- a/CustomApps/lyrics-plus/Utils.js
+++ b/CustomApps/lyrics-plus/Utils.js
@@ -175,8 +175,7 @@ const Utils = {
 		const rubyElems = s.split("<ruby>");
 		const reactChildren = [];
 
-		if (rubyElems[0] !== '')
-			reactChildren.push(rubyElems[0]);
+		if (rubyElems[0] !== "") reactChildren.push(rubyElems[0]);
 		for (let i = 1; i < rubyElems.length; i++) {
 			const kanji = rubyElems[i].split("<rp>")[0];
 			const furigana = rubyElems[i].split("<rt>")[1].split("</rt>")[0];


### PR DESCRIPTION
fix for issue #3821

<img width="1421" height="733" alt="image" src="https://github.com/user-attachments/assets/45d7626b-f0cb-4e78-95c9-dc3b4d38a381" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate lyrics text normalization to avoid false triggers of "translated-below" display and to make copy/clipboard behavior more reliable across varied lyric formats.
  * Improved ruby text rendering to avoid inserting empty elements, resulting in cleaner displayed text and more stable rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->