### PR TITLE
fix(update): close response body and file on error paths

### DIFF
--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -74,6 +74,7 @@ func Update(currentVersion string) bool {
 	_, err = io.Copy(out, resp2.Body)
 	if err != nil {
 		resp2.Body.Close()
+		out.Close()
 		spinner.Fail("Failed to download Spicetify")
 		utils.Fatal(err)
 	}

--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -57,18 +57,23 @@ func Update(currentVersion string) bool {
 
 	resp2, err := http.Get(assetURL)
 	if err != nil {
+		out.Close()
 		spinner.Fail("Failed to download Spicetify")
 		utils.Fatal(err)
 	}
-	defer resp2.Body.Close()
 
 	if resp2.StatusCode != http.StatusOK {
+		resp2.Body.Close()
+		out.Close()
 		spinner.Fail("Failed to download Spicetify")
 		utils.Fatal(fmt.Errorf("unexpected HTTP status: %s for %s", resp2.Status, assetURL))
 	}
 
+	defer resp2.Body.Close()
+
 	_, err = io.Copy(out, resp2.Body)
 	if err != nil {
+		resp2.Body.Close()
 		spinner.Fail("Failed to download Spicetify")
 		utils.Fatal(err)
 	}


### PR DESCRIPTION
`utils.Fatal` calls `os.Exit(1)`, so deferred closes never run on error paths.

Manually close `out` and `resp2.Body` before each `Fatal` call.
Move `defer resp2.Body.Close()` to after all error checks pass.

Fixes resource leak in `src/cmd/update.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the update download process by ensuring temporary files and network connections are reliably closed on all error paths, preventing resource leaks and improving stability during failed or partial downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->