### PR TITLE
fix(loopyLoop): loop between markers when repeat-one is active

### DIFF
--- a/Extensions/loopyLoop.js
+++ b/Extensions/loopyLoop.js
@@ -68,6 +68,7 @@
 	let lastSkipSeek = 0;
 	let lastSkippedZoneIdx = -1;
 	let lastNextCall = 0;
+	let lastEndLoopSeek = 0;
 	let seekStartPendingUri = null;
 	let lastStartEnforce = 0;
 	let prevProgressPercent = -1;
@@ -300,15 +301,16 @@
 
 		// Song end enforcement: at ], either loop back (repeat-one) or advance to next track
 		if (end !== null && percent >= end) {
-			if (ts - lastNextCall > 2000) {
-				lastNextCall = ts;
-				// Spicetify.Player.getRepeat(): 0 = off, 1 = repeat context, 2 = repeat track
-				if (Spicetify.Player.getRepeat() === 2) {
+			// Spicetify.Player.getRepeat(): 0 = off, 1 = repeat context, 2 = repeat track
+			if (Spicetify.Player.getRepeat() === 2) {
+				if (ts - lastEndLoopSeek > 500) {
+					lastEndLoopSeek = ts;
 					Spicetify.Player.seek(start ?? 0);
-				} else {
-					seekStartPendingUri = Spicetify.Player.data?.item?.uri ?? null;
-					Spicetify.Player.next();
 				}
+			} else if (ts - lastNextCall > 2000) {
+				lastNextCall = ts;
+				seekStartPendingUri = Spicetify.Player.data?.item?.uri ?? null;
+				Spicetify.Player.next();
 			}
 			return;
 		}
@@ -343,6 +345,7 @@
 		prevPressedAt = 0;
 		lastStartEnforce = 0;
 		lastNextCall = 0;
+		lastEndLoopSeek = 0;
 		lastSkipSeek = 0;
 		lastSkippedZoneIdx = -1;
 	});

--- a/Extensions/loopyLoop.js
+++ b/Extensions/loopyLoop.js
@@ -298,12 +298,17 @@
 			return;
 		}
 
-		// Song end enforcement: advance to next track when playback reaches ]
+		// Song end enforcement: at ], either loop back (repeat-one) or advance to next track
 		if (end !== null && percent >= end) {
 			if (ts - lastNextCall > 2000) {
 				lastNextCall = ts;
-				seekStartPendingUri = Spicetify.Player.data?.item?.uri ?? null;
-				Spicetify.Player.next();
+				// Spicetify.Player.getRepeat(): 0 = off, 1 = repeat context, 2 = repeat track
+				if (Spicetify.Player.getRepeat() === 2) {
+					Spicetify.Player.seek(start ?? 0);
+				} else {
+					seekStartPendingUri = Spicetify.Player.data?.item?.uri ?? null;
+					Spicetify.Player.next();
+				}
 			}
 			return;
 		}


### PR DESCRIPTION
Fixes not looping on repeat one. 

https://github.com/spicetify/cli/pull/3771#issuecomment-4303393620 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Loop behavior now respects Spotify repeat mode: with repeat-one enabled, tracks loop back to the configured start position rather than advancing.
  * Prevents rapid/duplicate seeks when looping (seek rate is managed and reset on track change) to provide smoother replay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->