### PR TITLE
fix(loopyLoop): update progress bar selectors to use data-testid

### DIFF
--- a/Extensions/loopyLoop.js
+++ b/Extensions/loopyLoop.js
@@ -7,8 +7,7 @@
 /// <reference path="../globals.d.ts" />
 
 (function LoopyLoop() {
-	const playbackBar = document.querySelector(".playback-bar");
-	const progressContainer = playbackBar?.querySelector(".playback-progressbar-container");
+	const progressContainer = document.querySelector('[data-testid="playback-progressbar"]');
 	const rangeInput = progressContainer?.querySelector('input[type="range"]');
 	const bar = rangeInput?.closest("label")?.nextElementSibling;
 	if (!(bar && Spicetify.Player)) {
@@ -17,7 +16,7 @@
 	}
 
 	function getBar() {
-		const pc = document.querySelector(".playback-progressbar-container");
+		const pc = document.querySelector('[data-testid="playback-progressbar"]');
 		return pc?.querySelector('input[type="range"]')?.closest("label")?.nextElementSibling ?? null;
 	}
 
@@ -558,7 +557,7 @@
 			}
 
 			// Progress bar area
-			const currentProgressContainer = document.querySelector(".playback-progressbar-container");
+			const currentProgressContainer = document.querySelector('[data-testid="playback-progressbar"]');
 			if (!currentProgressContainer?.contains(target)) return;
 			event.preventDefault();
 			event.stopPropagation();


### PR DESCRIPTION
Spotify's recent UI updates removed the legacy .playback-bar and .playback-progressbar-container classes, causing the extension to fail silently. This commit replaces those class selectors with the persistent data-testid="playback-progressbar" attribute to restore context menu and UI injection functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of playback progress bar detection to ensure consistent interaction handling across different UI states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spicetify/cli/pull/3844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->