### PR TITLE
feat(config/linux): add Beta Flatpak Spotify Path for Spicetify detection

### DIFF
--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -310,6 +310,7 @@ func linuxApp() string {
 		"/usr/share/spotify-client/",
 		"/var/lib/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
 		"$HOME/.local/share/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
+		"$HOME/.local/share/flatpak/app/com.spotify.Client/x86_64/beta/active/files/extra/share/spotify/",
 		"$HOME/.local/share/spotify-launcher/install/usr/share/spotify/",
 	}
 

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -310,7 +310,7 @@ func linuxApp() string {
 		"/usr/share/spotify-client/",
 		"/var/lib/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
 		"$HOME/.local/share/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
-		"/var/lib/flatpak/app/com.spotify.Client/x86_64/beta/active/files/extra/share/spotify",
+		"/var/lib/flatpak/app/com.spotify.Client/x86_64/beta/active/files/extra/share/spotify/",
 		"$HOME/.local/share/spotify-launcher/install/usr/share/spotify/",
 	}
 

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -310,6 +310,7 @@ func linuxApp() string {
 		"/usr/share/spotify-client/",
 		"/var/lib/flatpak/app/com.spotify.Client/x86_64/beta/active/files/extra/share/spotify/",
 		"/var/lib/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
+		"$HOME/.local/share/flatpak/app/com.spotify.Client/x86_64/beta/active/files/extra/share/spotify/",
 		"$HOME/.local/share/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
 		"$HOME/.local/share/spotify-launcher/install/usr/share/spotify/",
 	}

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -310,7 +310,7 @@ func linuxApp() string {
 		"/usr/share/spotify-client/",
 		"/var/lib/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
 		"$HOME/.local/share/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
-		"$HOME/.local/share/flatpak/app/com.spotify.Client/x86_64/beta/active/files/extra/share/spotify/",
+		"/var/lib/flatpak/app/com.spotify.Client/x86_64/beta/active/files/extra/share/spotify",
 		"$HOME/.local/share/spotify-launcher/install/usr/share/spotify/",
 	}
 

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -308,9 +308,9 @@ func linuxApp() string {
 		"/usr/share/spotify/",
 		"/usr/libexec/spotify/",
 		"/usr/share/spotify-client/",
+		"/var/lib/flatpak/app/com.spotify.Client/x86_64/beta/active/files/extra/share/spotify/",
 		"/var/lib/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
 		"$HOME/.local/share/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
-		"/var/lib/flatpak/app/com.spotify.Client/x86_64/beta/active/files/extra/share/spotify/",
 		"$HOME/.local/share/spotify-launcher/install/usr/share/spotify/",
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Spotify detection on Linux by adding support for Flatpak beta installation locations (both system and user installs), reducing failed app-detection cases and improving launch and integration reliability for users running the Flatpak beta of Spotify.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spicetify/cli/pull/3850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->