### PR TITLE
fix(lyrics-plus): support Netease translations with convert mode

### DIFF
--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -176,12 +176,10 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation, musixmat
 			sourceOptions = { ...sourceOptions, ...musixmatchOptions };
 		}
 
-		if (hasTranslation.netease) {
-			sourceOptions = {
-				...sourceOptions,
-				neteaseTranslation: "Chinese (Netease)",
-			};
-		}
+		sourceOptions = {
+			...sourceOptions,
+			neteaseTranslation: "Chinese (Netease)",
+		};
 
 		switch (friendlyLanguage) {
 			case "japanese": {
@@ -298,17 +296,7 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation, musixmat
 							type: "translation-menu",
 							items,
 							onChange: (name, value) => {
-								if (name === "translate") {
-									CONFIG.visual["translate:translated-lyrics-source"] = "none";
-									localStorage.setItem(`${APP_NAME}:visual:translate:translated-lyrics-source`, "none");
-								}
 								if (name === "translate:translated-lyrics-source") {
-									const hasTranslationProvider = typeof value === "string" && value !== "none";
-									if (hasTranslationProvider && CONFIG.visual.translate) {
-										CONFIG.visual.translate = false;
-										localStorage.setItem(`${APP_NAME}:visual:translate`, "false");
-									}
-
 									let nextMusixmatchLanguage = "none";
 									if (typeof value === "string" && value.startsWith(musixmatchTranslationPrefix)) {
 										nextMusixmatchLanguage = value.slice(musixmatchTranslationPrefix.length) || "none";

--- a/CustomApps/lyrics-plus/Pages.js
+++ b/CustomApps/lyrics-plus/Pages.js
@@ -57,6 +57,17 @@ const isPauseLine = (text) => {
 	return trimmed === "♪" || trimmed === "";
 };
 
+const lyricNodeToText = (value) => {
+	if (value == null) return "";
+	if (typeof value === "string") return value;
+	if (typeof value === "number") return String(value);
+	if (Array.isArray(value)) return value.map(lyricNodeToText).join("");
+	if (typeof value === "object") return lyricNodeToText(value.props?.children);
+	return String(value);
+};
+
+const comparableLyricText = (value) => lyricNodeToText(value).replace(/\s+/g, "");
+
 const findNextLineStartTime = (lines, fromIndex) => {
 	for (let j = fromIndex + 1; j < lines.length; j++) {
 		if (!isPauseLine(lines[j].text) && lines[j].startTime != null) {
@@ -309,13 +320,8 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
 				const lineText = originalText && showTranslatedBelow ? originalText : text;
 
 				// Convert lyrics to text for comparison
-				const belowOrigin = (typeof originalText === "object" ? originalText?.props?.children?.[0] : originalText)?.replace(/\s+/g, "");
-				const belowTxt =
-					typeof text === "string"
-						? text.replace(/\s+/g, "")
-						: typeof text?.props?.children?.[0] === "string"
-							? text.props.children[0].replace(/\s+/g, "")
-							: "";
+				const belowOrigin = comparableLyricText(originalText);
+				const belowTxt = comparableLyricText(text);
 
 				const belowMode = showTranslatedBelow && originalText && belowOrigin !== belowTxt;
 
@@ -357,6 +363,7 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
 						react.createElement(
 							"p",
 							{
+								className: "lyrics-lyricsContainer-TranslatedLine",
 								style: {
 									opacity: 0.5,
 								},
@@ -638,13 +645,8 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 			const lineText = originalText && showTranslatedBelow ? originalText : text;
 
 			// Convert lyrics to text for comparison
-			const belowOrigin = (typeof originalText === "object" ? originalText?.props?.children?.[0] : originalText)?.replace(/\s+/g, "");
-			const belowTxt =
-				typeof text === "string"
-					? text.replace(/\s+/g, "")
-					: typeof text?.props?.children?.[0] === "string"
-						? text.props.children[0].replace(/\s+/g, "")
-						: "";
+			const belowOrigin = comparableLyricText(originalText);
+			const belowTxt = comparableLyricText(text);
 
 			const belowMode = showTranslatedBelow && originalText && belowOrigin !== belowTxt;
 
@@ -683,6 +685,7 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 					react.createElement(
 						"p",
 						{
+							className: "lyrics-lyricsContainer-TranslatedLine",
 							style: { opacity: 0.5 },
 							onContextMenu: (event) => {
 								event.preventDefault();
@@ -722,13 +725,8 @@ const UnsyncedLyricsPage = react.memo(({ lyrics, provider, copyright }) => {
 			const lineText = originalText && showTranslatedBelow ? originalText : text;
 
 			// Convert lyrics to text for comparison
-			const belowOrigin = (typeof originalText === "object" ? originalText?.props?.children?.[0] : originalText)?.replace(/\s+/g, "");
-			const belowTxt =
-				typeof text === "string"
-					? text.replace(/\s+/g, "")
-					: typeof text?.props?.children?.[0] === "string"
-						? text.props.children[0].replace(/\s+/g, "")
-						: "";
+			const belowOrigin = comparableLyricText(originalText);
+			const belowTxt = comparableLyricText(text);
 
 			const belowMode = showTranslatedBelow && originalText && belowOrigin !== belowTxt;
 
@@ -756,6 +754,7 @@ const UnsyncedLyricsPage = react.memo(({ lyrics, provider, copyright }) => {
 					react.createElement(
 						"p",
 						{
+							className: "lyrics-lyricsContainer-TranslatedLine",
 							style: { opacity: 0.5 },
 							onContextMenu: (event) => {
 								event.preventDefault();

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -1,14 +1,15 @@
 const ProviderNetease = (() => {
 	const requestHeader = {
-		"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:93.0) Gecko/20100101 Firefox/93.0",
+		"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36",
+		Referer: "https://music.163.com/",
 	};
 
 	async function findLyrics(info) {
-		const searchURL = "https://music.xianqiao.wang/neteaseapiv2/search?limit=10&type=1&keywords=";
-		const lyricURL = "https://music.xianqiao.wang/neteaseapiv2/lyric?id=";
-
 		const cleanTitle = Utils.removeExtraInfo(Utils.removeSongFeat(Utils.normalize(info.title)));
-		const finalURL = searchURL + encodeURIComponent(`${cleanTitle} ${info.artist}`);
+		const finalURL =
+			"https://music.163.com/api/cloudsearch/pc?csrf_token=&type=1&offset=0&limit=10&s=" +
+			encodeURIComponent(`${cleanTitle} ${info.artist}`);
+		const getArtists = (val) => (val.ar ?? val.artists ?? []).map((artist) => artist.name).filter(Boolean);
 
 		const searchResults = await Spicetify.CosmosAsync.get(finalURL, null, requestHeader);
 		const items = searchResults.result.songs;
@@ -16,15 +17,50 @@ const ProviderNetease = (() => {
 			throw "Cannot find track";
 		}
 
+		const normalizedTitle = Utils.normalize(cleanTitle);
+		const normalizedArtist = Utils.normalize(info.artist);
+
 		// normalized expected album name
 		const neAlbumName = Utils.normalize(info.album);
 		const expectedAlbumName = Utils.containsHanCharacter(neAlbumName) ? await Utils.toSimplifiedChinese(neAlbumName) : neAlbumName;
-		let itemId = items.findIndex((val) => Utils.normalize(val.album.name) === expectedAlbumName);
-		if (itemId === -1) itemId = items.findIndex((val) => Math.abs(info.duration - val.duration) < 3000);
-		if (itemId === -1) itemId = items.findIndex((val) => val.name === cleanTitle);
-		if (itemId === -1) throw "Cannot find track";
+		const matches = items
+			.map((val, index) => {
+				const name = Utils.normalize(val.name);
+				const album = Utils.normalize(val.al?.name ?? val.album?.name);
+				const artists = Utils.normalize(getArtists(val).join(" "));
+				const durationDiff = Math.abs(info.duration - (val.dt ?? val.duration));
+				let score = 0;
 
-		return await Spicetify.CosmosAsync.get(lyricURL + items[itemId].id, null, requestHeader);
+				if (name === normalizedTitle) score += 50;
+				else if (name.includes(normalizedTitle) || normalizedTitle.includes(name)) score += 20;
+				if (artists && normalizedArtist && artists === normalizedArtist) score += 40;
+				else if (artists && normalizedArtist && (artists.includes(normalizedArtist) || normalizedArtist.includes(artists))) score += 25;
+				if (album === expectedAlbumName) score += 20;
+				if (durationDiff < 3000) score += 30;
+				else if (durationDiff < 10000) score += 10;
+
+				return { index, score };
+			})
+			.sort((a, b) => b.score - a.score);
+
+		const itemId = matches[0]?.score > 0 ? matches[0].index : -1;
+		if (itemId === -1) {
+			throw "Cannot find track";
+		}
+
+		const lyricURLs = [
+			`https://music.163.com/api/song/lyric/v1?id=${items[itemId].id}&lv=1&kv=1&tv=1`,
+			`https://music.163.com/api/song/lyric?id=${items[itemId].id}&lv=1&kv=1&tv=1`,
+		];
+
+		for (const url of lyricURLs) {
+			const list = await Spicetify.CosmosAsync.get(url, null, requestHeader);
+			if (list?.lrc?.lyric || list?.tlyric?.lyric || list?.klyric?.lyric) {
+				return list;
+			}
+		}
+
+		throw "Cannot find lyrics";
 	}
 
 	const creditInfo = [

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -6,9 +6,7 @@ const ProviderNetease = (() => {
 
 	async function findLyrics(info) {
 		const cleanTitle = Utils.removeExtraInfo(Utils.removeSongFeat(Utils.normalize(info.title)));
-		const finalURL =
-			"https://music.163.com/api/cloudsearch/pc?csrf_token=&type=1&offset=0&limit=10&s=" +
-			encodeURIComponent(`${cleanTitle} ${info.artist}`);
+		const finalURL = "https://music.163.com/api/cloudsearch/pc?csrf_token=&type=1&offset=0&limit=10&s=" + encodeURIComponent(`${cleanTitle} ${info.artist}`);
 		const getArtists = (val) => (val.ar ?? val.artists ?? []).map((artist) => artist.name).filter(Boolean);
 
 		const searchResults = await Spicetify.CosmosAsync.get(finalURL, null, requestHeader);

--- a/CustomApps/lyrics-plus/ProviderNetease.js
+++ b/CustomApps/lyrics-plus/ProviderNetease.js
@@ -6,7 +6,8 @@ const ProviderNetease = (() => {
 
 	async function findLyrics(info) {
 		const cleanTitle = Utils.removeExtraInfo(Utils.removeSongFeat(Utils.normalize(info.title)));
-		const finalURL = "https://music.163.com/api/cloudsearch/pc?csrf_token=&type=1&offset=0&limit=10&s=" + encodeURIComponent(`${cleanTitle} ${info.artist}`);
+		const finalURL =
+			"https://music.163.com/api/cloudsearch/pc?csrf_token=&type=1&offset=0&limit=10&s=" + encodeURIComponent(`${cleanTitle} ${info.artist}`);
 		const getArtists = (val) => (val.ar ?? val.artists ?? []).map((artist) => artist.name).filter(Boolean);
 
 		const searchResults = await Spicetify.CosmosAsync.get(finalURL, null, requestHeader);

--- a/CustomApps/lyrics-plus/Providers.js
+++ b/CustomApps/lyrics-plus/Providers.js
@@ -156,11 +156,18 @@ const Providers = {
 		const translation = ProviderNetease.getTranslation(list);
 		if ((synced || unsynced) && Array.isArray(translation)) {
 			const baseLyrics = synced ?? unsynced;
-			result.neteaseTranslation = baseLyrics.map((line) => ({
-				...line,
-				text: translation.find((t) => t.startTime === line.startTime)?.text ?? line.text,
-				originalText: line.text,
-			}));
+			const baseLanguage = Utils.detectLanguage(baseLyrics);
+			if (!baseLanguage?.startsWith("zh")) {
+				const comparableText = (value) => Utils.processLyrics(String(value ?? ""));
+				const neteaseTranslation = baseLyrics.map((line) => ({
+					...line,
+					text: translation.find((t) => Number(t.startTime) === Number(line.startTime))?.text ?? line.text,
+					originalText: line.text,
+				}));
+				if (neteaseTranslation.some((line) => comparableText(line.text) !== comparableText(line.originalText))) {
+					result.neteaseTranslation = neteaseTranslation;
+				}
+			}
 		}
 
 		return result;

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -88,7 +88,7 @@ const CONFIG = {
 		},
 		netease: {
 			on: getConfig("lyrics-plus:provider:netease:on", false),
-			desc: "Crowdsourced lyrics provider ran by Chinese developers and users.",
+			desc: "Lyrics and translated lyrics sourced from official Netease Cloud Music APIs.",
 			modes: [KARAOKE, SYNCED, UNSYNCED],
 		},
 		genius: {
@@ -109,7 +109,12 @@ const CONFIG = {
 
 try {
 	CONFIG.providersOrder = JSON.parse(CONFIG.providersOrder);
-	if (!Array.isArray(CONFIG.providersOrder) || Object.keys(CONFIG.providers).length !== CONFIG.providersOrder.length) {
+	const providerKeys = Object.keys(CONFIG.providers);
+	if (
+		!Array.isArray(CONFIG.providersOrder) ||
+		providerKeys.length !== CONFIG.providersOrder.length ||
+		providerKeys.some((key) => !CONFIG.providersOrder.includes(key))
+	) {
 		throw "";
 	}
 } catch {
@@ -433,6 +438,109 @@ class LyricsContainer extends react.Component {
 		finishRequest();
 	}
 
+	async attachNeteaseTranslation(trackInfo, finalData) {
+		if (!finalData || finalData.provider === "Netease" || finalData.neteaseTranslation) {
+			return finalData;
+		}
+
+		const baseLyrics = finalData.synced ?? finalData.unsynced;
+		if (!baseLyrics?.length) {
+			return finalData;
+		}
+		const baseLanguage = Utils.detectLanguage(baseLyrics);
+		if (baseLanguage?.startsWith("zh")) {
+			return finalData;
+		}
+
+		let list;
+		try {
+			list = await ProviderNetease.findLyrics(trackInfo);
+		} catch {
+			return finalData;
+		}
+
+		const translation = ProviderNetease.getTranslation(list);
+		if (!Array.isArray(translation) || !translation.length) {
+			return finalData;
+		}
+
+		const findTranslation = (line, index) => {
+			const startTime = Number(line.startTime);
+			if (Number.isFinite(startTime)) {
+				let nearest = null;
+				let nearestDiff = Number.POSITIVE_INFINITY;
+				for (const translatedLine of translation) {
+					const translatedStartTime = Number(translatedLine.startTime);
+					if (!Number.isFinite(translatedStartTime)) continue;
+					const diff = Math.abs(translatedStartTime - startTime);
+					if (diff < nearestDiff) {
+						nearest = translatedLine;
+						nearestDiff = diff;
+					}
+				}
+				if (nearestDiff <= 1500) {
+					return nearest;
+				}
+			}
+
+			return translation.length === baseLyrics.length ? translation[index] : null;
+		};
+
+		const comparableText = (value) => Utils.processLyrics(String(value ?? ""));
+		const neteaseTranslation = baseLyrics.map((line, index) => {
+			const matched = findTranslation(line, index);
+			const originalText = line.originalText ?? line.text;
+			return {
+				...line,
+				text: matched?.text ?? line.text,
+				originalText,
+			};
+		});
+		const translatedCount = neteaseTranslation.filter((line) => comparableText(line.text) !== comparableText(line.originalText)).length;
+		if (!translatedCount) {
+			return finalData;
+		}
+		finalData.neteaseTranslation = neteaseTranslation;
+
+		return finalData;
+	}
+
+	mergeConvertedOriginalLyrics(translatedLyrics, convertedLyrics) {
+		if (!Array.isArray(translatedLyrics) || !Array.isArray(convertedLyrics)) {
+			return translatedLyrics;
+		}
+
+		const findConvertedLine = (line, index) => {
+			const startTime = Number(line.startTime);
+			if (Number.isFinite(startTime)) {
+				let nearest = null;
+				let nearestDiff = Number.POSITIVE_INFINITY;
+				for (const convertedLine of convertedLyrics) {
+					const convertedStartTime = Number(convertedLine.startTime);
+					if (!Number.isFinite(convertedStartTime)) continue;
+					const diff = Math.abs(convertedStartTime - startTime);
+					if (diff < nearestDiff) {
+						nearest = convertedLine;
+						nearestDiff = diff;
+					}
+				}
+				if (nearestDiff <= 1500) {
+					return nearest;
+				}
+			}
+
+			return convertedLyrics.length === translatedLyrics.length ? convertedLyrics[index] : null;
+		};
+
+		return translatedLyrics.map((line, index) => {
+			const convertedLine = findConvertedLine(line, index);
+			return {
+				...line,
+				originalText: convertedLine?.text ?? line.originalText,
+			};
+		});
+	}
+
 	async tryServices(trackInfo, mode = -1) {
 		const currentMode = CONFIG.modes[mode] || "";
 		let finalData = { ...emptyState, uri: trackInfo.uri };
@@ -453,7 +561,7 @@ class LyricsContainer extends react.Component {
 			if (data.error || (!data.karaoke && !data.synced && !data.unsynced && !data.genius)) continue;
 			if (mode === -1) {
 				finalData = data;
-				return finalData;
+				return await this.attachNeteaseTranslation(trackInfo, finalData);
 			}
 
 			if (!data[currentMode]) {
@@ -484,10 +592,10 @@ class LyricsContainer extends react.Component {
 				}));
 			}
 
-			return finalData;
+			return await this.attachNeteaseTranslation(trackInfo, finalData);
 		}
 
-		return finalData;
+		return await this.attachNeteaseTranslation(trackInfo, finalData);
 	}
 
 	async fetchLyrics(track, mode = -1, refresh = false) {
@@ -513,6 +621,10 @@ class LyricsContainer extends react.Component {
 			if (CACHE[info.uri]?.mode) {
 				this.state.explicitMode = CACHE[info.uri]?.mode;
 				tempState = { ...tempState, mode: CACHE[info.uri]?.mode };
+			}
+			if (!tempState.neteaseTranslation && (tempState.synced || tempState.unsynced)) {
+				tempState = await this.attachNeteaseTranslation(info, tempState);
+				CACHE[info.uri] = { ...CACHE[info.uri], ...tempState };
 			}
 		} else {
 			this.setState({ ...emptyState, isLoading: true, isCached: false });
@@ -584,7 +696,8 @@ class LyricsContainer extends react.Component {
 		if (tempState.uri !== this.state.uri || refresh) {
 			// when a song starts for the first time and language-override is selected, the lyrics are converted to the specified language.
 			// however, when switching it off again, the detected language needs to be known, so defaultLanguage has been introduced.
-			const defaultLanguage = Utils.detectLanguage(this.state.currentLyrics);
+			const originalLyrics = tempState[CONFIG.modes[finalMode]] ?? this.state.currentLyrics;
+			const defaultLanguage = Utils.detectLanguage(originalLyrics);
 			const language =
 				CONFIG.visual["translate:detect-language-override"] !== "off" ? CONFIG.visual["translate:detect-language-override"] : defaultLanguage;
 			const friendlyLanguage = language && new Intl.DisplayNames(["en"], { type: "language" }).of(language.split("-")[0])?.toLowerCase();
@@ -592,11 +705,14 @@ class LyricsContainer extends react.Component {
 
 			const isMemory = CACHE[tempState.uri]?.[targetConvert];
 			if (CONFIG.visual.translate && defaultLanguage && !isMemory) {
-				this.translateLyrics(language, this.state.currentLyrics, targetConvert).then((translated) => {
+				this.translateLyrics(language, originalLyrics, targetConvert).then((translated) => {
 					const res = { [targetConvert]: translated };
 					// Cache translated lyrics
 					CACHE[tempState.uri] = { ...CACHE[tempState.uri], ...res };
-					this.setState({ ...res });
+					this.setState((prevState) => {
+						const nextState = { ...prevState, ...res };
+						return { ...res, currentLyrics: this.getCurrentLyricsForMode(nextState, finalMode) };
+					});
 				});
 			}
 
@@ -635,19 +751,43 @@ class LyricsContainer extends react.Component {
 		});
 	}
 
+	getCurrentLyricsForMode(lyricsState, mode) {
+		if (!lyricsState) return null;
+
+		const lyrics = lyricsState[CONFIG.modes[mode]];
+		const lang = this.provideLanguageCode(lyrics);
+		const friendlyLanguage = lang && new Intl.DisplayNames(["en"], { type: "language" }).of(lang.split("-")[0])?.toLowerCase();
+		const targetConvert = CONFIG.visual[`translation-mode:${friendlyLanguage}`];
+		const convertedLyrics = CONFIG.visual.translate ? lyricsState[targetConvert] : null;
+		const translatedLyrics = lyricsState[resolveTranslationSource(CONFIG.visual["translate:translated-lyrics-source"]).key];
+
+		if (translatedLyrics && convertedLyrics) {
+			return this.mergeConvertedOriginalLyrics(translatedLyrics, convertedLyrics);
+		}
+		if (translatedLyrics) {
+			return translatedLyrics;
+		}
+		return convertedLyrics ?? lyrics;
+	}
+
 	lyricsSource(lyricsState, mode) {
 		if (!lyricsState) return;
 
-		const lang = this.provideLanguageCode(this.state.currentLyrics);
+		// get original Lyrics
+		const lyrics = lyricsState[CONFIG.modes[mode]];
+		const lang = this.provideLanguageCode(lyrics);
 		const friendlyLanguage = lang && new Intl.DisplayNames(["en"], { type: "language" }).of(lang.split("-")[0])?.toLowerCase();
 
 		if (!this.displayMode) {
 			this.displayMode = CONFIG.visual[`translation-mode:${friendlyLanguage}`];
 		}
 
-		// get original Lyrics
-		const lyrics = lyricsState[CONFIG.modes[mode]];
-		const translationSourceConfig = resolveTranslationSource(CONFIG.visual["translate:translated-lyrics-source"]);
+		let translationSourceConfig = resolveTranslationSource(CONFIG.visual["translate:translated-lyrics-source"]);
+		if (translationSourceConfig.key === "none" && lyricsState.neteaseTranslation) {
+			translationSourceConfig = { key: "neteaseTranslation", language: null };
+			CONFIG.visual["translate:translated-lyrics-source"] = "neteaseTranslation";
+			localStorage.setItem(`${APP_NAME}:visual:translate:translated-lyrics-source`, "neteaseTranslation");
+		}
 
 		if (translationSourceConfig.language) {
 			const translationLanguageKey = `${APP_NAME}:visual:musixmatch-translation-language`;
@@ -662,11 +802,8 @@ class LyricsContainer extends react.Component {
 			}
 		}
 
-		if (CONFIG.visual.translate) {
-			this.state.currentLyrics = lyricsState[CONFIG.visual[`translation-mode:${friendlyLanguage}`]] ?? lyrics;
-		} else {
-			this.state.currentLyrics = lyricsState[translationSourceConfig.key] ?? lyrics;
-		}
+		const targetConvert = CONFIG.visual[`translation-mode:${friendlyLanguage}`];
+		this.state.currentLyrics = this.getCurrentLyricsForMode(lyricsState, mode);
 
 		// Convert Mode re-fresh
 		if (
@@ -679,7 +816,6 @@ class LyricsContainer extends react.Component {
 			this.displayMode = CONFIG.visual[`translation-mode:${friendlyLanguage}`];
 
 			if (CONFIG.visual.translate) {
-				const targetConvert = CONFIG.visual[`translation-mode:${friendlyLanguage}`];
 				const isCached = CACHE[lyricsState.uri]?.[targetConvert];
 
 				if (!isCached) {
@@ -687,7 +823,10 @@ class LyricsContainer extends react.Component {
 						const res = { [targetConvert]: translated };
 						// Cache translated lyrics
 						CACHE[lyricsState.uri] = { ...CACHE[lyricsState.uri], ...res };
-						this.setState({ ...this.state, ...res });
+						this.setState((prevState) => {
+							const nextState = { ...prevState, ...res };
+							return { ...res, currentLyrics: this.getCurrentLyricsForMode(nextState, mode) };
+						});
 					});
 				}
 			} else {

--- a/CustomApps/lyrics-plus/style.css
+++ b/CustomApps/lyrics-plus/style.css
@@ -227,6 +227,12 @@
 	line-height: var(--lyrics-line-height);
 }
 
+.lyrics-lyricsContainer-TranslatedLine {
+	font-size: 0.76em;
+	line-height: 1.15;
+	letter-spacing: 0;
+}
+
 @media (min-width: 1280px) {
 	.lyrics-lyricsContainer-SyncedLyrics .lyrics-lyricsContainer-LyricsLine {
 		font-weight: 900;


### PR DESCRIPTION
## Summary

- Switch Lyrics Plus Netease lookup to official Netease Cloud Music search and lyric APIs.
- Fetch Netease translated lyrics as a supplemental translation source even when the primary lyrics come from Spotify, LRCLIB, or Musixmatch.
- Allow translation providers and text conversion modes, such as Japanese furigana, to be used together.
- Avoid showing duplicate Chinese translations for Chinese source lyrics and make below-original translated lines smaller.

## Root Cause

Netease translations were only available when Netease was selected as the primary lyrics provider and returned `neteaseTranslation`. The translation menu also treated conversion and translated lyrics as mutually exclusive, so furigana and Chinese translations could not coexist. In addition, matching relied on exact timestamp types, which failed when timestamps were strings.

## Validation

- Ran `node --check` for the changed Lyrics Plus JavaScript files.
- Ran `git diff --check -- CustomApps/lyrics-plus`.
- Manually verified locally that Netease `tlyric` can be fetched, aligned, and displayed below converted Japanese lyrics, and that Chinese source lyrics do not duplicate as translations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Netease translation integration with improved lyrics matching and automatic language detection
  * Translation source selection now persists without automatic resets when toggling settings

* **Bug Fixes**
  * Improved accuracy in comparing original and translated lyrics content

* **Style**
  * Added dedicated styling for translated lyrics sections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spicetify/cli/pull/3851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->