### PR TITLE
fix: show error reason when installation fails

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -98,8 +98,15 @@ function Get-Spicetify {
       UseBasicParsin = $true
       OutFile        = $archivePath
     }
-    Invoke-WebRequest @Parameters
-    Write-Success
+    try {
+      Invoke-WebRequest @Parameters
+      Write-Success
+    } catch {
+      Write-Unsuccess
+      Write-Warning "Failed to download spicetify v$targetVersion. Reason: $_"
+      Pause
+      exit
+    }
   }
   end {
     $archivePath
@@ -121,9 +128,16 @@ function Add-SpicetifyToPath {
     }
   }
   end {
-    [Environment]::SetEnvironmentVariable('PATH', $path, $user)
-    $env:PATH = $path
-    Write-Success
+    try {
+      [Environment]::SetEnvironmentVariable('PATH', $path, $user)
+      $env:PATH = $path
+      Write-Success
+    } catch {
+      Write-Unsuccess
+      Write-Warning "Failed to add spicetify to PATH. Reason: $_"
+      Pause
+      exit
+    }
   }
 }
 
@@ -136,8 +150,15 @@ function Install-Spicetify {
   process {
     $archivePath = Get-Spicetify
     Write-Host -Object 'Extracting spicetify...' -NoNewline
-    Expand-Archive -Path $archivePath -DestinationPath $spicetifyFolderPath -Force
-    Write-Success
+    try {
+      Expand-Archive -Path $archivePath -DestinationPath $spicetifyFolderPath -Force
+      Write-Success
+    } catch {
+      Write-Unsuccess
+      Write-Warning "Failed to extract spicetify. Reason: $_"
+      Pause
+      exit
+    }
     Add-SpicetifyToPath
   }
   end {

--- a/install.ps1
+++ b/install.ps1
@@ -80,7 +80,7 @@ function Get-Spicetify {
       else {
         Write-Warning -Message "You have specified an invalid spicetify version: $v `nThe version must be in the following format: 1.2.3"
         Pause
-        exit
+        exit 1
       }
     }
     else {

--- a/install.ps1
+++ b/install.ps1
@@ -105,7 +105,7 @@ function Get-Spicetify {
       Write-Unsuccess
       Write-Warning "Failed to download spicetify v$targetVersion. Reason: $_"
       Pause
-      exit
+      exit 1
     }
   }
   end {
@@ -136,7 +136,7 @@ function Add-SpicetifyToPath {
       Write-Unsuccess
       Write-Warning "Failed to add spicetify to PATH. Reason: $_"
       Pause
-      exit
+      exit 1
     }
   }
 }
@@ -157,7 +157,7 @@ function Install-Spicetify {
       Write-Unsuccess
       Write-Warning "Failed to extract spicetify. Reason: $_"
       Pause
-      exit
+      exit 1
     }
     Add-SpicetifyToPath
   }

--- a/install.ps1
+++ b/install.ps1
@@ -179,7 +179,7 @@ if (-not (Test-PowerShellVersion)) {
   Write-Host -Object 'PowerShell 7 install guide:'
   Write-Host -Object 'https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-windows'
   Pause
-  exit
+  exit 1
 }
 else {
   Write-Success
@@ -196,7 +196,7 @@ if (-not (Test-Admin)) {
   if ($choice -eq 0) {
     Write-Host -Object 'spicetify installation aborted' -ForegroundColor 'Yellow'
     Pause
-    exit
+    exit 1
   }
 }
 else {

--- a/install.sh
+++ b/install.sh
@@ -75,13 +75,22 @@ tar="$spicetify_install/spicetify.tar.gz"
 [ ! -d "$spicetify_install" ] && log "CREATING $spicetify_install" && mkdir -p "$spicetify_install"
 
 log "DOWNLOADING $download_uri"
-curl --fail --location --progress-bar --output "$tar" "$download_uri"
+if ! curl --fail --location --progress-bar --output "$tar" "$download_uri"; then
+    log "ERROR: Failed to download spicetify. Check your internet connection or if the version '$tag' exists."
+    exit 1
+fi
 
 log "EXTRACTING $tar"
-tar xzf "$tar" -C "$spicetify_install"
+if ! tar xzf "$tar" -C "$spicetify_install"; then
+    log "ERROR: Failed to extract spicetify. The downloaded file may be corrupted."
+    exit 1
+fi
 
 log "SETTING EXECUTABLE PERMISSIONS TO $exe"
-chmod +x "$exe"
+if ! chmod +x "$exe"; then
+    log "ERROR: Failed to set executable permissions on $exe. Try running with correct permissions."
+    exit 1
+fi
 
 log "REMOVING $tar"
 rm "$tar"


### PR DESCRIPTION
Fixes #3854

Installation scripts now print a specific error reason when a step 
fails, instead of silently exiting.

## Changes
- install.sh: Added error handling for download, extraction, and chmod steps  
- install.ps1: Added try/catch blocks for download, extraction, and PATH update steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer reliability improved: Windows and Unix/Linux installers now detect and report failures during download, extraction, permission and environment setup steps, provide clearer diagnostic hints, pause on error, and terminate with a failure status. Installation now also exits early on invalid version input or unmet prerequisites to avoid partial or broken installs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spicetify/cli/pull/3855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->