### PR TITLE
fix: support rspack builds (Spotify 1.2.93+)

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -519,13 +519,30 @@ const fnStr = (f) => {
 };
 
 (async function hotloadWebpackModules() {
-	while (!window?.webpackChunkclient_web) {
+	// Spotify 1.2.93+ builds with rspack, which renames the chunk global.
+	while (!(window?.webpackChunkclient_web || window?.rspackChunkclient_web)) {
 		await new Promise((r) => setTimeout(r, 50));
 	}
+	const chunkGlobal = window.webpackChunkclient_web || window.rspackChunkclient_web;
 
 	// Force all webpack modules to load
-	const require = webpackChunkclient_web.push([[Symbol()], {}, (re) => re]);
+	const require = chunkGlobal.push([[Symbol()], {}, (re) => re]);
 	while (!require.m) await new Promise((r) => setTimeout(r, 50));
+
+	// rspack exposes proxy-trap module exports that return an object for any
+	// property access and throw on toString, matching every symbol heuristic
+	// below. Drop them from the cache.
+	const isProxyTrap = (m) => {
+		try {
+			return m != null && (typeof m === "object" || typeof m === "function") && m.__spicetify_probe__ !== undefined;
+		} catch {
+			return true;
+		}
+	};
+	const buildCache = () =>
+		Object.keys(require.m)
+			.map((id) => require(id))
+			.filter((m) => !isProxyTrap(m));
 	console.log("[spicetifyWrapper] Waiting for required webpack modules to load");
 	let webpackDidCallback = false;
 	// https://github.com/webpack/webpack/blob/main/lib/runtime/OnChunksLoadedRuntimeModule.js
@@ -539,7 +556,7 @@ const fnStr = (f) => {
 	);
 
 	let chunks = Object.entries(require.m);
-	let cache = Object.keys(require.m).map((id) => require(id));
+	let cache = buildCache();
 
 	// For _renderNavLinks to work
 	Spicetify.React = cache.find((m) => m?.useMemo);
@@ -549,7 +566,7 @@ const fnStr = (f) => {
 	}
 	console.log("[spicetifyWrapper] All required webpack modules loaded");
 	chunks = Object.entries(require.m);
-	cache = Object.keys(require.m).map((id) => require(id));
+	cache = buildCache();
 	Spicetify.Events.platformLoaded.fire();
 
 	const modules = cache
@@ -1363,7 +1380,8 @@ body[data-dragging-uri-type] .spicetify-sc-chevronBtn { pointer-events: none; }`
 				// Avoid creating 2 arrays of the same values
 				try {
 					const values = Object.values(m);
-					return values.some((m) => typeof m === "function") && values.some((m) => m?.PLAYLIST_V2);
+					// PLAYLIST_V2 must be a string; rspack proxy-trap exports return an object for any key.
+					return values.some((m) => typeof m === "function") && values.some((m) => typeof m?.PLAYLIST_V2 === "string");
 				} catch {
 					return false;
 				}
@@ -1371,7 +1389,7 @@ body[data-dragging-uri-type] .spicetify-sc-chevronBtn { pointer-events: none; }`
 		const URIModules = Object.values(URIChunk);
 
 		// URI.Type
-		Spicetify.URI.Type = URIModules.find((m) => m?.PLAYLIST_V2);
+		Spicetify.URI.Type = URIModules.find((m) => typeof m?.PLAYLIST_V2 === "string");
 
 		// Parse functions
 		Spicetify.URI.from = URIModules.find((m) => typeof m === "function" && m.toString().includes("allowedTypes"));

--- a/src/apply/apply.go
+++ b/src/apply/apply.go
@@ -62,6 +62,8 @@ func AdditionalOptions(appsFolderPath string, flags Flag) {
 	}
 
 	filesToModified[filepath.Join(appsFolderPath, "xpui", "xpui.js")] = append(filesToModified[filepath.Join(appsFolderPath, "xpui", "xpui.js")], insertCustomApp)
+	// Spotify 1.2.93+ (rspack) splits the route/lazy code into xpui-modules.js
+	filesToModified[filepath.Join(appsFolderPath, "xpui", "xpui-modules.js")] = append(filesToModified[filepath.Join(appsFolderPath, "xpui", "xpui-modules.js")], insertCustomApp)
 	if spotifyMajor >= 1 && spotifyMinor >= 2 && spotifyPatch >= 57 {
 		filesToModified[filepath.Join(appsFolderPath, "xpui", "xpui.js")] = append(filesToModified[filepath.Join(appsFolderPath, "xpui", "xpui.js")], insertExpFeatures)
 	} else {

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -366,12 +366,13 @@ func RefreshApps(list ...string) {
 			}
 		}
 
+		// Register with rspackChunkclient_web on Spotify 1.2.93+ (rspack) and fall
+		// back to webpackChunkclient_web on older builds.
 		jsTemplate := fmt.Sprintf(
-			`(("undefined"!=typeof self?self:global).webpackChunkclient_web=("undefined"!=typeof self?self:global).webpackChunkclient_web||[])
-.push([["%s"],{"%s":(e,t,n)=>{
+			`(g=>(g.rspackChunkclient_web||(g.webpackChunkclient_web=g.webpackChunkclient_web||[])).push([["%s"],{"%s":(e,t,n)=>{
 "use strict";n.r(t),n.d(t,{default:()=>render});
 %s
-}}]);`,
+}}]))("undefined"!=typeof self?self:global);`,
 			appName, appName, jsFileContent)
 
 		os.WriteFile(


### PR DESCRIPTION
## Problem

Spotify 1.2.93 migrated its client bundle from **webpack to rspack**. This breaks Spicetify in several ways on current Spotify, with no workaround from config:

- **Extensions & context menus break** — `Spicetify.React` and `Spicetify.URI` resolve to `undefined` ("Something went wrong" on right-click).
- **Custom apps don't mount** — Marketplace (and other custom apps) render a blank page with `useNavigateStable must be used within a StableUseNavigateProvider`, and `apply` prints "Spotify version mismatch".

## Root causes & fixes

**Wrapper (`jsHelper/spicetifyWrapper.js`)**
- rspack renames the chunk global to `rspackChunkclient_web`; accept either global.
- rspack exposes proxy-trap module exports that return an object for any property and throw on `toString`, matching every symbol heuristic. Filter them out of the module cache.
- The URI chunk lookup accepted any truthy `PLAYLIST_V2` (a proxy-trap satisfied it); require a string.

**Custom apps (`src/apply/apply.go`, `src/cmd/apply.go`)**
- Routing moved out of `xpui.js` (which no longer exists on rspack) into `xpui-modules.js`; run `insertCustomApp` against that file too. The existing regexes already match rspack's output — only the target file was wrong.
- Generated custom-app chunks registered with `webpackChunkclient_web`, which the rspack runtime never reads, causing `ChunkLoadError`. Register with `rspackChunkclient_web` when present, falling back to the webpack global for older Spotify.

## Testing

Built from this branch and applied against **Spotify 1.2.93.667** (rspack). After applying:
- Extensions load and context menus work again (`Spicetify.React`/`URI` resolve).
- Marketplace mounts and renders its catalog.
- Verified older-Spotify paths are preserved (webpack global fallback, `xpui.js` still targeted when present).

Backwards compatible: all changes fall back to the previous webpack behaviour when the rspack globals/files are absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer Spotify builds, reducing issues when loading or refreshing custom apps.
  * Fixed module detection so app routing and URI handling work more reliably across different build types.
* **New Features**
  * Added broader support for modern build formats, helping the app continue working on updated releases without manual changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->