### PR TITLE
fix(css-map): correct malformed CSS class name

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -2109,7 +2109,7 @@
 	"MWWPQQjbjRfoGdPD8D68": "profile-userOverview-subPage",
 	"uJxNEI2k7x8UCDdMKELt": "profile-userOverview-title",
 	"kWCnF32FrVtGHmTy8QeV": "profile-userOverview-topTrackSubPage",
-	"kPLEzaZADEAjWLC2s": "progress-bar",
+	"kPLEzaZADEAjWLC2": "progress-bar",
 	"TywOcKZEqNynWecCiATc": "progress-bar",
 	"NP0jD9fPfkH_VmIJ4hEg": "progress-bar",
 	"LS6q7yFFlYCqXoVxEETT": "progress-bar",


### PR DESCRIPTION
An extra 's' was in the class name.

This class affects the playback progress bar and volume control bar.

<img width="918" height="93" alt="Snipaste_2026-07-05_00-03-00" src="https://github.com/user-attachments/assets/900e04ff-1626-4875-b994-3be53e1b9e7f" />

<img width="918" height="93" alt="Snipaste_2026-07-05_00-00-43" src="https://github.com/user-attachments/assets/3cde11a4-0816-47f0-8cc6-5af2aab1c96c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the progress bar’s style mapping key to ensure consistent rendering across views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->