### PR TITLE
fix(installer): keep spicetify in process PATH

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -95,7 +95,7 @@ function Get-Spicetify {
     Write-Host -Object "Downloading spicetify v$targetVersion..." -NoNewline
     $Parameters = @{
       Uri            = "https://github.com/spicetify/cli/releases/download/v$targetVersion/spicetify-$targetVersion-windows-$architecture.zip"
-      UseBasicParsin = $true
+      UseBasicParsing = $true
       OutFile        = $archivePath
     }
     Invoke-WebRequest @Parameters
@@ -113,16 +113,22 @@ function Add-SpicetifyToPath {
     Write-Host -Object 'Making spicetify available in the PATH...' -NoNewline
     $user = [EnvironmentVariableTarget]::User
     $path = [Environment]::GetEnvironmentVariable('PATH', $user)
+    $processPath = $env:PATH
   }
   process {
     $path = $path -replace "$([regex]::Escape($spicetifyOldFolderPath))\\*;*", ''
     if ($path -notlike "*$spicetifyFolderPath*") {
       $path = "$path;$spicetifyFolderPath"
     }
+
+    $processPath = $processPath -replace "$([regex]::Escape($spicetifyOldFolderPath))\\*;*", ''
+    if ($processPath -notlike "*$spicetifyFolderPath*") {
+      $processPath = "$processPath;$spicetifyFolderPath"
+    }
   }
   end {
     [Environment]::SetEnvironmentVariable('PATH', $path, $user)
-    $env:PATH = $path
+    $env:PATH = $processPath
     Write-Success
   }
 }


### PR DESCRIPTION
## Summary
- keep the existing process `PATH` when adding the Spicetify install directory, so child scripts can resolve `spicetify` in the same PowerShell session
- remove the old install directory from the process `PATH` as well as the user `PATH`
- fix the `UseBasicParsing` splatted parameter typo in the Windows installer download step

Fixes #3871

## Tests
- parsed `install.ps1` with `System.Management.Automation.Language.Parser`
- verified `Invoke-WebRequest` exposes `UseBasicParsing` in Windows PowerShell 5.1
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`
- `go test ./...`

Note: I did not run the full installer locally to avoid modifying the machine's Spicetify/Spotify installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the install/download process so web requests are configured correctly, helping avoid installation issues.
  * Fixed PATH updates to reliably remove old entries and add the app location to both the current session and future sessions, making the app easier to run after setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->