### PR TITLE
fix(utils): avoid panics when creating default ini sections

### DIFF
--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -147,7 +147,8 @@ func getDefaultConfig() *ini.File {
 	for sectionName, keyList := range configLayout {
 		section, err := cfg.NewSection(sectionName)
 		if err != nil {
-			panic(err)
+			PrintError(fmt.Sprintf("Failed to create config section %s: %s", sectionName, err.Error()))
+			continue
 		}
 		for keyName, defaultValue := range keyList {
 			section.NewKey(keyName, defaultValue)
@@ -156,11 +157,12 @@ func getDefaultConfig() *ini.File {
 
 	version, err := cfg.NewSection("Backup")
 	if err != nil {
-		panic(err)
+		PrintError(fmt.Sprintf("Failed to create Backup section: %s", err.Error()))
+	} else {
+		version.Comment = "DO NOT CHANGE!"
+		version.NewKey("version", "")
+		version.NewKey("with", "")
 	}
-	version.Comment = "DO NOT CHANGE!"
-	version.NewKey("version", "")
-	version.NewKey("with", "")
 	return cfg
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration setup resilience by reporting section-creation errors without terminating the application.
  * Continued processing available configuration sections when individual sections cannot be created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->