### PR TITLE
feat(cli): hard-fail backup/apply on unsupported Spotify versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
         if: env.IS_UNIX == 'true'
         uses: edgarrc/action-7z@v1
         with:
-          args: 7z a -bb0 "spicetify-${{ env.TAG }}-${{ matrix.os }}-${{ matrix.arch }}.tar" "./spicetify" "./CustomApps" "./Extensions" "./Themes" "./jsHelper" "globals.d.ts" "css-map.json"
+          args: 7z a -bb0 "spicetify-${{ env.TAG }}-${{ matrix.os }}-${{ matrix.arch }}.tar" "./spicetify" "./CustomApps" "./Extensions" "./Themes" "./jsHelper" "globals.d.ts" "css-map.json" "supported-versions.json"
 
       - name: 7z - .tar.gz
         if: env.IS_UNIX == 'true'
@@ -156,7 +156,7 @@ jobs:
         if: env.IS_WIN == 'true'
         uses: edgarrc/action-7z@v1
         with:
-          args: 7z a -bb0 -mx9 "spicetify-${{ env.TAG }}-${{ matrix.os }}-${{ (matrix.arch == 'amd64' && 'x64') || (matrix.arch == 'arm64' && 'arm64') || 'x32' }}.zip" "./spicetify.exe" "./CustomApps" "./Extensions" "./Themes" "./jsHelper" "globals.d.ts" "css-map.json"
+          args: 7z a -bb0 -mx9 "spicetify-${{ env.TAG }}-${{ matrix.os }}-${{ (matrix.arch == 'amd64' && 'x64') || (matrix.arch == 'arm64' && 'arm64') || 'x32' }}.zip" "./spicetify.exe" "./CustomApps" "./Extensions" "./Themes" "./jsHelper" "globals.d.ts" "css-map.json" "supported-versions.json"
 
       - name: Release
         if: env.IS_UNIX == 'true' || env.IS_WIN == 'true'

--- a/spicetify.go
+++ b/spicetify.go
@@ -25,15 +25,16 @@ var (
 )
 
 var (
-	flags            = []string{}
-	commands         = []string{}
-	quiet            = false
-	extensionFocus   = false
-	appFocus         = false
-	styleFocus       = false
-	noRestart        = false
-	liveRefresh      = false
-	bypassAdminCheck = false
+	flags                   = []string{}
+	commands                = []string{}
+	quiet                   = false
+	extensionFocus          = false
+	appFocus                = false
+	styleFocus              = false
+	noRestart               = false
+	liveRefresh             = false
+	bypassAdminCheck        = false
+	forceUnsupportedSpotify = false
 )
 
 func init() {
@@ -70,6 +71,8 @@ func init() {
 		switch v {
 		case "--bypass-admin":
 			bypassAdminCheck = true
+		case "--force-unsupported-spotify":
+			forceUnsupportedSpotify = true
 		case "-c", "--config":
 			log.Println(cmd.GetConfigPath())
 			os.Exit(0)
@@ -123,16 +126,19 @@ func init() {
 		os.Exit(1)
 	}
 
-	for i, flag := range flags {
-		if flag == "--bypass-admin" {
-			flags = append(flags[:i], flags[i+1:]...)
-			break
+	for _, strip := range []string{"--bypass-admin", "--force-unsupported-spotify"} {
+		for i, flag := range flags {
+			if flag == strip {
+				flags = append(flags[:i], flags[i+1:]...)
+				break
+			}
 		}
 	}
 
 	utils.MigrateConfigFolder()
 	utils.MigrateFolders()
 	cmd.InitConfig(quiet)
+	cmd.SetForceUnsupportedSpotify(forceUnsupportedSpotify)
 
 	if len(commands) < 1 {
 		help()
@@ -494,6 +500,10 @@ upgrade|update      Update spicetify to the latest version if an update is avail
 
 --bypass-admin      Bypass admin or root (sudo) check. NOT RECOMMENDED
 
+--force-unsupported-spotify
+                    Allow backup/apply on Spotify versions outside the
+                    supported list. NOT RECOMMENDED; the client may break.
+
 -c, --config        Print config file path and quit
 
 -h, --help          Print this help text and quit
@@ -539,6 +549,10 @@ always_enable_devtools <0 | 1>
 
 check_spicetify_update <0 | 1>
     Whether to always check for updates when running Spicetify.
+
+spotify_version_check <0 | 1>
+    Whether backup/apply refuse unsupported Spotify versions.
+    Disable only if you accept that the client may break.
 
 ` + utils.Bold("[Preprocesses]") + `
 disable_sentry <0 | 1>

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -15,6 +15,8 @@ import (
 
 // Apply .
 func Apply(spicetifyVersion string) {
+	RequireSupportedSpotify()
+
 	utils.MigrateConfigFolder()
 
 	backupSpicetifyVersion := backupSection.Key("with").MustString("")

--- a/src/cmd/auto.go
+++ b/src/cmd/auto.go
@@ -10,6 +10,8 @@ import (
 // Auto checks Spotify state, re-backup and apply if needed, then launch
 // Spotify client normally.
 func Auto(spicetifyVersion string) {
+	RequireSupportedSpotify()
+
 	backupVersion := backupSection.Key("version").MustString("")
 	spotStat := spotifystatus.Get(appPath)
 	backStat := backupstatus.Get(prefsPath, backupFolder, backupVersion)

--- a/src/cmd/backup.go
+++ b/src/cmd/backup.go
@@ -15,6 +15,8 @@ import (
 // Backup stores original apps packages, extracts them and preprocesses extracted apps' assets
 // If silent is true, the final readiness message is suppressed (useful when chaining with "apply")
 func Backup(spicetifyVersion string, silent bool) {
+	RequireSupportedSpotify()
+
 	if isAppX {
 		utils.PrintInfo(`You are using the Microsoft Store version of Spotify, which is only partly supported.
 Don't use the Microsoft Store version with Spicetify unless you absolutely CANNOT install Spotify from its installer.

--- a/src/cmd/support.go
+++ b/src/cmd/support.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spicetify/cli/src/utils"
+)
+
+// forceUnsupportedSpotify allows backup/apply when the installed Spotify
+// version is outside the shipped support list.
+var forceUnsupportedSpotify bool
+
+// SetForceUnsupportedSpotify enables the one-shot CLI override.
+func SetForceUnsupportedSpotify(force bool) {
+	forceUnsupportedSpotify = force
+}
+
+// RequireSupportedSpotify exits if the installed Spotify version is not in
+// supported-versions.json, unless the user opted out via flag or config.
+// prefsPath must already be resolved (InitPaths).
+func RequireSupportedSpotify() {
+	raw := utils.GetSpotifyVersion(prefsPath)
+
+	if forceUnsupportedSpotify {
+		utils.PrintWarning("Skipping Spotify version support check (--force-unsupported-spotify). The client may break.")
+		return
+	}
+
+	if settingSection != nil && !settingSection.Key("spotify_version_check").MustBool(true) {
+		utils.PrintWarning("Skipping Spotify version support check (spotify_version_check=0). The client may break.")
+		return
+	}
+
+	if raw == "" {
+		utils.PrintError("Cannot read Spotify version from prefs. Is prefs_path correct and has Spotify been launched at least once?")
+		utils.PrintInfo("Set prefs_path in config-xpui.ini, or launch Spotify once, then retry.")
+		os.Exit(1)
+	}
+
+	normalized, err := utils.NormalizeSpotifyVersion(raw)
+	if err != nil {
+		utils.PrintError("Cannot parse Spotify version " + raw + ": " + err.Error())
+		os.Exit(1)
+	}
+
+	listPath := utils.DefaultSupportedVersionsPath()
+	list, err := utils.LoadSupportedVersions(listPath)
+	if err != nil {
+		utils.PrintError(err.Error())
+		utils.PrintInfo("Reinstall Spicetify so supported-versions.json is next to the spicetify binary.")
+		os.Exit(1)
+	}
+
+	if list.IsSupported(normalized) {
+		return
+	}
+
+	classmapKey, keyErr := utils.SpotifyVersionToClassmapKey(normalized)
+	utils.PrintError("Spotify " + raw + " (" + normalized + ") is not supported by this Spicetify release.")
+	utils.PrintInfo("Supported versions: " + list.SupportedSummary())
+	if keyErr == nil {
+		utils.PrintInfo("Classmap key for this version would be: " + classmapKey)
+	}
+	utils.PrintInfo("Install a supported Spotify build, or upgrade Spicetify when support is added.")
+	utils.PrintInfo("To override (may break the client): --force-unsupported-spotify")
+	utils.PrintInfo("Or set spotify_version_check=0 in config-xpui.ini")
+	os.Exit(1)
+}

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -24,6 +24,7 @@ var (
 			"overwrite_assets":       "0",
 			"spotify_launch_flags":   "",
 			"check_spicetify_update": "1",
+			"spotify_version_check":  "1",
 			"always_enable_devtools": "0",
 		},
 		"Preprocesses": {

--- a/src/utils/spotify_version.go
+++ b/src/utils/spotify_version.go
@@ -1,0 +1,116 @@
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// SpotifyVersion is a normalized major.minor.patch Spotify desktop version.
+type SpotifyVersion struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+// String returns the normalized major.minor.patch form.
+func (v SpotifyVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// ClassmapKey encodes the version as used by spicetify/classmaps folders
+// (e.g. 1.2.45 -> "1020045", 1.2.93 -> "1020093").
+func (v SpotifyVersion) ClassmapKey() string {
+	return fmt.Sprintf("%d%02d%04d", v.Major, v.Minor, v.Patch)
+}
+
+// ParseSpotifyVersion parses a Spotify version string from prefs or config.
+// Accepts forms like "1.2.93", "1.2.93.12.gdeadbeef", and optional leading "v".
+func ParseSpotifyVersion(raw string) (SpotifyVersion, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return SpotifyVersion{}, fmt.Errorf("empty Spotify version")
+	}
+	if strings.HasPrefix(raw, "v") || strings.HasPrefix(raw, "V") {
+		raw = raw[1:]
+	}
+
+	parts := strings.Split(raw, ".")
+	if len(parts) < 3 {
+		return SpotifyVersion{}, fmt.Errorf("invalid Spotify version %q: need major.minor.patch", raw)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return SpotifyVersion{}, fmt.Errorf("invalid Spotify major version in %q: %w", raw, err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return SpotifyVersion{}, fmt.Errorf("invalid Spotify minor version in %q: %w", raw, err)
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return SpotifyVersion{}, fmt.Errorf("invalid Spotify patch version in %q: %w", raw, err)
+	}
+	if major < 0 || minor < 0 || patch < 0 {
+		return SpotifyVersion{}, fmt.Errorf("invalid Spotify version %q: negative component", raw)
+	}
+
+	return SpotifyVersion{Major: major, Minor: minor, Patch: patch}, nil
+}
+
+// NormalizeSpotifyVersion returns the major.minor.patch form of raw.
+func NormalizeSpotifyVersion(raw string) (string, error) {
+	v, err := ParseSpotifyVersion(raw)
+	if err != nil {
+		return "", err
+	}
+	return v.String(), nil
+}
+
+// CompareSpotifyVersion compares two version strings on major.minor.patch.
+// Returns -1 if a < b, 0 if equal, 1 if a > b.
+func CompareSpotifyVersion(a, b string) (int, error) {
+	va, err := ParseSpotifyVersion(a)
+	if err != nil {
+		return 0, err
+	}
+	vb, err := ParseSpotifyVersion(b)
+	if err != nil {
+		return 0, err
+	}
+	return va.Compare(vb), nil
+}
+
+// Compare returns -1 if v < other, 0 if equal, 1 if v > other.
+func (v SpotifyVersion) Compare(other SpotifyVersion) int {
+	if v.Major != other.Major {
+		if v.Major < other.Major {
+			return -1
+		}
+		return 1
+	}
+	if v.Minor != other.Minor {
+		if v.Minor < other.Minor {
+			return -1
+		}
+		return 1
+	}
+	if v.Patch != other.Patch {
+		if v.Patch < other.Patch {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+// SpotifyVersionToClassmapKey converts a normalized or full version string
+// into a classmap folder key.
+func SpotifyVersionToClassmapKey(raw string) (string, error) {
+	v, err := ParseSpotifyVersion(raw)
+	if err != nil {
+		return "", err
+	}
+	return v.ClassmapKey(), nil
+}

--- a/src/utils/spotify_version_test.go
+++ b/src/utils/spotify_version_test.go
@@ -1,0 +1,81 @@
+package utils
+
+import "testing"
+
+func TestParseAndNormalizeSpotifyVersion(t *testing.T) {
+	tests := []struct {
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{"1.2.93", "1.2.93", false},
+		{"1.2.93.12.gdeadbeef", "1.2.93", false},
+		{"v1.2.45", "1.2.45", false},
+		{" 1.2.86 ", "1.2.86", false},
+		{"", "", true},
+		{"1.2", "", true},
+		{"foo", "", true},
+		{"1.2.x", "", true},
+	}
+
+	for _, tt := range tests {
+		got, err := NormalizeSpotifyVersion(tt.raw)
+		if tt.wantErr {
+			if err == nil {
+				t.Fatalf("NormalizeSpotifyVersion(%q) expected error, got %q", tt.raw, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("NormalizeSpotifyVersion(%q) unexpected error: %v", tt.raw, err)
+		}
+		if got != tt.want {
+			t.Fatalf("NormalizeSpotifyVersion(%q) = %q, want %q", tt.raw, got, tt.want)
+		}
+	}
+}
+
+func TestSpotifyVersionClassmapKey(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want string
+	}{
+		{"1.2.45", "1020045"},
+		{"1.2.93", "1020093"},
+		{"1.2.8", "1020008"},
+		{"1.2.38", "1020038"},
+	}
+
+	for _, tt := range tests {
+		got, err := SpotifyVersionToClassmapKey(tt.raw)
+		if err != nil {
+			t.Fatalf("SpotifyVersionToClassmapKey(%q): %v", tt.raw, err)
+		}
+		if got != tt.want {
+			t.Fatalf("SpotifyVersionToClassmapKey(%q) = %q, want %q", tt.raw, got, tt.want)
+		}
+	}
+}
+
+func TestCompareSpotifyVersion(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1.2.86", "1.2.86", 0},
+		{"1.2.86", "1.2.93", -1},
+		{"1.2.93", "1.2.86", 1},
+		{"1.2.93.9.gabc", "1.2.93", 0},
+		{"1.1.99", "1.2.0", -1},
+	}
+
+	for _, tt := range tests {
+		got, err := CompareSpotifyVersion(tt.a, tt.b)
+		if err != nil {
+			t.Fatalf("CompareSpotifyVersion(%q, %q): %v", tt.a, tt.b, err)
+		}
+		if got != tt.want {
+			t.Fatalf("CompareSpotifyVersion(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}

--- a/src/utils/supported_versions.go
+++ b/src/utils/supported_versions.go
@@ -1,0 +1,143 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// SupportRange is an inclusive major.minor.patch range.
+type SupportRange struct {
+	Min  string `json:"min"`
+	Max  string `json:"max"`
+	Note string `json:"note,omitempty"`
+}
+
+// SupportList is the on-disk schema for supported-versions.json.
+type SupportList struct {
+	SchemaVersion int               `json:"schema_version"`
+	Updated       string            `json:"updated,omitempty"`
+	Policy        string            `json:"policy"`
+	Versions      []string          `json:"versions"`
+	Ranges        []SupportRange    `json:"ranges"`
+	Notes         map[string]string `json:"notes,omitempty"`
+}
+
+// DefaultSupportedVersionsPath returns the path next to the executable,
+// matching how css-map.json is resolved.
+func DefaultSupportedVersionsPath() string {
+	return filepath.Join(GetExecutableDir(), "supported-versions.json")
+}
+
+// LoadSupportedVersions reads and validates a support list file.
+func LoadSupportedVersions(path string) (*SupportList, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read supported versions list at %s: %w", path, err)
+	}
+
+	var list SupportList
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("supported versions list is malformed (%s): %w", path, err)
+	}
+
+	if list.SchemaVersion != 1 {
+		return nil, fmt.Errorf("unsupported supported-versions schema_version %d (want 1)", list.SchemaVersion)
+	}
+	if list.Policy != "" && list.Policy != "allowlist" {
+		return nil, fmt.Errorf("unsupported supported-versions policy %q (want allowlist)", list.Policy)
+	}
+	if list.Policy == "" {
+		list.Policy = "allowlist"
+	}
+
+	for i, v := range list.Versions {
+		normalized, err := NormalizeSpotifyVersion(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid versions[%d] %q: %w", i, v, err)
+		}
+		list.Versions[i] = normalized
+	}
+
+	for i, r := range list.Ranges {
+		min, err := NormalizeSpotifyVersion(r.Min)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ranges[%d].min %q: %w", i, r.Min, err)
+		}
+		max, err := NormalizeSpotifyVersion(r.Max)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ranges[%d].max %q: %w", i, r.Max, err)
+		}
+		if cmp, err := CompareSpotifyVersion(min, max); err != nil {
+			return nil, err
+		} else if cmp > 0 {
+			return nil, fmt.Errorf("invalid ranges[%d]: min %s is greater than max %s", i, min, max)
+		}
+		list.Ranges[i].Min = min
+		list.Ranges[i].Max = max
+	}
+
+	return &list, nil
+}
+
+// IsSupported reports whether normalized major.minor.patch is allowlisted.
+func (s *SupportList) IsSupported(normalized string) bool {
+	if s == nil {
+		return false
+	}
+
+	v, err := ParseSpotifyVersion(normalized)
+	if err != nil {
+		return false
+	}
+	normalized = v.String()
+
+	for _, exact := range s.Versions {
+		if exact == normalized {
+			return true
+		}
+	}
+
+	for _, r := range s.Ranges {
+		minCmp, err := CompareSpotifyVersion(normalized, r.Min)
+		if err != nil {
+			continue
+		}
+		maxCmp, err := CompareSpotifyVersion(normalized, r.Max)
+		if err != nil {
+			continue
+		}
+		if minCmp >= 0 && maxCmp <= 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// SupportedSummary returns a compact human-readable list of supported versions.
+func (s *SupportList) SupportedSummary() string {
+	if s == nil {
+		return "(none)"
+	}
+
+	parts := make([]string, 0, len(s.Versions)+len(s.Ranges))
+	parts = append(parts, s.Versions...)
+	for _, r := range s.Ranges {
+		if r.Min == r.Max {
+			parts = append(parts, r.Min)
+		} else {
+			parts = append(parts, fmt.Sprintf("%s–%s", r.Min, r.Max))
+		}
+	}
+
+	if len(parts) == 0 {
+		return "(none listed)"
+	}
+
+	sort.Strings(parts)
+	return strings.Join(parts, ", ")
+}

--- a/src/utils/supported_versions_test.go
+++ b/src/utils/supported_versions_test.go
@@ -1,0 +1,131 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSupportListIsSupported(t *testing.T) {
+	list := &SupportList{
+		SchemaVersion: 1,
+		Policy:        "allowlist",
+		Versions:      []string{"1.2.93"},
+		Ranges: []SupportRange{
+			{Min: "1.2.86", Max: "1.2.92"},
+		},
+	}
+
+	cases := map[string]bool{
+		"1.2.93":        true,
+		"1.2.93.1.gabc": true,
+		"1.2.86":        true,
+		"1.2.92":        true,
+		"1.2.90":        true,
+		"1.2.85":        false,
+		"1.2.94":        false,
+		"":              false,
+		"nope":          false,
+	}
+
+	for raw, want := range cases {
+		normalized := raw
+		if raw != "" && raw != "nope" {
+			var err error
+			normalized, err = NormalizeSpotifyVersion(raw)
+			if err != nil {
+				if want {
+					t.Fatalf("unexpected normalize error for %q: %v", raw, err)
+				}
+				if list.IsSupported(raw) {
+					t.Fatalf("IsSupported(%q) = true, want false", raw)
+				}
+				continue
+			}
+		}
+		if got := list.IsSupported(normalized); got != want {
+			t.Fatalf("IsSupported(%q) = %v, want %v", raw, got, want)
+		}
+	}
+}
+
+func TestLoadSupportedVersions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "supported-versions.json")
+	content := `{
+  "schema_version": 1,
+  "policy": "allowlist",
+  "versions": ["1.2.93"],
+  "ranges": [{"min": "1.2.86", "max": "1.2.92"}]
+}`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	list, err := LoadSupportedVersions(path)
+	if err != nil {
+		t.Fatalf("LoadSupportedVersions: %v", err)
+	}
+	if !list.IsSupported("1.2.90") || !list.IsSupported("1.2.93") {
+		t.Fatalf("loaded list missing expected support")
+	}
+	if list.IsSupported("1.2.85") {
+		t.Fatalf("loaded list should not support 1.2.85")
+	}
+
+	summary := list.SupportedSummary()
+	if summary == "" || summary == "(none)" {
+		t.Fatalf("unexpected summary %q", summary)
+	}
+}
+
+func TestLoadSupportedVersionsRejectsBadRange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "supported-versions.json")
+	content := `{
+  "schema_version": 1,
+  "policy": "allowlist",
+  "versions": [],
+  "ranges": [{"min": "1.2.93", "max": "1.2.86"}]
+}`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadSupportedVersions(path); err == nil {
+		t.Fatal("expected error for inverted range")
+	}
+}
+
+func TestLoadSupportedVersionsMissingFile(t *testing.T) {
+	if _, err := LoadSupportedVersions(filepath.Join(t.TempDir(), "nope.json")); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestShippedSupportedVersionsJSON(t *testing.T) {
+	// When tests run from package dir, walk up to module root.
+	candidates := []string{
+		"supported-versions.json",
+		filepath.Join("..", "..", "supported-versions.json"),
+	}
+	var path string
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			path = c
+			break
+		}
+	}
+	if path == "" {
+		t.Skip("supported-versions.json not found relative to test cwd")
+	}
+	list, err := LoadSupportedVersions(path)
+	if err != nil {
+		t.Fatalf("shipped supported-versions.json invalid: %v", err)
+	}
+	if !list.IsSupported("1.2.93") || !list.IsSupported("1.2.86") {
+		t.Fatalf("seed range should include 1.2.86–1.2.93")
+	}
+	if list.IsSupported("1.2.85") || list.IsSupported("1.2.94") {
+		t.Fatalf("seed range edges incorrect")
+	}
+}

--- a/supported-versions.json
+++ b/supported-versions.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "updated": "2026-07-20",
+  "policy": "allowlist",
+  "versions": [],
+  "ranges": [
+    {
+      "min": "1.2.86",
+      "max": "1.2.93",
+      "note": "Recent mainline support window"
+    }
+  ],
+  "notes": {
+    "1.2.93": "Explicitly targeted in cli main"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `supported-versions.json` (seed allowlist: Spotify **1.2.86–1.2.93**) shipped with releases
- Gate `backup`, `apply`, and `auto` so unknown Spotify versions fail closed with a clear message
- Escape hatches: `--force-unsupported-spotify` and `spotify_version_check=0`
- Version helpers normalize prefs strings (`1.2.93.x…` → `1.2.93`) and encode classmap keys for later phases

## Why

Spicetify currently fails late (regex mismatch) on new Spotify builds. This is the first step toward only applying to known versions, with the support list as the source of truth.

## Overrides

| Mechanism | Effect |
|-----------|--------|
| Default | Hard-fail when version is outside the list |
| `--force-unsupported-spotify` | One-shot bypass (warns) |
| `spotify_version_check=0` | Persistent bypass in config |

`restore` / `clear` / config commands stay ungated so recovery always works.

## Test plan

- [x] `go test ./src/utils/`
- [x] `go build`
- [ ] On a supported Spotify: `spicetify backup` proceeds past the gate
- [ ] Temporarily shrink the range so current Spotify is excluded: `backup`/`apply` exit 1 with support summary
- [ ] Same case with `--force-unsupported-spotify` continues after a warning
- [ ] `spicetify config spotify_version_check 0` then backup continues after a warning
- [ ] `restore` still works when version is unsupported
- [ ] Release archives include `supported-versions.json` (build.yml)