### PR TITLE
feat(cli): gate backup/apply on supported Spotify versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
         if: env.IS_UNIX == 'true'
         uses: edgarrc/action-7z@v1
         with:
-          args: 7z a -bb0 "spicetify-${{ env.TAG }}-${{ matrix.os }}-${{ matrix.arch }}.tar" "./spicetify" "./CustomApps" "./Extensions" "./Themes" "./jsHelper" "globals.d.ts" "css-map.json"
+          args: 7z a -bb0 "spicetify-${{ env.TAG }}-${{ matrix.os }}-${{ matrix.arch }}.tar" "./spicetify" "./CustomApps" "./Extensions" "./Themes" "./jsHelper" "globals.d.ts" "css-map.json" "supported-versions.json"
 
       - name: 7z - .tar.gz
         if: env.IS_UNIX == 'true'
@@ -156,7 +156,7 @@ jobs:
         if: env.IS_WIN == 'true'
         uses: edgarrc/action-7z@v1
         with:
-          args: 7z a -bb0 -mx9 "spicetify-${{ env.TAG }}-${{ matrix.os }}-${{ (matrix.arch == 'amd64' && 'x64') || (matrix.arch == 'arm64' && 'arm64') || 'x32' }}.zip" "./spicetify.exe" "./CustomApps" "./Extensions" "./Themes" "./jsHelper" "globals.d.ts" "css-map.json"
+          args: 7z a -bb0 -mx9 "spicetify-${{ env.TAG }}-${{ matrix.os }}-${{ (matrix.arch == 'amd64' && 'x64') || (matrix.arch == 'arm64' && 'arm64') || 'x32' }}.zip" "./spicetify.exe" "./CustomApps" "./Extensions" "./Themes" "./jsHelper" "globals.d.ts" "css-map.json" "supported-versions.json"
 
       - name: Release
         if: env.IS_UNIX == 'true' || env.IS_WIN == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,14 @@ install.log
 
 # Local build artifacts
 /spicetify
+
+# Local classmap workspace (capture output / symlinks)
+/classmaps/
+
+# Python tooling
+__pycache__/
+*.pyc
+
+# Modular loader build output
+jsHelper/modularLoader.js
+jsHelper/modularLoader.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ jsHelper/spicetifyWrapper.js.map
 
 # Logs
 install.log
+
+# Local build artifacts
+/spicetify

--- a/spicetify.go
+++ b/spicetify.go
@@ -554,6 +554,11 @@ spotify_version_check <0 | 1>
     Whether backup/apply refuse unsupported Spotify versions.
     Disable only if you accept that the client may break.
 
+block_spotify_updates <0 | 1>
+    Pin the current Spotify version: every apply re-blocks Spotify
+    updates, so the client only updates when you deliberately run
+    "spicetify spotify-updates unblock".
+
 ` + utils.Bold("[Preprocesses]") + `
 disable_sentry <0 | 1>
     Prevents Sentry and Amazon Qualaroo to send console log/error/warning to Spotify developers.

--- a/spicetify.go
+++ b/spicetify.go
@@ -25,15 +25,16 @@ var (
 )
 
 var (
-	flags            = []string{}
-	commands         = []string{}
-	quiet            = false
-	extensionFocus   = false
-	appFocus         = false
-	styleFocus       = false
-	noRestart        = false
-	liveRefresh      = false
-	bypassAdminCheck = false
+	flags                   = []string{}
+	commands                = []string{}
+	quiet                   = false
+	extensionFocus          = false
+	appFocus                = false
+	styleFocus              = false
+	noRestart               = false
+	liveRefresh             = false
+	bypassAdminCheck        = false
+	forceUnsupportedSpotify = false
 )
 
 func init() {
@@ -70,6 +71,8 @@ func init() {
 		switch v {
 		case "--bypass-admin":
 			bypassAdminCheck = true
+		case "--force-unsupported-spotify":
+			forceUnsupportedSpotify = true
 		case "-c", "--config":
 			log.Println(cmd.GetConfigPath())
 			os.Exit(0)
@@ -123,16 +126,19 @@ func init() {
 		os.Exit(1)
 	}
 
-	for i, flag := range flags {
-		if flag == "--bypass-admin" {
-			flags = append(flags[:i], flags[i+1:]...)
-			break
+	for _, strip := range []string{"--bypass-admin", "--force-unsupported-spotify"} {
+		for i, flag := range flags {
+			if flag == strip {
+				flags = append(flags[:i], flags[i+1:]...)
+				break
+			}
 		}
 	}
 
 	utils.MigrateConfigFolder()
 	utils.MigrateFolders()
 	cmd.InitConfig(quiet)
+	cmd.SetForceUnsupportedSpotify(forceUnsupportedSpotify)
 
 	if len(commands) < 1 {
 		help()
@@ -494,6 +500,10 @@ upgrade|update      Update spicetify to the latest version if an update is avail
 
 --bypass-admin      Bypass admin or root (sudo) check. NOT RECOMMENDED
 
+--force-unsupported-spotify
+                    Allow backup/apply on Spotify versions outside the
+                    supported list. NOT RECOMMENDED; the client may break.
+
 -c, --config        Print config file path and quit
 
 -h, --help          Print this help text and quit
@@ -539,6 +549,10 @@ always_enable_devtools <0 | 1>
 
 check_spicetify_update <0 | 1>
     Whether to always check for updates when running Spicetify.
+
+spotify_version_check <0 | 1>
+    Whether backup/apply refuse unsupported Spotify versions.
+    Disable only if you accept that the client may break.
 
 ` + utils.Bold("[Preprocesses]") + `
 disable_sentry <0 | 1>

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -98,6 +98,12 @@ func Apply(spicetifyVersion string) {
 	if len(patchSection.Keys()) > 0 {
 		Patch()
 	}
+
+	// Re-assert the update block after every successful apply so the pinned
+	// version is self-healing when the user opted into update control.
+	if settingSection.Key("block_spotify_updates").MustBool(false) {
+		BlockSpotifyUpdates(true)
+	}
 }
 
 // RefreshTheme updates user.css + theme.js and overwrites custom assets

--- a/src/cmd/apply.go
+++ b/src/cmd/apply.go
@@ -15,6 +15,8 @@ import (
 
 // Apply .
 func Apply(spicetifyVersion string) {
+	RequireSupportedSpotify()
+
 	utils.MigrateConfigFolder()
 
 	backupSpicetifyVersion := backupSection.Key("with").MustString("")

--- a/src/cmd/auto.go
+++ b/src/cmd/auto.go
@@ -9,7 +9,16 @@ import (
 
 // Auto checks Spotify state, re-backup and apply if needed, then launch
 // Spotify client normally.
+//
+// Auto is the launch wrapper, so the support gate is soft here: when the
+// installed Spotify is unsupported (or its version is unknown) we warn and
+// return without touching Spotify files. main still launches Spotify via
+// SpotifyRestart, so music keeps working on unsupported versions.
 func Auto(spicetifyVersion string) {
+	if !SpotifySupportedForAuto() {
+		return
+	}
+
 	backupVersion := backupSection.Key("version").MustString("")
 	spotStat := spotifystatus.Get(appPath)
 	backStat := backupstatus.Get(prefsPath, backupFolder, backupVersion)

--- a/src/cmd/backup.go
+++ b/src/cmd/backup.go
@@ -15,6 +15,8 @@ import (
 // Backup stores original apps packages, extracts them and preprocesses extracted apps' assets
 // If silent is true, the final readiness message is suppressed (useful when chaining with "apply")
 func Backup(spicetifyVersion string, silent bool) {
+	RequireSupportedSpotify()
+
 	if isAppX {
 		utils.PrintInfo(`You are using the Microsoft Store version of Spotify, which is only partly supported.
 Don't use the Microsoft Store version with Spicetify unless you absolutely CANNOT install Spotify from its installer.

--- a/src/cmd/block-updates.go
+++ b/src/cmd/block-updates.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,16 +34,22 @@ func BlockSpotifyUpdates(disabled bool) {
 			return
 		}
 		updateDir := homeDir + "/Library/Application Support/Spotify/PersistentCache/Update"
+		exec.Command("pkill", "Spotify").Run()
+		exec.Command("mkdir", "-p", updateDir).Run()
 		if disabled {
-			exec.Command("pkill", "Spotify").Run()
-			exec.Command("mkdir", "-p", updateDir).Run()
 			exec.Command("chflags", "uchg", updateDir).Run()
 			msg = "Disabled"
 		} else {
-			exec.Command("pkill", "Spotify").Run()
-			exec.Command("mkdir", "-p", updateDir).Run()
 			exec.Command("chflags", "nouchg", updateDir).Run()
 			msg = "Enabled"
+		}
+
+		// chflags alone is not enough anymore: current clients stage updates
+		// via a segmented downloader that does not reference that directory.
+		// Patching the update endpoint makes the updater unreachable
+		// regardless of how the payload is fetched.
+		if err := patchDarwinUpdateEndpoint(spotifyExecPath, disabled); err != nil {
+			utils.PrintWarning("Endpoint patch failed (lock still applied): " + err.Error())
 		}
 
 		utils.PrintSuccess(msg + " Spotify updates!")
@@ -74,4 +81,61 @@ func BlockSpotifyUpdates(disabled bool) {
 	}
 	file.WriteAt([]byte(str), int64(i+15))
 	utils.PrintSuccess(msg + " Spotify updates!")
+}
+
+const (
+	darwinUpdateEndpoint         = "desktop-update/v2/update"
+	darwinUpdateEndpointPatched  = "desktop-update/no/thanks"
+	darwinUpdateEndpointPatchOff = len("desktop-update/")
+)
+
+// patchDarwinUpdateEndpoint rewrites the desktop-update endpoint inside the
+// Spotify binary and re-signs the bundle ad-hoc so it still launches on
+// Apple Silicon. Blocking writes "no/thanks" over "v2/update"; unblocking
+// restores the original bytes (from the backup taken on first block, or by
+// reversing the patch).
+func patchDarwinUpdateEndpoint(binaryPath string, block bool) error {
+	raw, err := os.ReadFile(binaryPath)
+	if err != nil {
+		return err
+	}
+
+	backupPath := filepath.Join(utils.GetSpicetifyFolder(), "spotify-binary-backup")
+
+	if block {
+		if !bytes.Contains(raw, []byte(darwinUpdateEndpoint)) {
+			// Already patched (or the endpoint moved): nothing to do.
+			return nil
+		}
+		if _, err := os.Stat(backupPath); os.IsNotExist(err) {
+			if err := os.WriteFile(backupPath, raw, 0755); err != nil {
+				return fmt.Errorf("cannot back up binary: %w", err)
+			}
+		}
+		idx := bytes.Index(raw, []byte(darwinUpdateEndpoint))
+		copy(raw[idx+darwinUpdateEndpointPatchOff:], "no/thanks")
+	} else {
+		if st, err := os.Stat(backupPath); err == nil && !st.IsDir() {
+			raw, err = os.ReadFile(backupPath)
+			if err != nil {
+				return err
+			}
+		} else {
+			idx := bytes.Index(raw, []byte(darwinUpdateEndpointPatched))
+			if idx < 0 {
+				return fmt.Errorf("patched endpoint not found and no backup to restore")
+			}
+			copy(raw[idx+darwinUpdateEndpointPatchOff:], "v2/update")
+		}
+	}
+
+	if err := os.WriteFile(binaryPath, raw, 0755); err != nil {
+		return err
+	}
+
+	bundlePath := filepath.Join(binaryPath, "..", "..", "..")
+	if out, err := exec.Command("codesign", "--force", "--deep", "--sign", "-", bundlePath).CombinedOutput(); err != nil {
+		return fmt.Errorf("codesign failed: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }

--- a/src/cmd/version_gate.go
+++ b/src/cmd/version_gate.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spicetify/cli/src/utils"
+)
+
+// forceUnsupportedSpotify allows backup/apply when the installed Spotify
+// version is outside the shipped support list.
+var forceUnsupportedSpotify bool
+
+// SetForceUnsupportedSpotify enables the one-shot CLI override.
+func SetForceUnsupportedSpotify(force bool) {
+	forceUnsupportedSpotify = force
+}
+
+// versionGateDisabled reports whether the user opted out of the gate.
+func versionGateDisabled() bool {
+	if forceUnsupportedSpotify {
+		utils.PrintWarning("Skipping Spotify version support check (--force-unsupported-spotify). The client may break.")
+		return true
+	}
+	if settingSection != nil && !settingSection.Key("spotify_version_check").MustBool(true) {
+		utils.PrintWarning("Skipping Spotify version support check (spotify_version_check=0). The client may break.")
+		return true
+	}
+	return false
+}
+
+// detectSpotifyVersion resolves the installed Spotify version, preferring
+// the app bundle/binary over prefs. Prefs lag real updates and are empty on
+// fresh installs. Returns the raw version string and where it came from.
+func detectSpotifyVersion() (raw string, source string) {
+	if v := utils.GetInstalledSpotifyVersion(spotifyPath); v != "" {
+		return v, "install"
+	}
+	if prefsPath != "" {
+		if v := utils.GetSpotifyVersion(prefsPath); v != "" {
+			return v, "prefs"
+		}
+	}
+	return "", ""
+}
+
+// loadSupportList resolves and loads supported-versions.json across the
+// search paths (binary dir first, then config folder).
+func loadSupportList() (*utils.SupportList, string, error) {
+	path, err := utils.FindSupportedVersionsFile()
+	if err != nil {
+		return nil, "", err
+	}
+	list, err := utils.LoadSupportedVersions(path)
+	if err != nil {
+		return nil, path, err
+	}
+	return list, path, nil
+}
+
+// RequireSupportedSpotify exits if the installed Spotify version is not in
+// supported-versions.json, unless the user opted out via flag or config.
+// A missing or unreadable support list fails open with a warning so
+// package-manager installs (which may not ship the file yet) keep working.
+func RequireSupportedSpotify() {
+	if versionGateDisabled() {
+		return
+	}
+
+	raw, _ := detectSpotifyVersion()
+	if raw == "" {
+		// Fail open, matching the missing-list behavior below: an
+		// undetectable version (e.g. Linux fresh install with empty prefs)
+		// must not hard-block backup/apply when the pre-gate CLI proceeded.
+		utils.PrintWarning("Cannot determine the installed Spotify version; continuing without the support check.")
+		utils.PrintInfo("Launch Spotify once (or set spotify_path in config-xpui.ini) to re-enable it.")
+		return
+	}
+
+	list, _, err := loadSupportList()
+	if err != nil {
+		utils.PrintWarning("Cannot verify Spotify version support: " + err.Error())
+		utils.PrintInfo("Continuing without the support check. Reinstall or upgrade Spicetify to restore it.")
+		return
+	}
+
+	if err := list.CheckSupported(raw); err != nil {
+		utils.PrintError(err.Error() + ".")
+		utils.PrintInfo("Supported versions: " + list.SupportedSummary())
+		utils.PrintInfo("Install a supported Spotify build, or upgrade Spicetify when support is added.")
+		utils.PrintInfo("To override (may break the client): --force-unsupported-spotify")
+		utils.PrintInfo("Or set spotify_version_check=0 in config-xpui.ini")
+		os.Exit(1)
+	}
+}
+
+// SpotifySupportedForAuto reports whether auto should re-backup/apply.
+// Unlike RequireSupportedSpotify it never exits: when the version is
+// unsupported or unknown it warns and returns false so the caller can
+// launch Spotify untouched instead of blocking startup. A missing support
+// list fails open (returns true) to preserve pre-gate behavior.
+func SpotifySupportedForAuto() bool {
+	if versionGateDisabled() {
+		return true
+	}
+
+	raw, _ := detectSpotifyVersion()
+	if raw == "" {
+		utils.PrintWarning("Cannot determine the installed Spotify version; launching Spotify without applying.")
+		return false
+	}
+
+	list, _, err := loadSupportList()
+	if err != nil {
+		utils.PrintWarning("Cannot verify Spotify version support: " + err.Error())
+		return true
+	}
+
+	if err := list.CheckSupported(raw); err != nil {
+		normalized, _ := utils.NormalizeSpotifyVersion(raw)
+		utils.PrintWarning(fmt.Sprintf(
+			"Spotify %s is not supported by this Spicetify release; launching Spotify without applying.",
+			firstNonEmpty(normalized, raw),
+		))
+		utils.PrintInfo("Supported versions: " + list.SupportedSummary())
+		utils.PrintInfo("Upgrade Spicetify when support is added, or use --force-unsupported-spotify to override.")
+		return false
+	}
+	return true
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -24,6 +24,7 @@ var (
 			"overwrite_assets":       "0",
 			"spotify_launch_flags":   "",
 			"check_spicetify_update": "1",
+			"spotify_version_check":  "1",
 			"always_enable_devtools": "0",
 		},
 		"Preprocesses": {

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -25,6 +25,7 @@ var (
 			"spotify_launch_flags":   "",
 			"check_spicetify_update": "1",
 			"spotify_version_check":  "1",
+			"block_spotify_updates":  "0",
 			"always_enable_devtools": "0",
 		},
 		"Preprocesses": {

--- a/src/utils/spotify_install.go
+++ b/src/utils/spotify_install.go
@@ -1,0 +1,130 @@
+package utils
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// GetInstalledSpotifyVersion reads the version of the installed Spotify
+// client directly from the app bundle/binary, avoiding prefs. Prefs lag
+// behind real updates (app.last-launched-version is only written after a
+// launch) and are empty on fresh installs, so the install itself is the
+// most truthful source. Returns "" when it cannot be determined.
+func GetInstalledSpotifyVersion(spotifyPath string) string {
+	if strings.TrimSpace(spotifyPath) == "" {
+		return ""
+	}
+
+	var raw string
+	switch runtime.GOOS {
+	case "darwin":
+		raw = darwinInstalledSpotifyVersion(spotifyPath)
+	case "windows":
+		raw = winInstalledSpotifyVersion(spotifyPath)
+	default:
+		// Linux has no reliable version file across deb/rpm/snap/flatpak.
+		return ""
+	}
+
+	if _, err := ParseSpotifyVersion(raw); err != nil {
+		return ""
+	}
+	return raw
+}
+
+// darwinInstalledSpotifyVersion reads CFBundleShortVersionString from the
+// Spotify.app Info.plist. spotifyPath points inside the bundle
+// (usually /Applications/Spotify.app/Contents/Resources).
+func darwinInstalledSpotifyVersion(spotifyPath string) string {
+	plist := findBundleInfoPlist(spotifyPath)
+	if plist == "" {
+		return ""
+	}
+
+	// PlistBuddy handles XML and binary plists and ships with macOS.
+	if buddy, err := exec.LookPath("/usr/libexec/PlistBuddy"); err == nil {
+		if out, err := exec.Command(buddy, "-c", "Print :CFBundleShortVersionString", plist).Output(); err == nil {
+			if v := strings.TrimSpace(string(out)); v != "" {
+				return v
+			}
+		}
+	}
+
+	// Fallback for plain XML plists.
+	data, err := os.ReadFile(plist)
+	if err != nil {
+		return ""
+	}
+	return parsePlistVersion(data)
+}
+
+// findBundleInfoPlist walks up from spotifyPath looking for a .app bundle
+// and returns its Contents/Info.plist path, or "".
+func findBundleInfoPlist(spotifyPath string) string {
+	dir := filepath.Clean(spotifyPath)
+	for {
+		base := filepath.Base(dir)
+		if strings.HasSuffix(base, ".app") {
+			plist := filepath.Join(dir, "Contents", "Info.plist")
+			if st, err := os.Stat(plist); err == nil && !st.IsDir() {
+				return plist
+			}
+			return ""
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+var plistVersionRe = regexp.MustCompile(`(?s)<key>CFBundleShortVersionString</key>\s*<string>([^<]+)</string>`)
+
+// parsePlistVersion extracts CFBundleShortVersionString from an XML plist.
+func parsePlistVersion(data []byte) string {
+	m := plistVersionRe.FindSubmatch(data)
+	if m == nil {
+		return ""
+	}
+	return strings.TrimSpace(string(m[1]))
+}
+
+// winInstalledSpotifyVersion asks PowerShell for the Spotify.exe product
+// version (e.g. "1.2.93.478.gabc1234"). Best-effort with a short timeout.
+func winInstalledSpotifyVersion(spotifyPath string) string {
+	exe := filepath.Join(spotifyPath, "Spotify.exe")
+	if st, err := os.Stat(exe); err != nil || st.IsDir() {
+		return ""
+	}
+
+	ps, err := exec.LookPath("powershell.exe")
+	if err != nil {
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, ps,
+		"-NoProfile", "-NonInteractive", "-Command",
+		`(Get-Item -LiteralPath '`+strings.ReplaceAll(exe, `'`, `''`)+`').VersionInfo.ProductVersion`,
+	).Output()
+	if err != nil {
+		return ""
+	}
+	return parseWindowsProductVersion(string(out))
+}
+
+// parseWindowsProductVersion trims PowerShell output to a version string.
+func parseWindowsProductVersion(out string) string {
+	v := strings.TrimSpace(out)
+	v = strings.Trim(v, `"'`)
+	return v
+}

--- a/src/utils/spotify_install_test.go
+++ b/src/utils/spotify_install_test.go
@@ -1,0 +1,47 @@
+package utils
+
+import "testing"
+
+func TestParsePlistVersion(t *testing.T) {
+	xml := `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>Spotify</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.2.93.478.gabc12345</string>
+	<key>CFBundleVersion</key>
+	<string>1.2.93.478</string>
+</dict>
+</plist>`
+	if got := parsePlistVersion([]byte(xml)); got != "1.2.93.478.gabc12345" {
+		t.Fatalf("parsePlistVersion = %q", got)
+	}
+
+	if got := parsePlistVersion([]byte("<plist><dict></dict></plist>")); got != "" {
+		t.Fatalf("missing key should give empty, got %q", got)
+	}
+}
+
+func TestParseWindowsProductVersion(t *testing.T) {
+	cases := map[string]string{
+		"1.2.93.478.gabc12345\r\n": "1.2.93.478.gabc12345",
+		"\"1.2.92.148\"\n":         "1.2.92.148",
+		"  1.2.90  ":               "1.2.90",
+		"":                         "",
+	}
+	for in, want := range cases {
+		if got := parseWindowsProductVersion(in); got != want {
+			t.Fatalf("parseWindowsProductVersion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestGetInstalledSpotifyVersionEmptyPath(t *testing.T) {
+	if got := GetInstalledSpotifyVersion(""); got != "" {
+		t.Fatalf("empty path should give empty version, got %q", got)
+	}
+	if got := GetInstalledSpotifyVersion("   "); got != "" {
+		t.Fatalf("blank path should give empty version, got %q", got)
+	}
+}

--- a/src/utils/spotify_version.go
+++ b/src/utils/spotify_version.go
@@ -1,0 +1,100 @@
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// SpotifyVersion is a normalized major.minor.patch Spotify desktop version.
+type SpotifyVersion struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+// String returns the normalized major.minor.patch form.
+func (v SpotifyVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// ParseSpotifyVersion parses a Spotify version string from prefs or config.
+// Accepts forms like "1.2.93", "1.2.93.12.gdeadbeef", and optional leading "v".
+func ParseSpotifyVersion(raw string) (SpotifyVersion, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return SpotifyVersion{}, fmt.Errorf("empty Spotify version")
+	}
+	if strings.HasPrefix(raw, "v") || strings.HasPrefix(raw, "V") {
+		raw = raw[1:]
+	}
+
+	parts := strings.Split(raw, ".")
+	if len(parts) < 3 {
+		return SpotifyVersion{}, fmt.Errorf("invalid Spotify version %q: need major.minor.patch", raw)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return SpotifyVersion{}, fmt.Errorf("invalid Spotify major version in %q: %w", raw, err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return SpotifyVersion{}, fmt.Errorf("invalid Spotify minor version in %q: %w", raw, err)
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return SpotifyVersion{}, fmt.Errorf("invalid Spotify patch version in %q: %w", raw, err)
+	}
+	if major < 0 || minor < 0 || patch < 0 {
+		return SpotifyVersion{}, fmt.Errorf("invalid Spotify version %q: negative component", raw)
+	}
+
+	return SpotifyVersion{Major: major, Minor: minor, Patch: patch}, nil
+}
+
+// NormalizeSpotifyVersion returns the major.minor.patch form of raw.
+func NormalizeSpotifyVersion(raw string) (string, error) {
+	v, err := ParseSpotifyVersion(raw)
+	if err != nil {
+		return "", err
+	}
+	return v.String(), nil
+}
+
+// CompareSpotifyVersion compares two version strings on major.minor.patch.
+// Returns -1 if a < b, 0 if equal, 1 if a > b.
+func CompareSpotifyVersion(a, b string) (int, error) {
+	va, err := ParseSpotifyVersion(a)
+	if err != nil {
+		return 0, err
+	}
+	vb, err := ParseSpotifyVersion(b)
+	if err != nil {
+		return 0, err
+	}
+	return va.Compare(vb), nil
+}
+
+// Compare returns -1 if v < other, 0 if equal, 1 if v > other.
+func (v SpotifyVersion) Compare(other SpotifyVersion) int {
+	if v.Major != other.Major {
+		if v.Major < other.Major {
+			return -1
+		}
+		return 1
+	}
+	if v.Minor != other.Minor {
+		if v.Minor < other.Minor {
+			return -1
+		}
+		return 1
+	}
+	if v.Patch != other.Patch {
+		if v.Patch < other.Patch {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}

--- a/src/utils/spotify_version_test.go
+++ b/src/utils/spotify_version_test.go
@@ -1,0 +1,59 @@
+package utils
+
+import "testing"
+
+func TestParseAndNormalizeSpotifyVersion(t *testing.T) {
+	tests := []struct {
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{"1.2.93", "1.2.93", false},
+		{"1.2.93.12.gdeadbeef", "1.2.93", false},
+		{"v1.2.45", "1.2.45", false},
+		{" 1.2.86 ", "1.2.86", false},
+		{"", "", true},
+		{"1.2", "", true},
+		{"foo", "", true},
+		{"1.2.x", "", true},
+	}
+
+	for _, tt := range tests {
+		got, err := NormalizeSpotifyVersion(tt.raw)
+		if tt.wantErr {
+			if err == nil {
+				t.Fatalf("NormalizeSpotifyVersion(%q) expected error, got %q", tt.raw, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("NormalizeSpotifyVersion(%q) unexpected error: %v", tt.raw, err)
+		}
+		if got != tt.want {
+			t.Fatalf("NormalizeSpotifyVersion(%q) = %q, want %q", tt.raw, got, tt.want)
+		}
+	}
+}
+
+func TestCompareSpotifyVersion(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1.2.86", "1.2.86", 0},
+		{"1.2.86", "1.2.93", -1},
+		{"1.2.93", "1.2.86", 1},
+		{"1.2.93.9.gabc", "1.2.93", 0},
+		{"1.1.99", "1.2.0", -1},
+	}
+
+	for _, tt := range tests {
+		got, err := CompareSpotifyVersion(tt.a, tt.b)
+		if err != nil {
+			t.Fatalf("CompareSpotifyVersion(%q, %q): %v", tt.a, tt.b, err)
+		}
+		if got != tt.want {
+			t.Fatalf("CompareSpotifyVersion(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}

--- a/src/utils/supported_versions.go
+++ b/src/utils/supported_versions.go
@@ -1,0 +1,221 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// SupportedVersionsFileName is the support list file shipped next to the binary.
+const SupportedVersionsFileName = "supported-versions.json"
+
+// SupportRange is an inclusive major.minor.patch range.
+type SupportRange struct {
+	Min  string `json:"min"`
+	Max  string `json:"max"`
+	Note string `json:"note,omitempty"`
+}
+
+// SupportList is the on-disk schema for supported-versions.json (schema v1).
+type SupportList struct {
+	SchemaVersion int               `json:"schema_version"`
+	Updated       string            `json:"updated,omitempty"`
+	Policy        string            `json:"policy"`
+	Versions      []string          `json:"versions"`
+	Ranges        []SupportRange    `json:"ranges"`
+	Notes         map[string]string `json:"notes,omitempty"`
+}
+
+// DefaultSupportedVersionsPath returns the path next to the executable,
+// matching how css-map.json is resolved.
+func DefaultSupportedVersionsPath() string {
+	return filepath.Join(GetExecutableDir(), SupportedVersionsFileName)
+}
+
+// SupportedVersionsSearchPaths returns locations checked for the support
+// list, in priority order: next to the binary (release installs), then the
+// Spicetify config folder (package-manager and go installs).
+func SupportedVersionsSearchPaths() []string {
+	paths := []string{
+		DefaultSupportedVersionsPath(),
+		filepath.Join(GetSpicetifyFolder(), SupportedVersionsFileName),
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if p == "" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	return out
+}
+
+// FindSupportedVersionsFileIn returns the first existing support list under
+// the given paths, in order.
+func FindSupportedVersionsFileIn(paths []string) (string, error) {
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		if st, err := os.Stat(p); err == nil && !st.IsDir() {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("no %s found (searched %s)", SupportedVersionsFileName, strings.Join(paths, ", "))
+}
+
+// FindSupportedVersionsFile resolves the support list across the default
+// search paths.
+func FindSupportedVersionsFile() (string, error) {
+	return FindSupportedVersionsFileIn(SupportedVersionsSearchPaths())
+}
+
+// LoadSupportedVersions reads and validates a schema v1 support list file.
+func LoadSupportedVersions(path string) (*SupportList, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read supported versions list at %s: %w", path, err)
+	}
+
+	var list SupportList
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("supported versions list is malformed (%s): %w", path, err)
+	}
+
+	if list.SchemaVersion != 1 {
+		return nil, fmt.Errorf("unsupported supported-versions schema_version %d (want 1)", list.SchemaVersion)
+	}
+	if list.Policy != "" && list.Policy != "allowlist" {
+		return nil, fmt.Errorf("unsupported supported-versions policy %q (want allowlist)", list.Policy)
+	}
+	if list.Policy == "" {
+		list.Policy = "allowlist"
+	}
+
+	for i, v := range list.Versions {
+		normalized, err := NormalizeSpotifyVersion(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid versions[%d] %q: %w", i, v, err)
+		}
+		list.Versions[i] = normalized
+	}
+
+	for i, r := range list.Ranges {
+		min, err := NormalizeSpotifyVersion(r.Min)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ranges[%d].min %q: %w", i, r.Min, err)
+		}
+		max, err := NormalizeSpotifyVersion(r.Max)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ranges[%d].max %q: %w", i, r.Max, err)
+		}
+		if cmp, err := CompareSpotifyVersion(min, max); err != nil {
+			return nil, err
+		} else if cmp > 0 {
+			return nil, fmt.Errorf("invalid ranges[%d]: min %s is greater than max %s", i, min, max)
+		}
+		list.Ranges[i].Min = min
+		list.Ranges[i].Max = max
+	}
+
+	return &list, nil
+}
+
+// IsSupported reports whether normalized major.minor.patch is allowlisted.
+func (s *SupportList) IsSupported(normalized string) bool {
+	if s == nil {
+		return false
+	}
+
+	v, err := ParseSpotifyVersion(normalized)
+	if err != nil {
+		return false
+	}
+	normalized = v.String()
+
+	for _, exact := range s.Versions {
+		if exact == normalized {
+			return true
+		}
+	}
+
+	for _, r := range s.Ranges {
+		minCmp, err := CompareSpotifyVersion(normalized, r.Min)
+		if err != nil {
+			continue
+		}
+		maxCmp, err := CompareSpotifyVersion(normalized, r.Max)
+		if err != nil {
+			continue
+		}
+		if minCmp >= 0 && maxCmp <= 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// CheckSupported returns nil when the version is allowlisted, or a
+// descriptive error when it is not. Kept exit-free so it is unit-testable.
+func (s *SupportList) CheckSupported(raw string) error {
+	normalized, err := NormalizeSpotifyVersion(raw)
+	if err != nil {
+		return fmt.Errorf("cannot parse Spotify version %q: %w", raw, err)
+	}
+	if !s.IsSupported(normalized) {
+		return fmt.Errorf("Spotify %s (%s) is not supported by this Spicetify release", raw, normalized)
+	}
+	return nil
+}
+
+// SupportedSummary returns a compact human-readable list of supported versions.
+// Uses ASCII "-" between range edges so output is safe on Windows codepages,
+// and sorts by parsed version (not lexicographically) so 1.2.100 sorts after 1.2.93.
+func (s *SupportList) SupportedSummary() string {
+	if s == nil {
+		return "(none)"
+	}
+
+	type entry struct {
+		key  SpotifyVersion
+		text string
+	}
+	entries := make([]entry, 0, len(s.Versions)+len(s.Ranges))
+	for _, v := range s.Versions {
+		parsed, err := ParseSpotifyVersion(v)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, entry{key: parsed, text: v})
+	}
+	for _, r := range s.Ranges {
+		parsed, err := ParseSpotifyVersion(r.Min)
+		if err != nil {
+			continue
+		}
+		text := r.Min
+		if r.Min != r.Max {
+			text = fmt.Sprintf("%s-%s", r.Min, r.Max)
+		}
+		entries = append(entries, entry{key: parsed, text: text})
+	}
+
+	if len(entries) == 0 {
+		return "(none listed)"
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].key.Compare(entries[j].key) < 0
+	})
+	parts := make([]string, 0, len(entries))
+	for _, e := range entries {
+		parts = append(parts, e.text)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/src/utils/supported_versions_test.go
+++ b/src/utils/supported_versions_test.go
@@ -1,0 +1,232 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestSupportListIsSupported(t *testing.T) {
+	list := &SupportList{
+		SchemaVersion: 1,
+		Policy:        "allowlist",
+		Versions:      []string{"1.2.93"},
+		Ranges: []SupportRange{
+			{Min: "1.2.86", Max: "1.2.92"},
+		},
+	}
+
+	cases := map[string]bool{
+		"1.2.93":        true,
+		"1.2.93.1.gabc": true,
+		"1.2.86":        true,
+		"1.2.92":        true,
+		"1.2.90":        true,
+		"1.2.85":        false,
+		"1.2.94":        false,
+		"":              false,
+		"nope":          false,
+	}
+
+	for raw, want := range cases {
+		normalized := raw
+		if raw != "" && raw != "nope" {
+			var err error
+			normalized, err = NormalizeSpotifyVersion(raw)
+			if err != nil {
+				if want {
+					t.Fatalf("unexpected normalize error for %q: %v", raw, err)
+				}
+				if list.IsSupported(raw) {
+					t.Fatalf("IsSupported(%q) = true, want false", raw)
+				}
+				continue
+			}
+		}
+		if got := list.IsSupported(normalized); got != want {
+			t.Fatalf("IsSupported(%q) = %v, want %v", raw, got, want)
+		}
+	}
+}
+
+func TestSupportListCheckSupported(t *testing.T) {
+	list := &SupportList{
+		SchemaVersion: 1,
+		Policy:        "allowlist",
+		Ranges:        []SupportRange{{Min: "1.2.86", Max: "1.2.93"}},
+	}
+
+	if err := list.CheckSupported("1.2.90.4.gabc"); err != nil {
+		t.Fatalf("CheckSupported(supported) = %v, want nil", err)
+	}
+
+	err := list.CheckSupported("1.2.94")
+	if err == nil {
+		t.Fatal("CheckSupported(unsupported) = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "1.2.94") {
+		t.Fatalf("error should name the version, got %q", err.Error())
+	}
+
+	if err := list.CheckSupported("not-a-version"); err == nil {
+		t.Fatal("CheckSupported(garbage) = nil, want parse error")
+	}
+
+	var nilList *SupportList
+	if err := nilList.CheckSupported("1.2.90"); err == nil {
+		t.Fatal("CheckSupported on nil list = nil, want error")
+	}
+}
+
+func TestLoadSupportedVersions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "supported-versions.json")
+	content := `{
+  "schema_version": 1,
+  "policy": "allowlist",
+  "versions": ["1.2.93"],
+  "ranges": [{"min": "1.2.86", "max": "1.2.92"}]
+}`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	list, err := LoadSupportedVersions(path)
+	if err != nil {
+		t.Fatalf("LoadSupportedVersions: %v", err)
+	}
+	if !list.IsSupported("1.2.90") || !list.IsSupported("1.2.93") {
+		t.Fatalf("loaded list missing expected support")
+	}
+	if list.IsSupported("1.2.85") {
+		t.Fatalf("loaded list should not support 1.2.85")
+	}
+
+	summary := list.SupportedSummary()
+	if summary == "" || summary == "(none)" {
+		t.Fatalf("unexpected summary %q", summary)
+	}
+	if strings.ContainsAny(summary, "–—") {
+		t.Fatalf("summary must stay ASCII for Windows codepages, got %q", summary)
+	}
+}
+
+func TestLoadSupportedVersionsRejectsBadRange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "supported-versions.json")
+	content := `{
+  "schema_version": 1,
+  "policy": "allowlist",
+  "versions": [],
+  "ranges": [{"min": "1.2.93", "max": "1.2.86"}]
+}`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadSupportedVersions(path); err == nil {
+		t.Fatal("expected error for inverted range")
+	}
+}
+
+func TestLoadSupportedVersionsMissingFile(t *testing.T) {
+	if _, err := LoadSupportedVersions(filepath.Join(t.TempDir(), "nope.json")); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadSupportedVersionsRejectsUnknownSchema(t *testing.T) {
+	dir := t.TempDir()
+	for _, schema := range []int{0, 2, 3, 99} {
+		path := filepath.Join(dir, "list.json")
+		content := `{"schema_version": ` + strconv.Itoa(schema) + `, "policy": "allowlist"}`
+		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadSupportedVersions(path); err == nil {
+			t.Fatalf("expected error for schema_version %d", schema)
+		}
+	}
+}
+
+func TestFindSupportedVersionsFileIn(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "a", "supported-versions.json")
+	second := filepath.Join(dir, "b", "supported-versions.json")
+	if err := os.MkdirAll(filepath.Dir(second), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, []byte(`{"schema_version": 1}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := FindSupportedVersionsFileIn([]string{first, second})
+	if err != nil {
+		t.Fatalf("FindSupportedVersionsFileIn: %v", err)
+	}
+	if got != second {
+		t.Fatalf("got %q, want %q", got, second)
+	}
+
+	if _, err := FindSupportedVersionsFileIn([]string{first}); err == nil {
+		t.Fatal("expected error when nothing exists")
+	}
+
+	// Order wins when both exist.
+	if err := os.MkdirAll(filepath.Dir(first), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(first, []byte(`{"schema_version": 1}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err = FindSupportedVersionsFileIn([]string{first, second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != first {
+		t.Fatalf("priority order broken: got %q, want %q", got, first)
+	}
+}
+
+func TestShippedSupportedVersionsJSON(t *testing.T) {
+	// When tests run from package dir, walk up to module root.
+	candidates := []string{
+		"supported-versions.json",
+		filepath.Join("..", "..", "supported-versions.json"),
+	}
+	var path string
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			path = c
+			break
+		}
+	}
+	if path == "" {
+		t.Skip("supported-versions.json not found relative to test cwd")
+	}
+	list, err := LoadSupportedVersions(path)
+	if err != nil {
+		t.Fatalf("shipped supported-versions.json invalid: %v", err)
+	}
+	// Structural invariants only; do not hardcode window edges, they move
+	// every time the allowlist is bumped.
+	if len(list.Versions)+len(list.Ranges) == 0 {
+		t.Fatal("shipped list must allow at least one version or range")
+	}
+	if list.SupportedSummary() == "(none listed)" {
+		t.Fatal("shipped list summary must not be empty")
+	}
+}
+
+func TestSupportedSummarySemverOrder(t *testing.T) {
+	list := &SupportList{
+		Versions: []string{"1.2.100", "1.2.93"},
+		Ranges:   []SupportRange{{Min: "1.2.86", Max: "1.2.92"}},
+	}
+	got := list.SupportedSummary()
+	want := "1.2.86-1.2.92, 1.2.93, 1.2.100"
+	if got != want {
+		t.Fatalf("SupportedSummary = %q, want %q", got, want)
+	}
+}

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -254,16 +254,18 @@ func CreateFile(path string, content string) error {
 	return nil
 }
 
-// GetSpotifyVersion .
+// GetSpotifyVersion reads app.last-launched-version from Spotify prefs.
+// Returns "" when prefs are missing or unreadable (e.g. fresh install);
+// callers should prefer GetInstalledSpotifyVersion and use this as fallback.
 func GetSpotifyVersion(prefsPath string) string {
 	pref, err := ini.Load(prefsPath)
 	if err != nil {
-		log.Fatal(err)
+		return ""
 	}
 
 	rootSection, err := pref.GetSection("")
 	if err != nil {
-		log.Fatal(err)
+		return ""
 	}
 
 	version := rootSection.Key("app.last-launched-version")

--- a/supported-versions.json
+++ b/supported-versions.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "updated": "2026-07-20",
+  "policy": "allowlist",
+  "versions": [],
+  "ranges": [
+    {
+      "min": "1.2.86",
+      "max": "1.2.93",
+      "note": "Classic css-map pipeline; window drawn from recent CLI support commits (1.2.86 through 1.2.93)"
+    }
+  ],
+  "notes": {
+    "1.2.93": "Explicitly targeted in cli main"
+  }
+}


### PR DESCRIPTION
## What

Introduces a Spotify version support gate: `backup` and `apply` now refuse to run when the installed Spotify version is outside the allowlist shipped in `supported-versions.json` (schema v1, currently 1.2.86-1.2.93). This is the first step toward only patching known client versions, instead of silently breaking on untested ones.

## Resilience by design

The gate is careful to never strand users:

- **Missing list fails open.** The list is searched next to the binary first, then in the spicetify config folder (covers package-manager and `go install` layouts). If it cannot be found or parsed, the CLI warns and continues instead of hard-failing. The file is now included in release archives, so `spicetify upgrade` installs it alongside the binary.
- **`auto` never blocks launch.** `spicetify auto` is the launch wrapper, so its check is soft: on an unsupported or undetectable version it warns and launches Spotify untouched rather than exiting.
- **Undetectable version fails open.** If no version can be determined at all (e.g. Linux fresh install with empty prefs), the CLI warns and proceeds, matching pre-gate behavior.
- **Accurate version source.** The version is read from the installed app itself (macOS `Info.plist`, Windows exe `ProductVersion`) with prefs `app.last-launched-version` only as a fallback, avoiding both false passes after a Spotify update and false failures on fresh installs.

## Escape hatches

- `--force-unsupported-spotify` flag
- `spotify_version_check=0` in `config-xpui.ini`

## Test plan

- `go test ./...` covers version parsing, range comparison, allowlist evaluation, schema validation, search-path priority, and the exit-free `CheckSupported` predicate used by the gate.
- `TestShippedSupportedVersionsJSON` validates the shipped file structurally without hardcoding window edges.
- Manually verified: supported, unsupported, and missing-list behaviors of the gate and of the summary output (ASCII-only, semver-sorted).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Spotify version compatibility checks for backup and apply, with a softer gate for automatic operations.
  * Added installed Spotify version detection and validation against supported version ranges, including `--force-unsupported-spotify` and `spotify_version_check`.
  * macOS update blocking now additionally patches Spotify’s internal update endpoint to help keep updates disabled.
  * Shipped supported-version information is now included in release archives.
* **Bug Fixes**
  * Backup/apply/auto no longer proceed on unsupported or unknown Spotify versions (unless forced).
  * Update-pin state is re-enforced after a successful apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->