### PR TITLE
fix(css-map): add progress bar container class for 1.2.94

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1988,6 +1988,7 @@
 	"fDGGPFmD54w05ut8Ns4S": "playback-progressbar",
 	"tNhfHQhWhj9RoA1rfwY5": "playback-progressbar-container",
 	"B1vgcMXBqOxgMxXh5j1f": "playback-progressbar-container",
+	"PuvORL_2IYHBmI6V": "playback-progressbar-container",
 	"ihE8PJvbefgJmRhO": "playback-progressbar-isInteractive",
 	"WFFDxnFUICVFNvvNU1IE": "playback-progressbar-isInteractive",
 	"OEbZDzXdU1OUQactz3ZA": "playback-progressbar-isInteractive",


### PR DESCRIPTION
## Problem

On Spotify `1.2.94.583`, `.playback-progressbar-container` no longer resolves.

The container element still exists in the DOM, but its obfuscated class hash
changed and the new one is not in `css-map.json`.

Ancestor chain of `.playback-bar input[type="range"]` on 1.2.94.583:

LABEL "hidden-visually"
DIV   "playback-progressbar playback-progressbar-isInteractive XDuVZbmy09wez6LS"
DIV   "PuvORL_2IYHBmI6V"                  <- container, unmapped
DIV   "playback-bar rlQO4qjGcwcPEZXN"
DIV   "player-controls"

`.playback-bar` and `.playback-progressbar` still map correctly — only the
container in between is missing.

## Fix

Add `"PuvORL_2IYHBmI6V": "playback-progressbar-container"` next to the two
existing hashes for that class. 

## Verification

Built from source and applied:

- `.playback-progressbar-container` resolves again
- `loopyLoop` markers render and the context menu works on the progress bar

Spicetify: built from this branch
Spotify: 1.2.94.583
OS: Windows 11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed styling for the playback progress bar container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->